### PR TITLE
Adding du for composing chainables

### DIFF
--- a/dtslint/ts3.0/index.ts
+++ b/dtslint/ts3.0/index.ts
@@ -3,6 +3,8 @@ import * as IO from 'fp-ts/lib/IO'
 import * as Task from 'fp-ts/lib/Task'
 import * as TaskEither from 'fp-ts/lib/TaskEither'
 import * as ReaderTaskEither from 'fp-ts/lib/ReaderTaskEither'
+import { either, right } from 'fp-ts/lib/Either'
+import { Do } from '../../src/Do'
 
 //
 // time
@@ -12,3 +14,7 @@ const time1 = time(IO.io) // $ExpectType <A>(ma: IO<A>) => IO<[A, number]>
 const time2 = time(Task.task) // $ExpectType <A>(ma: Task<A>) => Task<[A, number]>
 const time3 = time(TaskEither.taskEither) // $ExpectType <L, A>(ma: TaskEither<L, A>) => TaskEither<L, [A, number]>
 const time4 = time(ReaderTaskEither.readerTaskEither) // $ExpectType <U, L, A>(ma: ReaderTaskEither<U, L, A>) => ReaderTaskEither<U, L, [A, number]>
+
+Do(either)
+  .bind('name', right<string, string>('bob'))
+  .bindL('bad', () => right<boolean, number>(54)) // $ExpectError

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
+    "tsc": "tsc",
     "lint": "tslint -p tsconfig.json src/**/*.ts test/**/*.ts",
     "jest": "jest",
     "prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --list-different \"{src,test}/**/*.ts\"",

--- a/src/Do.ts
+++ b/src/Do.ts
@@ -1,0 +1,104 @@
+import { HKT, Type, Type2, URIS, URIS2, URIS3, Type3 } from 'fp-ts/lib/HKT'
+import { Monad, Monad1, Monad2, Monad2C, Monad3, Monad3C } from 'fp-ts/lib/Monad'
+
+export interface Do3<M extends URIS3, S extends object> {
+  do: <U, L>(ma: Type3<M, U, L, unknown>) => Do3C<M, S, U, L>
+  doL: <U, L>(f: (s: S) => Type3<M, U, L, unknown>) => Do3C<M, S, U, L>
+  bind: <N extends string, A, U, L>(
+    name: Exclude<N, keyof S>,
+    ma: Type3<M, U, L, A>
+  ) => Do3C<M, S & { [K in N]: A }, U, L>
+  bindL: <N extends string, A, U, L>(
+    name: Exclude<N, keyof S>,
+    f: (s: S) => Type3<M, U, L, A>
+  ) => Do3C<M, S & { [K in N]: A }, U, L>
+  return: <A, U, L>(f: (s: S) => A) => Type3<M, U, L, A>
+  done: <U, L>() => Type3<M, U, L, S>
+}
+
+export interface Do3C<M extends URIS3, S extends object, U, L> {
+  do: (ma: Type3<M, U, L, unknown>) => Do3C<M, S, U, L>
+  doL: (f: (s: S) => Type3<M, U, L, unknown>) => Do3C<M, S, U, L>
+  bind: <N extends string, A>(name: Exclude<N, keyof S>, ma: Type3<M, U, L, A>) => Do3C<M, S & { [K in N]: A }, U, L>
+  bindL: <N extends string, A>(
+    name: Exclude<N, keyof S>,
+    f: (s: S) => Type3<M, U, L, A>
+  ) => Do3C<M, S & { [K in N]: A }, U, L>
+  return: <A>(f: (s: S) => A) => Type3<M, U, L, A>
+  done: () => Type3<M, U, L, S>
+}
+
+export interface Do2<M extends URIS2, S extends object> {
+  do: <L>(ma: Type2<M, L, unknown>) => Do2C<M, S, L>
+  doL: <L>(f: (s: S) => Type2<M, L, unknown>) => Do2C<M, S, L>
+  bind: <N extends string, A, L>(name: Exclude<N, keyof S>, ma: Type2<M, L, A>) => Do2C<M, S & { [K in N]: A }, L>
+  bindL: <N extends string, A, L>(
+    name: Exclude<N, keyof S>,
+    f: (s: S) => Type2<M, L, A>
+  ) => Do2C<M, S & { [K in N]: A }, L>
+  return: <A, L>(f: (s: S) => A) => Type2<M, L, A>
+  done: <L>() => Type2<M, L, S>
+}
+
+export interface Do2C<M extends URIS2, S extends object, L> {
+  do: (ma: Type2<M, L, unknown>) => Do2C<M, S, L>
+  doL: (f: (s: S) => Type2<M, L, unknown>) => Do2C<M, S, L>
+  bind: <N extends string, A>(name: Exclude<N, keyof S>, ma: Type2<M, L, A>) => Do2C<M, S & { [K in N]: A }, L>
+  bindL: <N extends string, A>(
+    name: Exclude<N, keyof S>,
+    f: (s: S) => Type2<M, L, A>
+  ) => Do2C<M, S & { [K in N]: A }, L>
+  return: <A>(f: (s: S) => A) => Type2<M, L, A>
+  done: () => Type2<M, L, S>
+}
+
+export interface Do1<M extends URIS, S extends object> {
+  do: (ma: Type<M, unknown>) => Do1<M, S>
+  doL: (f: (s: S) => Type<M, unknown>) => Do1<M, S>
+  bind: <N extends string, A>(name: Exclude<N, keyof S>, ma: Type<M, A>) => Do1<M, S & { [K in N]: A }>
+  bindL: <N extends string, A>(name: Exclude<N, keyof S>, f: (s: S) => Type<M, A>) => Do1<M, S & { [K in N]: A }>
+  return: <A>(f: (s: S) => A) => Type<M, A>
+  done: () => Type<M, S>
+}
+
+export interface Do0<M, S extends object> {
+  do: (ma: HKT<M, unknown>) => Do0<M, S>
+  doL: (f: (s: S) => HKT<M, unknown>) => Do0<M, S>
+  bind: <N extends string, A>(name: Exclude<N, keyof S>, ma: HKT<M, A>) => Do0<M, S & { [K in N]: A }>
+  bindL: <N extends string, A>(name: Exclude<N, keyof S>, f: (s: S) => HKT<M, A>) => Do0<M, S & { [K in N]: A }>
+  return: <A>(f: (s: S) => A) => HKT<M, A>
+  done: () => HKT<M, S>
+}
+
+export function Do<M extends URIS3>(M: Monad3<M>): Do3<M, {}>
+export function Do<M extends URIS3, U, L>(M: Monad3C<M, U, L>): Do3C<M, {}, U, L>
+export function Do<M extends URIS2>(M: Monad2<M>): Do2<M, {}>
+export function Do<M extends URIS2, L>(M: Monad2C<M, L>): Do2C<M, {}, L>
+export function Do<M extends URIS>(M: Monad1<M>): Do1<M, {}>
+export function Do<M>(M: Monad<M>): Do0<M, {}>
+export function Do<M>(_: Monad<M>): Do0<M, {}> {
+  function toDo<A extends object>(ma: HKT<M, A>): Do0<M, A> {
+    return {
+      do(mv: HKT<M, unknown>): Do0<M, A> {
+        return toDo(_.chain(ma, a => _.map(mv, () => a)))
+      },
+      doL(fmv: (s: A) => HKT<M, unknown>): Do0<M, A> {
+        return toDo(_.chain(ma, a => _.map(fmv(a), () => a)))
+      },
+      bind<N extends string, B>(name: Exclude<N, keyof A>, mb: HKT<M, B>): Do0<M, A & { [K in N]: B }> {
+        return toDo(_.chain(ma, a => _.map(mb, b => ({ ...(a as object), [name]: b })))) as any
+      },
+      bindL<N extends string, B>(name: Exclude<N, keyof A>, fmb: (s: A) => HKT<M, B>): Do0<M, A & { [K in N]: B }> {
+        return toDo(_.chain(ma, a => _.map(fmb(a), b => ({ ...(a as object), [name]: b })))) as any
+      },
+      return<B>(f: (s: A) => B): HKT<M, B> {
+        return _.map(ma, f)
+      },
+      done(): HKT<M, A> {
+        return ma
+      }
+    }
+  }
+
+  return toDo(_.of({}))
+}

--- a/test/Do.ts
+++ b/test/Do.ts
@@ -1,0 +1,96 @@
+import * as assert from 'assert'
+import { option, some, none } from 'fp-ts/lib/Option'
+import { Do } from '../src/Do'
+import { Task, task } from 'fp-ts/lib/Task'
+import { getMonad, success, failure } from 'fp-ts/lib/Validation'
+import { either, right, left } from 'fp-ts/lib/Either'
+import { getSemigroup, NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
+
+describe('Do', () => {
+  it('should compose options', () => {
+    const user = Do(option)
+      .bindL('name', () => some('bob'))
+      .bindL('email', () => some('bsmith@example.com'))
+      .bindL('len', ({ name }) => some(name.length))
+      .return(({ name, email, len }) => ({ name, email, len }))
+
+    assert.deepStrictEqual(user, some({ name: 'bob', email: 'bsmith@example.com', len: 3 }))
+
+    const user2 = Do(option)
+      .bindL('name', () => some('bob'))
+      .bindL('email', () => some('bsmith@example.com'))
+      .bindL('len', () => none)
+      .done()
+    assert.deepStrictEqual(user2, none)
+  })
+
+  it('should compose tasks', () => {
+    const wait = <A>(ms: number, a: A): Task<A> =>
+      new Task(
+        () =>
+          new Promise(res => {
+            setTimeout(() => res(a), ms)
+          })
+      )
+
+    const user = Do(task)
+      .do(wait(1, 'nothing'))
+      .doL(() => wait(1, 'nothing'))
+      .bindL('name', () => wait(1, 'bob'))
+      .bind('email', wait(1, 'bsmith@example.com'))
+      .bindL('len', ({ name }) => wait(1, name.length))
+      .return(({ name, email, len }) => ({ name, email, len }))
+
+    const then = Date.now()
+    return user.run().then(u => {
+      const now = Date.now()
+      console.log('Took: ', now - then, ' milliseconds')
+      assert.deepStrictEqual(u, { name: 'bob', email: 'bsmith@example.com', len: 3 })
+    })
+  })
+
+  it('should compose eithers', () => {
+    const user = Do(either)
+      .do(right('nothing'))
+      .doL(() => right('nothing'))
+      .bind('name', right('bob'))
+      .bind('email', right('bsmith@example.com'))
+      .bindL('len', ({ name }) => right(name.length))
+      .return(({ name, email, len }) => ({ name, email, len }))
+
+    assert.deepStrictEqual(user, right({ name: 'bob', email: 'bsmith@example.com', len: 3 }))
+
+    const user2 = Do(either)
+      .do(right<string, string>('nothing'))
+      .doL(() => right('nothing'))
+      .bind('name', right('bob'))
+      .bind('email', left('error from email'))
+      .bindL('len', () => left('error from len'))
+      .return(({ name, email, len }) => ({ name, email, len }))
+
+    assert.deepStrictEqual(user2, left('error from email'))
+  })
+
+  it('should compose validations', () => {
+    const validationMonad = getMonad(getSemigroup<string>())
+    const neOf = <A>(a: A): NonEmptyArray<A> => new NonEmptyArray(a, [])
+
+    const user = Do(validationMonad)
+      .do(success('nothing'))
+      .doL(() => success('nothing'))
+      .bind('name', success('bob'))
+      .bind('email', success('bsmith@example.com'))
+      .bindL('len', ({ name }) => success(name.length))
+      .return(({ name, email, len }) => ({ name, email, len }))
+    assert.deepStrictEqual(user, success({ name: 'bob', email: 'bsmith@example.com', len: 3 }))
+
+    const user2 = Do(validationMonad)
+      .do(success('nothing'))
+      .doL(() => success('nothing'))
+      .bind('name', success('bob'))
+      .bind('email', failure(neOf('error from email')))
+      .bindL('len', () => failure(neOf('error from len')))
+      .return(({ name, email, len }) => ({ name, email, len }))
+    assert.deepStrictEqual(user2, failure(neOf('error from email')))
+  })
+})


### PR DESCRIPTION
`du` is a translation of scala's `for` comprehension for javascript.

It allows you to convert nested `chain` + `map` calls to top-level functions with increasing arity:
 
```ts
import { option, some, Option } from "fp-ts/lib/Option";

//from:
some("bob").chain(str => {
  return some(54).map(num => {
    return ({ name: str, age: num })
  })
})

//into:
du(option)(
  some("bob"),
  (str) => some(54),
  (num, str) => ({ name: str, age: num })
);
```