### PR TITLE
Improve Do performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts-contrib",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -78,6 +78,12 @@
         "traverse": "^0.6.6",
         "unified": "^6.1.6"
       }
+    },
+    "@types/benchmark": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@types/benchmark/-/benchmark-1.0.31.tgz",
+      "integrity": "sha512-F6fVNOkGEkSdo/19yWYOwVKGvzbTeWkR/XQYBKtGBQ9oGRjBN9f/L4aJI4sDcVPJO58Y1CJZN8va9V2BhrZapA==",
+      "dev": true
     },
     "@types/jest": {
       "version": "23.3.13",
@@ -934,6 +940,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "boundary": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/boundary/-/boundary-1.0.1.tgz",
@@ -1676,7 +1692,7 @@
       }
     },
     "dtslint": {
-      "version": "github:gcanti/dtslint#02aec0b72ae639458f02349c5c68dd6229287a6d",
+      "version": "github:gcanti/dtslint#b3910c2636a0ccffd966cb7de8ab10c79980a7cc",
       "from": "github:gcanti/dtslint",
       "dev": true,
       "requires": {
@@ -1684,13 +1700,13 @@
         "parsimmon": "^1.12.0",
         "strip-json-comments": "^2.0.1",
         "tslint": "^5.12.0",
-        "typescript": "^3.4.0-dev.20190222"
+        "typescript": "^3.5.0-dev.20190427"
       },
       "dependencies": {
         "typescript": {
-          "version": "3.4.0-dev.20190222",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.0-dev.20190222.tgz",
-          "integrity": "sha512-kKsfstKWNLMimo0d7+/jj7Jozlhvc6OHE9em8zmgsncCbM4QTr0y66j4UTDjYFRbSnK0taYlzrxpdGXiQgnuOA==",
+          "version": "3.5.0-dev.20190427",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.0-dev.20190427.tgz",
+          "integrity": "sha512-JvW5u5YEi1uyNFTTPYIKMI1zgKvvisMBXGGdF/ttHSSnNqSiMvdYuFYCCrJQzG74YWgmwZX6xweJGJO3eoOjNg==",
           "dev": true
         }
       }
@@ -5196,6 +5212,12 @@
         "find-up": "^2.1.0"
       }
     },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+      "dev": true
+    },
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
@@ -6406,6 +6428,7 @@
     },
     "strip-json-comments": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
     "fp-ts": "^1.14.3"
   },
   "devDependencies": {
+    "@types/benchmark": "^1.0.31",
     "@types/jest": "^23.3.13",
     "@types/node": "^10.12.18",
+    "benchmark": "^2.1.4",
     "docs-ts": "0.0.1",
     "doctoc": "^1.4.0",
     "dtslint": "github:gcanti/dtslint",

--- a/perf/Do.ts
+++ b/perf/Do.ts
@@ -1,0 +1,38 @@
+import * as Benchmark from 'benchmark'
+import { Do } from '../src/Do'
+import { option, some } from 'fp-ts/lib/Option'
+
+const suite = new Benchmark.Suite()
+
+// const chain = option.chain
+
+// // tslint:disable-next-line: no-console
+// console.log(
+//   Do(option)
+//     .bind('a', some('a'))
+//     .bind('b', some('b'))
+//     .bind('c', some('c'))
+//     .bind('d', some('d'))
+//     .bind('e', some('e'))
+//     .done()
+// )
+
+suite
+  .add('Do', function() {
+    Do(option)
+      .bind('a', some('a'))
+      .bind('b', some('b'))
+      .bind('c', some('c'))
+      .bind('d', some('d'))
+      .bind('e', some('e'))
+      .done()
+  })
+  .on('cycle', function(event: any) {
+    // tslint:disable-next-line: no-console
+    console.log(String(event.target))
+  })
+  .on('complete', function(this: any) {
+    // tslint:disable-next-line: no-console
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({ async: true })

--- a/src/Do.ts
+++ b/src/Do.ts
@@ -73,6 +73,90 @@ export interface Do0<M, S extends object> {
   done: () => HKT<M, S>
 }
 
+type LinkedList<A> = { type: 'Nil'; length: number } | { type: 'Cons'; head: A; tail: LinkedList<A>; length: number }
+
+const nil: LinkedList<never> = { type: 'Nil', length: 0 }
+
+const cons = <A>(head: A, tail: LinkedList<A>): LinkedList<A> => ({
+  type: 'Cons',
+  head,
+  tail,
+  length: tail.length + 1
+})
+
+const toArray = <A>(list: LinkedList<A>): Array<A> => {
+  const len = list.length
+  const r: Array<A> = new Array(len)
+  let l: LinkedList<A> = list
+  let i = 1
+  while (l.type !== 'Nil') {
+    r[len - i] = l.head
+    i++
+    l = l.tail
+  }
+  return r
+}
+
+type Action<M> =
+  | { type: 'do'; action: HKT<M, unknown> }
+  | { type: 'doL'; f: (s: unknown) => HKT<M, unknown> }
+  | { type: 'bind'; name: string; action: HKT<M, unknown> }
+  | { type: 'bindL'; name: string; f: (s: unknown) => HKT<M, unknown> }
+
+class DoClass<M> {
+  constructor(readonly M: Monad<M>, private actions: LinkedList<Action<M>>) {}
+  do(action: HKT<M, unknown>): DoClass<M> {
+    return new DoClass(this.M, cons({ type: 'do', action }, this.actions))
+  }
+  doL(f: (s: unknown) => HKT<M, unknown>): DoClass<M> {
+    return new DoClass(this.M, cons({ type: 'doL', f }, this.actions))
+  }
+  bind(name: string, action: HKT<M, unknown>): DoClass<M> {
+    return new DoClass(this.M, cons({ type: 'bind', name, action }, this.actions))
+  }
+  bindL(name: string, f: (s: unknown) => HKT<M, unknown>): DoClass<M> {
+    return new DoClass(this.M, cons({ type: 'bindL', name, f }, this.actions))
+  }
+  return<B>(f: (s: unknown) => B): HKT<M, B> {
+    return this.M.map(this.done(), f)
+  }
+  done(): HKT<M, unknown> {
+    const actions = this.actions
+    const len = actions.length
+    const as = toArray(actions)
+    let result: HKT<M, any> = this.M.of({})
+    const M = this.M
+    for (let i = 0; i < len; i++) {
+      const a = as[i]
+      switch (a.type) {
+        case 'do':
+          result = M.chain(result, s => M.map(a.action, () => s))
+          break
+        case 'doL':
+          result = M.chain(result, s => M.map(a.f(s), () => s))
+          break
+        case 'bind':
+          result = M.chain(result, s =>
+            M.map(a.action, b => {
+              s[a.name] = b
+              return s
+            })
+          )
+          break
+        case 'bindL':
+          result = M.chain(result, s =>
+            M.map(a.f(s), b => {
+              s[a.name] = b
+              return s
+            })
+          )
+          break
+      }
+    }
+    return result
+  }
+}
+
 /**
  * This function provides a simuation of Haskell do notation. The `bind` / `bindL` functions contributes to a threaded
  * scope that is available to each subsequent step. The `do` / `doL` functions can be used to perform computations that
@@ -100,28 +184,5 @@ export function Do<M extends URIS2, L>(M: Monad2C<M, L>): Do2C<M, {}, L>
 export function Do<M extends URIS>(M: Monad1<M>): Do1<M, {}>
 export function Do<M>(M: Monad<M>): Do0<M, {}>
 export function Do<M>(M: Monad<M>): Do0<M, {}> {
-  function toDo<S extends object>(ms: HKT<M, S>): Do0<M, S> {
-    return {
-      do(mv: HKT<M, unknown>): Do0<M, S> {
-        return toDo(M.chain(ms, a => M.map(mv, () => a)))
-      },
-      doL(fmv: (s: S) => HKT<M, unknown>): Do0<M, S> {
-        return toDo(M.chain(ms, a => M.map(fmv(a), () => a)))
-      },
-      bind<N extends string, B>(name: Exclude<N, keyof S>, mb: HKT<M, B>): Do0<M, S & { [K in N]: B }> {
-        return toDo(M.chain(ms, a => M.map(mb, b => ({ ...(a as object), [name]: b })))) as any
-      },
-      bindL<N extends string, B>(name: Exclude<N, keyof S>, fmb: (s: S) => HKT<M, B>): Do0<M, S & { [K in N]: B }> {
-        return toDo(M.chain(ms, a => M.map(fmb(a), b => ({ ...(a as object), [name]: b })))) as any
-      },
-      return<B>(f: (s: S) => B): HKT<M, B> {
-        return M.map(ms, f)
-      },
-      done(): HKT<M, S> {
-        return ms
-      }
-    }
-  }
-
-  return toDo(M.of({}))
+  return new DoClass(M, nil) as any
 }


### PR DESCRIPTION
@pfgray this PR tries to improve `Do`'s performance by avoiding the creation of too many objects (the "scope").

**The gist**

There's a small DSL representing the operations, which are accumulated in a linked list.
When the user calls `return` (or `done`) an interpreter is responsible to turn the list into an action.

**Benchmark**

Based on my benchmark [here](https://github.com/gcanti/fp-ts-contrib/blob/c01b4b96719ce9fb28bae70eb41528295b6e86f3/perf/Do.ts) looks like we can go from 255,854 ops/sec to 1,918,688 ops/sec
