### PR TITLE
Add Align & Semialign

### DIFF
--- a/dtslint/ts3.0/index.ts
+++ b/dtslint/ts3.0/index.ts
@@ -3,8 +3,10 @@ import * as IO from 'fp-ts/lib/IO'
 import * as Task from 'fp-ts/lib/Task'
 import * as TaskEither from 'fp-ts/lib/TaskEither'
 import * as ReaderTaskEither from 'fp-ts/lib/ReaderTaskEither'
+import * as Th from 'fp-ts/lib/These'
 import { either, right } from 'fp-ts/lib/Either'
 import { Do } from '../../src/Do'
+import * as Sa from '../../src/Semialign'
 
 //
 // time
@@ -18,3 +20,17 @@ const time4 = time(ReaderTaskEither.readerTaskEither) // $ExpectType <U, L, A>(m
 Do(either)
   .bind('name', right<string, string>('bob'))
   .bindL('bad', () => right<boolean, number>(54)) // $ExpectError
+
+//
+// Semialign
+//
+
+declare const d1: { [key: string]: number }
+declare const d2: Record<string, string>
+declare const r2: Record<'a', number>
+declare const r3: Record<'b', string>
+Sa.record.align(d1, d2) // $ExpectType Record<string, These<number, string>>
+Sa.record.align(r2, r3) // $ExpectType Record<"a" | "b", These<number, string>>
+
+Sa.record.alignWith(d1, d2, (x: Th.These<number, string>) => 'Test') // $ExpectType Record<string, string>
+Sa.record.alignWith(r2, r3, (x: Th.These<number, string>) => 'Test') // $ExpectType Record<"a" | "b", string>

--- a/dtslint/ts3.0/index.ts
+++ b/dtslint/ts3.0/index.ts
@@ -6,7 +6,7 @@ import * as ReaderTaskEither from 'fp-ts/lib/ReaderTaskEither'
 import * as Th from 'fp-ts/lib/These'
 import { either, right } from 'fp-ts/lib/Either'
 import { Do } from '../../src/Do'
-import * as Sa from '../../src/Semialign'
+import * as alignRecord from '../../src/Align/Record'
 
 //
 // time
@@ -22,15 +22,15 @@ Do(either)
   .bindL('bad', () => right<boolean, number>(54)) // $ExpectError
 
 //
-// Semialign
+// Align/Record
 //
 
 declare const d1: { [key: string]: number }
-declare const d2: Record<string, string>
-declare const r2: Record<'a', number>
-declare const r3: Record<'b', string>
-Sa.record.align(d1, d2) // $ExpectType Record<string, These<number, string>>
-Sa.record.align(r2, r3) // $ExpectType Record<"a" | "b", These<number, string>>
+declare const d2: { [key: string]: string }
+declare const r1: Record<'a', number>
+declare const r2: Record<'b', string>
+alignRecord.align(d1, d2) // $ExpectType Record<string, These<number, string>>
+alignRecord.align(r1, r2) // $ExpectType Record<"a" | "b", These<number, string>>
 
-Sa.record.alignWith(d1, d2, (x: Th.These<number, string>) => 'Test') // $ExpectType Record<string, string>
-Sa.record.alignWith(r2, r3, (x: Th.These<number, string>) => 'Test') // $ExpectType Record<"a" | "b", string>
+alignRecord.alignWith(d1, d2, (x: Th.These<number, string>) => 'Test') // $ExpectType Record<string, string>
+alignRecord.alignWith(r1, r2, (x: Th.These<number, string>) => 'Test') // $ExpectType Record<"a" | "b", string>

--- a/src/Align/Array.ts
+++ b/src/Align/Array.ts
@@ -1,0 +1,151 @@
+import { These, this_, that, both } from 'fp-ts/lib/These'
+import { array, URI, catOptions } from 'fp-ts/lib/Array'
+import { Option } from 'fp-ts/lib/Option'
+import { identity, tuple } from 'fp-ts/lib/function'
+
+import { Align1, padZipWith } from './'
+
+/**
+ * `Align` instance for `Array`.
+ *
+ * @since 0.0.3
+ */
+export const alignArray: Align1<URI> = {
+  URI,
+  map: array.map,
+  /**
+   * Unit value in regards to `align`
+   */
+  nil: <A>(): Array<A> => [],
+  /**
+   * Apply a function to pairs of elements at the same index in two arrays, collecting the results in a new array.
+   * Uses the `These` data type to handle arrays of different lengths.
+   *
+   * @example
+   * import { These } from 'fp-ts/lib/These'
+   * import { identity } from 'fp-ts/lib/function'
+   * import { alignArray } from 'fp-ts-contrib/lib/Align/Array'
+   *
+   * const f = (x: These<number, string>) => x.fold(a => a.toString(), identity, (a, b) => a + b)
+   *
+   * assert.deepStrictEqual(alignArray.alignWith([1, 2], ['a', 'b'], f), ['1a', '2b'])
+   * assert.deepStrictEqual(alignArray.alignWith([1, 2], ['a'], f), ['1a', '2'])
+   * assert.deepStrictEqual(alignArray.alignWith([1], ['a' 'b'], f), ['1a', 'b'])
+   *
+   * @since 0.0.3
+   */
+  alignWith: <A, B, C>(fa: Array<A>, fb: Array<B>, f: (x: These<A, B>) => C): Array<C> => {
+    const fc = []
+    const aLen = fa.length
+    const bLen = fb.length
+    const len = Math.min(aLen, bLen)
+    for (let i = 0; i < len; i++) {
+      fc[i] = f(both(fa[i], fb[i]))
+    }
+    if (aLen > bLen) {
+      for (let i = bLen; i < aLen; i++) {
+        fc[i] = f(this_<A, B>(fa[i]))
+      }
+    } else {
+      for (let i = aLen; i < bLen; i++) {
+        fc[i] = f(that<A, B>(fb[i]))
+      }
+    }
+    return fc
+  },
+  /**
+   * Takes two arrays and returns an array of corresponding pairs combined using the `These` data type.
+   *
+   * @example
+   * import { These } from 'fp-ts/lib/These'
+   * import { identity } from 'fp-ts/lib/function'
+   * import { alignArray } from 'fp-ts-contrib/lib/Align/Array'
+   *
+   * assert.deepStrictEqual(alignArray.align([1, 2], ['a', 'b']), [both(1, 'a'), both(2, 'b')])
+   * assert.deepStrictEqual(alignArray.align([1, 2], ['a']), [both(1, 'a'), this_(2)])
+   * assert.deepStrictEqual(alignArray.align([1], ['a' 'b']), [both(1, 'a'), that('b')])
+   *
+   * @since 0.0.3
+   */
+  align: <A, B>(fa: Array<A>, fb: Array<B>): Array<These<A, B>> => {
+    return alignArray.alignWith<A, B, These<A, B>>(fa, fb, identity)
+  }
+}
+
+/**
+ * Apply a function to pairs of elements at the same index in two arrays, collecting the results in a new array. If the
+ * left input array is short, it will be padded using `none`.
+ *
+ * It is similar to `zipWith`, but it doesn't discard elements when the left input array is shorter than the right.
+ *
+ * @example
+ * import { Option } from 'fp-ts/lib/Option'
+ * import { lpadZipWith } from 'fp-ts-contrib/lib/Align/Array'
+ *
+ * const f = (ma: Option<number>, b: string) => ma.fold('*', a => a.toString()) + b
+ * assert.deepStrictEqual(lpadZipWith([1, 2, 3], ['a', 'b', 'c', 'd'], f), ['1a', '2b', '3c', '*d'])
+ * assert.deepStrictEqual(lpadZipWith([1, 2, 3, 4], ['a', 'b', 'c'], f), ['1a', '2b', '3c'])
+ *
+ * @since 0.0.3
+ */
+export function lpadZipWith<A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: Option<A>, b: B) => C): Array<C> {
+  return catOptions(padZipWith(alignArray)(xs, ys, (ma, mb) => mb.map(b => f(ma, b))))
+}
+
+/**
+ * Takes two arrays and returns an array of corresponding pairs. If the left input array is short, it will be
+ * padded using `none`.
+ *
+ * It is similar to `zip`, but it doesn't discard elements when the left input array is shorter than the right.
+ *
+ * @example
+ * import { some, none } from 'fp-ts/lib/Option'
+ * import { lpadZip } from 'fp-ts-contrib/lib/Align/Array'
+ *
+ * assert.deepStrictEqual(lpadZip([1, 2], ['a', 'b', 'c']), [[some(1), 'a'], [some(2), 'b'], [none, 'c']])
+ * assert.deepStrictEqual(lpadZip([1, 2, 3], ['a', 'b']), [[some(1), 'a'], [some(2), 'b']])
+ *
+ * @since 0.0.3
+ */
+export function lpadZip<A, B>(xs: Array<A>, ys: Array<B>): Array<[Option<A>, B]> {
+  return lpadZipWith(xs, ys, (a, b) => tuple(a, b))
+}
+
+/**
+ * Apply a function to pairs of elements at the same index in two arrays, collecting the results in a new array. If the
+ * right input array is short, it will be padded using `none`.
+ *
+ * It is similar to `zipWith`, but it doesn't discard elements when the right input array is shorter than the left.
+ *
+ * @example
+ * import { Option } from 'fp-ts/lib/Option'
+ * import { rpadZipWith } from 'fp-ts-contrib/lib/Align/Array'
+ *
+ * const f = (a: number, mb: Option<string>) => a.toString() + mb.getOrElse('*')
+ * assert.deepStrictEqual(rpadZipWith([1, 2, 3, 4], ['a', 'b', 'c'], f), ['1a', '2b', '3c', '4*'])
+ * assert.deepStrictEqual(rpadZipWith([1, 2, 3], ['a', 'b', 'c', 'd'], f), ['1a', '2b', '3c'])
+ *
+ * @since 0.0.3
+ */
+export function rpadZipWith<A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: A, b: Option<B>) => C): Array<C> {
+  return lpadZipWith(ys, xs, (a, b) => f(b, a))
+}
+
+/**
+ * Takes two arrays and returns an array of corresponding pairs. If the right input array is short, it will be
+ * padded using `none`.
+ *
+ * It is similar to `zip`, but it doesn't discard elements when the right input array is shorter than the left.
+ *
+ * @example
+ * import { some, none } from 'fp-ts/lib/Option'
+ * import { rpadZip } from 'fp-ts-contrib/lib/Align/Array'
+ *
+ * assert.deepStrictEqual(rpadZip([1, 2, 3], ['a', 'b']), [[1, some('a')], [2, some('b')], [3, none]])
+ * assert.deepStrictEqual(rpadZip([1, 2], ['a', 'b', 'c']), [[1, some('a')], [2, some('b')]])
+ *
+ * @since 0.0.3
+ */
+export function rpadZip<A, B>(xs: Array<A>, ys: Array<B>): Array<[A, Option<B>]> {
+  return rpadZipWith(xs, ys, (a, b) => tuple(a, b))
+}

--- a/src/Align/Option.ts
+++ b/src/Align/Option.ts
@@ -1,0 +1,67 @@
+import { Option, some, none, option, URI } from 'fp-ts/lib/Option'
+import { These, this_, that, both } from 'fp-ts/lib/These'
+import { identity } from 'fp-ts/lib/function'
+
+import { Align1 } from './'
+
+/**
+ * `Align` instance for `Option`.
+ *
+ * @since 0.0.3
+ */
+export const alignOption: Align1<URI> = {
+  URI,
+  map: option.map,
+  /**
+   * Unit value in regards to `align`
+   *
+   * @since 0.0.3
+   */
+  nil: <A>(): Option<A> => none,
+  /**
+   * Apply a function to the values of two Option's, returning an Option with the result. Uses the `These` data type
+   * to handle the possibility of non existing values.
+   *
+   * @example
+   * import { some, none } from 'fp-ts/lib/Option'
+   * import { These } from 'fp-ts/lib/These'
+   * import { identity } from 'fp-ts/lib/function'
+   * import { alignOption } from 'fp-ts-contrib/lib/Align/Option'
+   *
+   * const f = (x: These<number, string>) => x.fold(a => a.toString(), identity, (a, b) => a + b)
+   *
+   * assert.deepStrictEqual(alignOption.alignWith(some(1), some('a'), f), some('1a'))
+   * assert.deepStrictEqual(alignOption.alignWith(some(1), none, f), some('1'))
+   * assert.deepStrictEqual(alignOption.alignWith(none, some('a'), f), some('a'))
+   * assert.deepStrictEqual(alignOption.alignWith(none, none, f), none)
+   *
+   * @since 0.0.3
+   */
+  alignWith: <A, B, C>(fa: Option<A>, fb: Option<B>, f: (x: These<A, B>) => C): Option<C> => {
+    if (fa.isSome() && fb.isSome()) {
+      return some(f(both(fa.value, fb.value)))
+    } else if (fa.isNone() && fb.isSome()) {
+      return some(f(that(fb.value)))
+    } else if (fa.isSome() && fb.isNone()) {
+      return some(f(this_(fa.value)))
+    } else {
+      return none
+    }
+  },
+  /**
+   * Takes two Option's and returns an Option with a value corresponding to the inputs combined using the `These` data type.
+   *
+   * @example
+   * import { some, none } from 'fp-ts/lib/Option'
+   * import { both, this_, that } from 'fp-ts/lib/These'
+   * import { alignOption } from 'fp-ts-contrib/lib/Align/Option'
+   *
+   * assert.deepStrictEqual(alignOption.align(some(1), some('a')), some(both(1, 'a')))
+   * assert.deepStrictEqual(alignOption.align(some(1, none), some(this_(1)))
+   * assert.deepStrictEqual(alignOption.align(none, some('a')), some(that('a')))
+   * assert.deepStrictEqual(alignOption.align(none, none), none)
+   *
+   * @since 0.0.3
+   */
+  align: <A, B>(fa: Option<A>, fb: Option<B>): Option<These<A, B>> => alignOption.alignWith(fa, fb, identity)
+}

--- a/src/Align/Record.ts
+++ b/src/Align/Record.ts
@@ -1,0 +1,45 @@
+import * as R from 'fp-ts/lib/Record'
+import { These, this_, that, both } from 'fp-ts/lib/These'
+import { identity } from 'fp-ts/lib/function'
+
+export function alignWith<K extends string, P extends string, A, B, C>(
+  fa: Record<K, A>,
+  fb: Record<P, B>,
+  f: (x: These<A, B>) => C
+): Record<K | P, C>
+export function alignWith<A, B, C>(
+  fa: Record<string, A>,
+  fb: Record<string, B>,
+  f: (x: These<A, B>) => C
+): Record<string, C>
+export function alignWith<A, B, C>(
+  fa: Record<string, A>,
+  fb: Record<string, B>,
+  f: (x: These<A, B>) => C
+): Record<string, C> {
+  const r: Record<string, C> = {}
+  for (const key of Object.keys(fa)) {
+    if (fb.hasOwnProperty(key)) {
+      r[key] = f(both(fa[key], fb[key]))
+    } else {
+      r[key] = f(this_(fa[key]))
+    }
+  }
+  for (const key of Object.keys(fb)) {
+    if (!fa.hasOwnProperty(key)) {
+      r[key] = f(that(fb[key]))
+    }
+  }
+  return r
+}
+
+export function align<K extends string, P extends string, A, B>(
+  fa: Record<K, A>,
+  fb: Record<P, B>
+): Record<K | P, These<A, B>>
+export function align<A, B>(fa: Record<string, A>, fb: Record<string, B>): Record<string, These<A, B>>
+export function align<A, B>(fa: Record<string, A>, fb: Record<string, B>): Record<string, These<A, B>> {
+  return alignWith<A, B, These<A, B>>(fa, fb, identity)
+}
+
+export const nil = <A>(): Record<string, A> => R.empty

--- a/src/Align/index.ts
+++ b/src/Align/index.ts
@@ -1,0 +1,156 @@
+/**
+ * @file The `Align` type class extends the `Semialign` type class with a value `nil`, which
+ * acts as a unit in regards to `align`.
+ *
+ * `Align` instances must satisfy the following laws in addition to the `Semialign` laws:
+ *
+ * 1. Right identity: `F.align(fa, nil) = F.map(fa, this_)`
+ * 2. Left identity: `F.align(nil, fa) = F.map(fa, that)`
+ *
+ * Adapted from http://hackage.haskell.org/package/these-0.8/docs/Data-Align.html
+ */
+import { HKT, Type, Type2, Type3, URIS, URIS2, URIS3 } from 'fp-ts/lib/HKT'
+import { Semigroup } from 'fp-ts/lib/Semigroup'
+import { identity, tuple } from 'fp-ts/lib/function'
+import { Option, some, none } from 'fp-ts/lib/Option'
+import { Semialign, Semialign1, Semialign2, Semialign2C, Semialign3, Semialign3C } from '../Semialign'
+
+/**
+ * @since 0.0.3
+ */
+export interface Align<F> extends Semialign<F> {
+  readonly nil: <A>() => HKT<F, A>
+}
+
+export interface Align1<F extends URIS> extends Semialign1<F> {
+  readonly nil: <A>() => Type<F, A>
+}
+
+export interface Align2<F extends URIS2> extends Semialign2<F> {
+  readonly nil: <L, A>() => Type2<F, L, A>
+}
+
+export interface Align3<F extends URIS3> extends Semialign3<F> {
+  readonly nil: <U, L, A>() => Type3<F, U, L, A>
+}
+
+export interface Align2C<F extends URIS2, L> extends Semialign2C<F, L> {
+  readonly nil: <A>() => Type2<F, L, A>
+}
+
+export interface Align3C<F extends URIS3, U, L> extends Semialign3C<F, U, L> {
+  readonly nil: <A>() => Type3<F, U, L, A>
+}
+
+/**
+ * Align two structures, using a semigroup for combining values.
+ *
+ * @example
+ * import { semigroupSum } from 'fp-ts/lib/Semigroup'
+ * import { salign } from 'fp-ts-contrib/lib/Align'
+ * import { alignArray } from 'fp-ts-contrib/lib/Align/Array'
+ *
+ * assert.deepStrictEqual(salign(alignArray, semigroupSum)([1, 2, 3], [4, 5]), [5, 7, 3])
+ *
+ * @since 0.0.3
+ */
+export function salign<F extends URIS3, A, L>(
+  F: Align3<F>,
+  S: Semigroup<A>
+): <U, L>(fx: Type3<F, U, L, A>, fy: Type3<F, U, L, A>) => Type3<F, U, L, A>
+export function salign<F extends URIS3, A, U, L>(
+  F: Align3C<F, U, L>,
+  S: Semigroup<A>
+): (fx: Type3<F, U, L, A>, fy: Type3<F, U, L, A>) => Type3<F, U, L, A>
+export function salign<F extends URIS2, A>(
+  F: Align2<F>,
+  S: Semigroup<A>
+): <L>(fx: Type2<F, L, A>, fy: Type2<F, L, A>) => Type2<F, L, A>
+export function salign<F extends URIS2, A, L>(
+  F: Align2C<F, L>,
+  S: Semigroup<A>
+): (fx: Type2<F, L, A>, fy: Type2<F, L, A>) => Type2<F, L, A>
+export function salign<F extends URIS, A>(F: Align1<F>, S: Semigroup<A>): (fx: Type<F, A>, fy: Type<F, A>) => Type<F, A>
+export function salign<F, A>(F: Align<F>, S: Semigroup<A>): (fx: HKT<F, A>, fy: HKT<F, A>) => HKT<F, A>
+export function salign<F, A>(F: Align<F>, S: Semigroup<A>): (fx: HKT<F, A>, fy: HKT<F, A>) => HKT<F, A> {
+  return (fx, fy) => F.alignWith(fx, fy, xy => xy.fold(identity, identity, S.concat))
+}
+
+/**
+ * Align two structures, using `none` to fill blanks.
+ *
+ * It is similar to `zip`, but it doesn't discard elements.
+ *
+ * @example
+ * import { some, none } from 'fp-ts/lib/Option'
+ * import { padZip } from 'fp-ts-contrib/lib/Align'
+ * import { alignArray } from 'fp-ts-contrib/lib/Align/Array'
+ *
+ * assert.deepStrictEqual(padZip(alignArray)([1, 2, 3], [4, 5]), [[some(1), some(4)], [some(2), some(5)], [some(3), none]])
+ *
+ * @since 0.0.3
+ */
+export function padZip<F extends URIS3, L>(
+  F: Align3<F>
+): <U, L, A, B>(fa: Type3<F, U, L, A>, fb: Type3<F, U, L, B>) => Type3<F, U, L, [Option<A>, Option<B>]>
+export function padZip<F extends URIS3, U, L>(
+  F: Align3C<F, U, L>
+): <A, B>(fa: Type3<F, U, L, A>, fb: Type3<F, U, L, B>) => Type3<F, U, L, [Option<A>, Option<B>]>
+export function padZip<F extends URIS2>(
+  F: Align2<F>
+): <L, A, B>(fa: Type2<F, L, A>, fb: Type2<F, L, B>) => Type2<F, L, [Option<A>, Option<B>]>
+export function padZip<F extends URIS2, L>(
+  F: Align2C<F, L>
+): <A, B>(fa: Type2<F, L, A>, fb: Type2<F, L, B>) => Type2<F, L, [Option<A>, Option<B>]>
+export function padZip<F extends URIS>(
+  F: Align1<F>
+): <A, B>(fa: Type<F, A>, fb: Type<F, B>) => Type<F, [Option<A>, Option<B>]>
+export function padZip<F>(F: Align<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, [Option<A>, Option<B>]>
+export function padZip<F>(F: Align<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, [Option<A>, Option<B>]> {
+  return (fa, fb) => padZipWith(F)(fa, fb, (a, b) => tuple(a, b))
+}
+
+/**
+ * Align two structures by applying a function to each pair of aligned elements, using `none` to fill blanks.
+ *
+ * It is similar to `zipWith`, but it doesn't discard elements.
+ *
+ * @example
+ * import { Option } from 'fp-ts/lib/Option'
+ * import { padZipWith } from 'fp-ts-contrib/lib/Align'
+ * import { alignArray } from 'fp-ts-contrib/lib/Align/Array'
+ *
+ * const f = (ma: Option<number>, mb: Option<string>) => ma.fold('*', a => a.toString()) + mb.getOrElse('#')
+ * assert.deepStrictEqual(padZipWith(alignArray)([1, 2], ['a'], f), ['1a', '2#'])
+ * assert.deepStrictEqual(padZipWith(alignArray)([1], ['a', 'b'], f), ['1a', '*b'])
+ *
+ * @since 0.0.3
+ */
+export function padZipWith<F extends URIS3, L>(
+  F: Align3<F>
+): <U, L, A, B, C>(
+  fa: Type3<F, U, L, A>,
+  fb: Type3<F, U, L, B>,
+  f: (a: Option<A>, b: Option<B>) => C
+) => Type3<F, U, L, C>
+export function padZipWith<F extends URIS3, U, L>(
+  F: Align3C<F, U, L>
+): <A, B, C>(fa: Type3<F, U, L, A>, fb: Type3<F, U, L, B>, f: (a: Option<A>, b: Option<B>) => C) => Type3<F, U, L, C>
+export function padZipWith<F extends URIS2>(
+  F: Align2<F>
+): <L, A, B, C>(fa: Type2<F, L, A>, fb: Type2<F, L, B>, f: (a: Option<A>, b: Option<B>) => C) => Type2<F, L, C>
+export function padZipWith<F extends URIS2, L>(
+  F: Align2C<F, L>
+): <A, B, C>(fa: Type2<F, L, A>, fb: Type2<F, L, B>, f: (a: Option<A>, b: Option<B>) => C) => Type2<F, L, C>
+export function padZipWith<F extends URIS>(
+  F: Align1<F>
+): <A, B, C>(fa: Type<F, A>, fb: Type<F, B>, f: (a: Option<A>, b: Option<B>) => C) => Type<F, C>
+export function padZipWith<F>(
+  F: Align<F>
+): <A, B, C>(fa: HKT<F, A>, fb: HKT<F, B>, f: (a: Option<A>, b: Option<B>) => C) => HKT<F, C>
+export function padZipWith<F>(
+  F: Align<F>
+): <A, B, C>(fa: HKT<F, A>, fb: HKT<F, B>, f: (a: Option<A>, b: Option<B>) => C) => HKT<F, C> {
+  return (fa, fb, f) =>
+    F.alignWith(fa, fb, ab => ab.bimap(some, some).fold(a => f(a, none), b => f(none, b), (a, b) => f(a, b)))
+}

--- a/src/Semialign/NonEmptyArray.ts
+++ b/src/Semialign/NonEmptyArray.ts
@@ -1,0 +1,51 @@
+import { NonEmptyArray, nonEmptyArray, URI } from 'fp-ts/lib/NonEmptyArray'
+import { These, both } from 'fp-ts/lib/These'
+import { alignArray } from '../Align/Array'
+import { Semialign1 } from './'
+
+/**
+ * `Semialign` instance for `NonEmptyArray`.
+ *
+ * @since 0.0.3
+ */
+export const semialignNonEmptyArray: Semialign1<URI> = {
+  URI,
+  map: nonEmptyArray.map,
+  /**
+   * Apply a function to pairs of elements at the same index in two arrays, collecting the results in a new array.
+   * Uses the `These` data type to handle arrays of different lengths.
+   *
+   * @example
+   * import { These } from 'fp-ts/lib/These'
+   * import { identity } from 'fp-ts/lib/function'
+   * import { alignNonEmptyArray } from 'fp-ts-contrib/lib/Semialign/NonEmptyArray'
+   *
+   * const f = (x: These<number, string>) => x.fold(a => a.toString(), identity, (a, b) => a + b)
+   *
+   * assert.deepStrictEqual(semialignNonEmptyArray.alignWith(new NonEmptyArray(1, [2, 3]), new NonEmptyArray('a', ['b', 'c']), f), new NonEmptyArray('1a', ['2b', '3c']))
+   * assert.deepStrictEqual(semialignNonEmptyArray.alignWith(new NonEmptyArray(1, [2, 3]), new NonEmptyArray('a', ['b']), f), new NonEmptyArray('1a', ['2b', '3']))
+   * assert.deepStrictEqual(semialignNonEmptyArray.alignWith(new NonEmptyArray(1, [2]), new NonEmptyArray('a', ['b', 'c']), f), new NonEmptyArray('1a', ['2b', 'c']))
+   *
+   * @since 0.0.3
+   */
+  alignWith: <A, B, C>(fa: NonEmptyArray<A>, fb: NonEmptyArray<B>, f: (x: These<A, B>) => C): NonEmptyArray<C> => {
+    return new NonEmptyArray(f(both(fa.head, fb.head)), alignArray.alignWith(fa.tail, fb.tail, f))
+  },
+  /**
+   * Takes two arrays and returns an array of corresponding pairs combined using the `These` data type.
+   *
+   * @example
+   * import { These } from 'fp-ts/lib/These'
+   * import { identity } from 'fp-ts/lib/function'
+   * import { alignNonEmptyArray } from 'fp-ts-contrib/lib/Semialign/NonEmptyArray'
+   *
+   * assert.deepStrictEqual(semialignNonEmptyArray.align(new NonEmptyArray(1, [2, 3]), new NonEmptyArray('a', ['b', 'c']), new NonEmptyArray(both(1, 'a'), [both(2, 'b'), both(3, 'c')]))
+   * assert.deepStrictEqual(semialignNonEmptyArray.align(new NonEmptyArray(1, [2, 3]), new NonEmptyArray('a', ['b']), new NonEmptyArray(both(1, 'a'), [both(2, 'b'), this_(3)])
+   * assert.deepStrictEqual(semialignNonEmptyArray.align(new NonEmptyArray(1, [2]), new NonEmptyArray('a', ['b', 'c']), new NonEmptyArray(both(1, 'a'), [both(2, 'b'), that('c')]))
+   *
+   * @since 0.0.3
+   */
+  align: <A, B>(fa: NonEmptyArray<A>, fb: NonEmptyArray<B>): NonEmptyArray<These<A, B>> => {
+    return new NonEmptyArray(both(fa.head, fb.head), alignArray.align(fa.tail, fb.tail))
+  }
+}

--- a/src/Semialign/index.ts
+++ b/src/Semialign/index.ts
@@ -1,0 +1,60 @@
+/**
+ * @file The `Semialign` type class represents functors supporting a zip operation that takes the
+ * union of non-uniform shapes.
+ *
+ * `Semialign` instances are required to satisfy the following laws:
+ *
+ * 1. `F.align(fa, fa) = F.map(fa, (a) => both(a, a))`
+ * 2. `F.align(F.map(fa, f), F.map(fb, g)) = F.map(F.align(fa, fb), (t) => These.bimap(t, f, g))`
+ * 3. `F.alignWith(fa, fb, f) = F.map(F.align(fa, fb), f)`
+ * 4. `F.align(fa, F.align(fb, fc)) = F.map(F.align(F.align(fa, fb), fc), These.assoc)`
+ *
+ * Where `These.assoc` implements the associativity law of `These` and has the following type signature:
+ * `function assoc<A, B, C>(fa: These<A, These<B, C>>): These<These<A, B>, C>`
+ *
+ * Adapted from http://hackage.haskell.org/package/these-0.8/docs/Data-Align.html
+ */
+import { Functor, Functor1, Functor2, Functor2C, Functor3, Functor3C } from 'fp-ts/lib/Functor'
+import { HKT, Type, Type2, Type3, URIS, URIS2, URIS3 } from 'fp-ts/lib/HKT'
+import { These } from 'fp-ts/lib/These'
+
+/**
+ * @since 0.3.0
+ */
+export interface Semialign<F> extends Functor<F> {
+  readonly align: <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, These<A, B>>
+  readonly alignWith: <A, B, C>(fa: HKT<F, A>, fb: HKT<F, B>, f: (x: These<A, B>) => C) => HKT<F, C>
+}
+
+export interface Semialign1<F extends URIS> extends Functor1<F> {
+  readonly align: <A, B>(fa: Type<F, A>, fb: Type<F, B>) => Type<F, These<A, B>>
+  readonly alignWith: <A, B, C>(fa: Type<F, A>, fb: Type<F, B>, f: (x: These<A, B>) => C) => Type<F, C>
+}
+
+export interface Semialign2<F extends URIS2> extends Functor2<F> {
+  readonly align: <L, A, B>(fa: Type2<F, L, A>, fb: Type2<F, L, B>) => Type2<F, L, These<A, B>>
+  readonly alignWith: <L, A, B, C>(fa: Type2<F, L, A>, fb: Type2<F, L, B>, f: (x: These<A, B>) => C) => Type2<F, L, C>
+}
+
+export interface Semialign3<F extends URIS3> extends Functor3<F> {
+  readonly align: <U, L, A, B>(fa: Type3<F, U, L, A>, fb: Type3<F, U, L, B>) => Type3<F, U, L, These<A, B>>
+  readonly alignWith: <U, L, A, B, C>(
+    fa: Type3<F, U, L, A>,
+    fb: Type3<F, U, L, B>,
+    f: (x: These<A, B>) => C
+  ) => Type3<F, U, L, C>
+}
+
+export interface Semialign2C<F extends URIS2, L> extends Functor2C<F, L> {
+  readonly align: <A, B>(fa: Type2<F, L, A>, fb: Type2<F, L, B>) => Type2<F, L, These<A, B>>
+  readonly alignWith: <A, B, C>(fa: Type2<F, L, A>, fb: Type2<F, L, B>, f: (x: These<A, B>) => C) => Type2<F, L, C>
+}
+
+export interface Semialign3C<F extends URIS3, U, L> extends Functor3C<F, U, L> {
+  readonly align: <A, B>(fa: Type3<F, U, L, A>, fb: Type3<F, U, L, B>) => Type3<F, U, L, These<A, B>>
+  readonly alignWith: <A, B, C>(
+    fa: Type3<F, U, L, A>,
+    fb: Type3<F, U, L, B>,
+    f: (x: These<A, B>) => C
+  ) => Type3<F, U, L, C>
+}

--- a/test/Align.ts
+++ b/test/Align.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert'
+import { Option, some, none } from 'fp-ts/lib/Option'
+import { These, both, this_, that } from 'fp-ts/lib/These'
+import { identity } from 'fp-ts/lib/function'
+import { alignArray, lpadZipWith, lpadZip, rpadZipWith, rpadZip } from '../src/Align/Array'
+
+describe('Align', () => {
+  describe('Array', () => {
+    it('align', () => {
+      assert.deepStrictEqual(alignArray.align([1, 2], ['a', 'b']), [both(1, 'a'), both(2, 'b')])
+      assert.deepStrictEqual(alignArray.align([1, 2], ['a']), [both(1, 'a'), this_(2)])
+      assert.deepStrictEqual(alignArray.align([1], ['a', 'b']), [both(1, 'a'), that('b')])
+      assert.deepStrictEqual(alignArray.align([], []), [])
+      assert.deepStrictEqual(alignArray.align([1], alignArray.nil<string>()), [this_(1)])
+      assert.deepStrictEqual(alignArray.align(alignArray.nil<number>(), ['a']), [that('a')])
+    })
+
+    it('alignWith', () => {
+      const f = (x: These<number, string>) => x.fold(a => a.toString(), identity, (a, b) => b + a)
+      assert.deepStrictEqual(alignArray.alignWith([1, 2], ['a', 'b'], f), ['a1', 'b2'])
+      assert.deepStrictEqual(alignArray.alignWith([1, 2], ['a'], f), ['a1', '2'])
+      assert.deepStrictEqual(alignArray.alignWith([1], ['a', 'b'], f), ['a1', 'b'])
+      assert.deepStrictEqual(alignArray.alignWith([], [], f), [])
+      assert.deepStrictEqual(alignArray.alignWith([1], alignArray.nil<string>(), f), ['1'])
+      assert.deepStrictEqual(alignArray.alignWith(alignArray.nil<number>(), ['a'], f), ['a'])
+    })
+
+    it('lpadZip', () => {
+      assert.deepStrictEqual(lpadZip([1, 2], ['a', 'b']), [[some(1), 'a'], [some(2), 'b']])
+      assert.deepStrictEqual(lpadZip([1, 2], ['a']), [[some(1), 'a']])
+      assert.deepStrictEqual(lpadZip([1], ['a', 'b']), [[some(1), 'a'], [none, 'b']])
+      assert.deepStrictEqual(lpadZip([], []), [])
+    })
+
+    it('lpadZipWith', () => {
+      const f = (ma: Option<number>, b: string) => b + ma.fold('*', a => a.toString())
+      assert.deepStrictEqual(lpadZipWith([1, 2], ['a', 'b'], f), ['a1', 'b2'])
+      assert.deepStrictEqual(lpadZipWith([1, 2], ['a'], f), ['a1'])
+      assert.deepStrictEqual(lpadZipWith([1], ['a', 'b'], f), ['a1', 'b*'])
+      assert.deepStrictEqual(lpadZipWith([], [], f), [])
+    })
+
+    it('rpadZip', () => {
+      assert.deepStrictEqual(rpadZip([1, 2], ['a', 'b']), [[1, some('a')], [2, some('b')]])
+      assert.deepStrictEqual(rpadZip([1, 2], ['a']), [[1, some('a')], [2, none]])
+      assert.deepStrictEqual(rpadZip([1], ['a', 'b']), [[1, some('a')]])
+      assert.deepStrictEqual(rpadZip([], []), [])
+    })
+
+    it('rpadZipWith', () => {
+      const f = (a: number, mb: Option<string>) => mb.getOrElse('*') + a.toString()
+      assert.deepStrictEqual(rpadZipWith([1, 2], ['a', 'b'], f), ['a1', 'b2'])
+      assert.deepStrictEqual(rpadZipWith([1, 2], ['a'], f), ['a1', '*2'])
+      assert.deepStrictEqual(rpadZipWith([1], ['a', 'b'], f), ['a1'])
+      assert.deepStrictEqual(rpadZipWith([], [], f), [])
+    })
+  })
+})

--- a/test/Align.ts
+++ b/test/Align.ts
@@ -1,10 +1,34 @@
 import * as assert from 'assert'
+import { semigroupSum } from 'fp-ts/lib/Semigroup'
 import { Option, some, none } from 'fp-ts/lib/Option'
 import { These, both, this_, that } from 'fp-ts/lib/These'
 import { identity } from 'fp-ts/lib/function'
+import { salign, padZip, padZipWith } from '../src/Align'
 import { alignArray, lpadZipWith, lpadZip, rpadZipWith, rpadZip } from '../src/Align/Array'
 
 describe('Align', () => {
+  it('salign', () => {
+    assert.deepStrictEqual(salign(alignArray, semigroupSum)([1, 2], [4, 5]), [5, 7])
+    assert.deepStrictEqual(salign(alignArray, semigroupSum)([1, 2], [4]), [5, 2])
+    assert.deepStrictEqual(salign(alignArray, semigroupSum)([1], [4, 5]), [5, 5])
+    assert.deepStrictEqual(salign(alignArray, semigroupSum)([], []), [])
+  })
+
+  it('padZip', () => {
+    assert.deepStrictEqual(padZip(alignArray)([1, 2], ['a', 'b']), [[some(1), some('a')], [some(2), some('b')]])
+    assert.deepStrictEqual(padZip(alignArray)([1, 2], ['a']), [[some(1), some('a')], [some(2), none]])
+    assert.deepStrictEqual(padZip(alignArray)([1], ['a', 'b']), [[some(1), some('a')], [none, some('b')]])
+    assert.deepStrictEqual(padZip(alignArray)([], []), [])
+  })
+
+  it('padZipWith', () => {
+    const f = (ma: Option<number>, mb: Option<string>) => mb.getOrElse('#') + ma.fold('*', a => a.toString())
+    assert.deepStrictEqual(padZipWith(alignArray)([1, 2], ['a', 'b'], f), ['a1', 'b2'])
+    assert.deepStrictEqual(padZipWith(alignArray)([1, 2], ['a'], f), ['a1', '#2'])
+    assert.deepStrictEqual(padZipWith(alignArray)([1], ['a', 'b'], f), ['a1', 'b*'])
+    assert.deepStrictEqual(padZipWith(alignArray)([], [], f), [])
+  })
+
   describe('Array', () => {
     it('align', () => {
       assert.deepStrictEqual(alignArray.align([1, 2], ['a', 'b']), [both(1, 'a'), both(2, 'b')])

--- a/test/Align.ts
+++ b/test/Align.ts
@@ -6,6 +6,7 @@ import { identity } from 'fp-ts/lib/function'
 import { salign, padZip, padZipWith } from '../src/Align'
 import { alignArray, lpadZipWith, lpadZip, rpadZipWith, rpadZip } from '../src/Align/Array'
 import { alignOption } from '../src/Align/Option'
+import * as alignRecord from '../src/Align/Record'
 
 describe('Align', () => {
   it('salign', () => {
@@ -95,6 +96,30 @@ describe('Align', () => {
       assert.deepStrictEqual(alignOption.alignWith(some(1), alignOption.nil<string>(), f), some('1'))
       assert.deepStrictEqual(alignOption.alignWith(alignOption.nil<number>(), some('a'), f), some('a'))
       assert.deepStrictEqual(alignOption.alignWith(alignOption.nil<number>(), alignOption.nil<string>(), f), none)
+    })
+  })
+
+  describe('Record', () => {
+    it('align', () => {
+      assert.deepStrictEqual(alignRecord.align({ a: 1, b: 2 }, { a: 'a', b: 'b' }), {
+        a: both(1, 'a'),
+        b: both(2, 'b')
+      })
+      assert.deepStrictEqual(alignRecord.align({ a: 1, b: 2 }, { a: 'a' }), { a: both(1, 'a'), b: this_(2) })
+      assert.deepStrictEqual(alignRecord.align({ a: 1 }, { a: 'a', b: 'b' }), { a: both(1, 'a'), b: that('b') })
+      assert.deepStrictEqual(alignRecord.align({}, {}), {})
+      assert.deepStrictEqual(alignRecord.align({ a: 1 }, alignRecord.nil<string>()), { a: this_(1) })
+      assert.deepStrictEqual(alignRecord.align(alignRecord.nil<number>(), { a: 'a' }), { a: that('a') })
+    })
+
+    it('alignWith', () => {
+      const f = (x: These<number, string>) => x.fold(a => a.toString(), identity, (a, b) => b + a)
+      assert.deepStrictEqual(alignRecord.alignWith({ a: 1, b: 2 }, { a: 'a', b: 'b' }, f), { a: 'a1', b: 'b2' })
+      assert.deepStrictEqual(alignRecord.alignWith({ a: 1, b: 2 }, { a: 'a' }, f), { a: 'a1', b: '2' })
+      assert.deepStrictEqual(alignRecord.alignWith({ a: 1 }, { a: 'a', b: 'b' }, f), { a: 'a1', b: 'b' })
+      assert.deepStrictEqual(alignRecord.alignWith({}, {}, f), {})
+      assert.deepStrictEqual(alignRecord.alignWith({ a: 1 }, alignRecord.nil<string>(), f), { a: '1' })
+      assert.deepStrictEqual(alignRecord.alignWith(alignRecord.nil<number>(), { a: 'a' }, f), { a: 'a' })
     })
   })
 })

--- a/test/Align.ts
+++ b/test/Align.ts
@@ -5,6 +5,7 @@ import { These, both, this_, that } from 'fp-ts/lib/These'
 import { identity } from 'fp-ts/lib/function'
 import { salign, padZip, padZipWith } from '../src/Align'
 import { alignArray, lpadZipWith, lpadZip, rpadZipWith, rpadZip } from '../src/Align/Array'
+import { alignOption } from '../src/Align/Option'
 
 describe('Align', () => {
   it('salign', () => {
@@ -77,6 +78,23 @@ describe('Align', () => {
       assert.deepStrictEqual(rpadZipWith([1, 2], ['a'], f), ['a1', '*2'])
       assert.deepStrictEqual(rpadZipWith([1], ['a', 'b'], f), ['a1'])
       assert.deepStrictEqual(rpadZipWith([], [], f), [])
+    })
+  })
+
+  describe('Option', () => {
+    it('align', () => {
+      assert.deepStrictEqual(alignOption.align(some(1), some('a')), some(both(1, 'a')))
+      assert.deepStrictEqual(alignOption.align(some(1), alignOption.nil<string>()), some(this_(1)))
+      assert.deepStrictEqual(alignOption.align(alignOption.nil<number>(), some('a')), some(that('a')))
+      assert.deepStrictEqual(alignOption.align(alignOption.nil<number>(), alignOption.nil<string>()), none)
+    })
+
+    it('alignWith', () => {
+      const f = (x: These<number, string>) => x.fold(a => a.toString(), identity, (a, b) => b + a)
+      assert.deepStrictEqual(alignOption.alignWith(some(1), some('a'), f), some('a1'))
+      assert.deepStrictEqual(alignOption.alignWith(some(1), alignOption.nil<string>(), f), some('1'))
+      assert.deepStrictEqual(alignOption.alignWith(alignOption.nil<number>(), some('a'), f), some('a'))
+      assert.deepStrictEqual(alignOption.alignWith(alignOption.nil<number>(), alignOption.nil<string>(), f), none)
     })
   })
 })

--- a/test/Semialign.ts
+++ b/test/Semialign.ts
@@ -1,0 +1,48 @@
+import * as assert from 'assert'
+import { These, this_, that, both } from 'fp-ts/lib/These'
+import { identity } from 'fp-ts/lib/function'
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
+import { semialignNonEmptyArray } from '../src/Semialign/NonEmptyArray'
+
+describe('Semialign', () => {
+  describe('NonEmptyArray', () => {
+    it('align', () => {
+      assert.deepStrictEqual(
+        semialignNonEmptyArray.align(new NonEmptyArray(1, [2, 3]), new NonEmptyArray('a', ['b', 'c'])),
+        new NonEmptyArray(both(1, 'a'), [both(2, 'b'), both(3, 'c')])
+      )
+      assert.deepStrictEqual(
+        semialignNonEmptyArray.align(new NonEmptyArray(1, [2, 3]), new NonEmptyArray('a', ['b'])),
+        new NonEmptyArray(both(1, 'a'), [both(2, 'b'), this_(3)])
+      )
+      assert.deepStrictEqual(
+        semialignNonEmptyArray.align(new NonEmptyArray(1, [2]), new NonEmptyArray('a', ['b', 'c'])),
+        new NonEmptyArray(both(1, 'a'), [both(2, 'b'), that('c')])
+      )
+      assert.deepStrictEqual(
+        semialignNonEmptyArray.align(new NonEmptyArray(1, []), new NonEmptyArray('a', [])),
+        new NonEmptyArray(both(1, 'a'), [])
+      )
+    })
+
+    it('alignWith', () => {
+      const f = (x: These<number, string>) => x.fold(a => a.toString(), identity, (a, b) => b + a)
+      assert.deepStrictEqual(
+        semialignNonEmptyArray.alignWith(new NonEmptyArray(1, [2, 3]), new NonEmptyArray('a', ['b', 'c']), f),
+        new NonEmptyArray('a1', ['b2', 'c3'])
+      )
+      assert.deepStrictEqual(
+        semialignNonEmptyArray.alignWith(new NonEmptyArray(1, [2, 3]), new NonEmptyArray('a', ['b']), f),
+        new NonEmptyArray('a1', ['b2', '3'])
+      )
+      assert.deepStrictEqual(
+        semialignNonEmptyArray.alignWith(new NonEmptyArray(1, [2]), new NonEmptyArray('a', ['b', 'c']), f),
+        new NonEmptyArray('a1', ['b2', 'c'])
+      )
+      assert.deepStrictEqual(
+        semialignNonEmptyArray.alignWith(new NonEmptyArray(1, []), new NonEmptyArray('a', []), f),
+        new NonEmptyArray('a1', [])
+      )
+    })
+  })
+})


### PR DESCRIPTION
As promised, heres my attempt at adding the Align and Semialign type classes.

I have tried a couple of different approaches on how to extend the existing instances.

At first I did something similar to what is done in PR #6. Where I extended and exported all the instances from the `Aling.ts` and `Semialign.ts` files.

Though I felt like this approach had a few downsides.

1. It created a bit of a mess with instances for multiple types in the same file.
2. If we want to add some additional type class instances to these types in the future, we will have to repeat the extending each time.
3. We also end up with the instances scattered across multiple locations which the user will have to import and combine somehow. This could be a benefit though as the user is free to select only the instances that they need.

Instead I have opted for using the same approach as `fp-ts` with separate files for each type. This way a user of the library can import these types the same way they would from `fp-ts` but with the additional functionality provided by `fp-ts-contrib`. The downside to this is that this will most likely result in additional runtime overhead.

Ultimately this comes down to how we want to approach this and what role we think `fp-ts-contrib` should have. Is it a collection of useful utilities that can be brought in a la carte or is it an extension of `fp-ts`.

It is your call. Let me know if you want me to change it back to exporting the extended instances from each type class file. Or if you have some better approach altogether.