### PR TITLE
Add withTimeout for Task, TaskEither, TaskOption, and TaskValidation

### DIFF
--- a/docs/modules/Task/withTimeout.ts.md
+++ b/docs/modules/Task/withTimeout.ts.md
@@ -1,0 +1,37 @@
+---
+title: Task/withTimeout.ts
+nav_order: 17
+parent: Modules
+---
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [withTimeout (function)](#withtimeout-function)
+
+---
+
+# withTimeout (function)
+
+Returns the task result if it completes within a timeout, or a fallback value instead.
+
+**Signature**
+
+```ts
+export const withTimeout = <A>(t: Task<A>, onTimeout: A, millis: number): Task<A> => ...
+```
+
+**Example**
+
+```ts
+import { withTimeout } from 'fp-ts-contrib/lib/Task/withTimeout'
+import { delay } from 'fp-ts/lib/Task'
+
+const completeAfter2s = delay(2000, 'result')
+
+withTimeout(completeAfter2s, 'timeout', 3000).run() // Promise('result')
+withTimeout(completeAfter2s, 'timeout', 1000).run() // Promise('timeout')
+```
+
+Added in v0.0.6

--- a/docs/modules/TaskEither/withTimeout.ts.md
+++ b/docs/modules/TaskEither/withTimeout.ts.md
@@ -1,0 +1,40 @@
+---
+title: TaskEither/withTimeout.ts
+nav_order: 18
+parent: Modules
+---
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [withTimeout (function)](#withtimeout-function)
+
+---
+
+# withTimeout (function)
+
+Returns the `TaskEither` result if it completes within a timeout, or a fallback value instead.
+
+**Signature**
+
+```ts
+export const withTimeout = <A, L>(t: TaskEither<L, A>, onTimeout: Either<L, A>, millis: number): TaskEither<L, A> => ...
+```
+
+**Example**
+
+```ts
+import { withTimeout } from 'fp-ts-contrib/lib/TaskEither/withTimeout'
+import { TaskEither } from 'fp-ts/lib/TaskEither'
+import { delay } from 'fp-ts/lib/Task'
+import { right, left } from 'fp-ts/lib/Either'
+
+const completeAfter2s = new TaskEither(delay(2000, right('result')))
+
+withTimeout(completeAfter2s, left('timeout'), 3000).run() // Promise(right('result'))
+withTimeout(completeAfter2s, left('timeout'), 1000).run() // Promise(left('timeout'))
+withTimeout(completeAfter2s, right('timeout'), 1000).run() // Promise(right('timeout'))
+```
+
+Added in v0.0.6

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskOption.ts
-nav_order: 17
+nav_order: 19
 parent: Modules
 ---
 
@@ -17,6 +17,7 @@ parent: Modules
   - [chain (method)](#chain-method)
   - [fold (method)](#fold-method)
   - [getOrElse (method)](#getorelse-method)
+  - [withTimeout (method)](#withtimeout-method)
 - [URI (constant)](#uri-constant)
 - [none (constant)](#none-constant)
 - [some (constant)](#some-constant)
@@ -100,6 +101,30 @@ fold<R>(onNone: R, onSome: (a: A) => R): Task<R> { ... }
 
 ```ts
 getOrElse(a: A): Task<A> { ... }
+```
+
+## withTimeout (method)
+
+Returns the `TaskOption` result if it completes within a timeout, or a fallback value instead.
+
+**Signature**
+
+```ts
+withTimeout(onTimeout: Option<A>, millis: number) { ... }
+```
+
+**Example**
+
+```ts
+import { TaskOption } from 'fp-ts-contrib/lib/TaskOption'
+import { delay } from 'fp-ts/lib/Task'
+import { some, none } from 'fp-ts/lib/Option'
+
+const completeAfter2s = new TaskOption(delay(2000, some('result')))
+
+completeAfter2s.withTimeout(some('timeout'), 3000).run() // Promise(some('result'))
+completeAfter2s.withTimeout(none, 1000).run() // Promise(none)
+completeAfter2s.withTimeout(some('timeout'), 1000).run() // Promise(some('timeout'))
 ```
 
 # URI (constant)

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -17,7 +17,6 @@ parent: Modules
   - [chain (method)](#chain-method)
   - [fold (method)](#fold-method)
   - [getOrElse (method)](#getorelse-method)
-  - [withTimeout (method)](#withtimeout-method)
 - [URI (constant)](#uri-constant)
 - [none (constant)](#none-constant)
 - [some (constant)](#some-constant)
@@ -25,6 +24,7 @@ parent: Modules
 - [fromOption (function)](#fromoption-function)
 - [fromTask (function)](#fromtask-function)
 - [tryCatch (function)](#trycatch-function)
+- [withTimeout (function)](#withtimeout-function)
 
 ---
 
@@ -103,30 +103,6 @@ fold<R>(onNone: R, onSome: (a: A) => R): Task<R> { ... }
 getOrElse(a: A): Task<A> { ... }
 ```
 
-## withTimeout (method)
-
-Returns the `TaskOption` result if it completes within a timeout, or a fallback value instead.
-
-**Signature**
-
-```ts
-withTimeout(onTimeout: Option<A>, millis: number) { ... }
-```
-
-**Example**
-
-```ts
-import { TaskOption } from 'fp-ts-contrib/lib/TaskOption'
-import { delay } from 'fp-ts/lib/Task'
-import { some, none } from 'fp-ts/lib/Option'
-
-const completeAfter2s = new TaskOption(delay(2000, some('result')))
-
-completeAfter2s.withTimeout(some('timeout'), 3000).run() // Promise(some('result'))
-completeAfter2s.withTimeout(none, 1000).run() // Promise(none)
-completeAfter2s.withTimeout(some('timeout'), 1000).run() // Promise(some('timeout'))
-```
-
 # URI (constant)
 
 **Signature**
@@ -182,4 +158,28 @@ export const fromTask = <A>(ma: Task<A>): TaskOption<A> => ...
 ```ts
 export const tryCatch = <A>(f: Lazy<Promise<A>>): TaskOption<A> =>
   new TaskOption(tryCatchTask(f, () => ...
+```
+
+# withTimeout (function)
+
+Returns the `TaskOption` result if it completes within a timeout, or a fallback value instead.
+
+**Signature**
+
+```ts
+export const withTimeout = <A>(fa: TaskOption<A>, onTimeout: Option<A>, millis: number): TaskOption<A> => ...
+```
+
+**Example**
+
+```ts
+import { TaskOption, withTimeout } from 'fp-ts-contrib/lib/TaskOption'
+import { delay } from 'fp-ts/lib/Task'
+import { some, none } from 'fp-ts/lib/Option'
+
+const completeAfter2s = new TaskOption(delay(2000, some('result')))
+
+withTimeout(completeAfter2s, some('timeout'), 3000).run() // Promise(some('result'))
+withTimeout(completeAfter2s, none, 1000).run() // Promise(none)
+withTimeout(completeAfter2s, some('timeout'), 1000).run() // Promise(some('timeout'))
 ```

--- a/docs/modules/TaskValidation.ts.md
+++ b/docs/modules/TaskValidation.ts.md
@@ -12,10 +12,10 @@ parent: Modules
 - [TaskValidation (class)](#taskvalidation-class)
   - [map (method)](#map-method)
   - [fold (method)](#fold-method)
-  - [withTimeout (method)](#withtimeout-method)
 - [URI (constant)](#uri-constant)
 - [taskValidation (constant)](#taskvalidation-constant)
 - [getApplicative (function)](#getapplicative-function)
+- [withTimeout (function)](#withtimeout-function)
 
 ---
 
@@ -54,30 +54,6 @@ map<B>(f: (a: A) => B): TaskValidation<L, B> { ... }
 fold<R>(failure: (l: L) => R, success: (a: A) => R): task.Task<R> { ... }
 ```
 
-## withTimeout (method)
-
-Returns the `TaskValidation` result if it completes within a timeout, or a fallback value instead.
-
-**Signature**
-
-```ts
-withTimeout(onTimeout: validation.Validation<L, A>, millis: number) { ... }
-```
-
-**Example**
-
-```ts
-import { TaskValidation } from 'fp-ts-contrib/lib/TaskValidation'
-import { delay } from 'fp-ts/lib/Task'
-import { success, failure } from 'fp-ts/lib/Validation'
-
-const completeAfter2s = new TaskValidation(delay(2000, success('result')))
-
-completeAfter2s.withTimeout(failure('timeout'), 3000).value.run() // Promise(success('result'))
-completeAfter2s.withTimeout(failure('timeout'), 1000).value.run() // Promise(failure('timeout'))
-completeAfter2s.withTimeout(success('timeout'), 1000).value.run() // Promise(success('timeout'))
-```
-
 # URI (constant)
 
 **Signature**
@@ -100,4 +76,32 @@ export const taskValidation: Functor2<URI> = ...
 
 ```ts
 export const getApplicative = <L>(S: Semigroup<L>): Applicative2C<URI, L> => ...
+```
+
+# withTimeout (function)
+
+Returns the `TaskValidation` result if it completes within a timeout, or a fallback value instead.
+
+**Signature**
+
+```ts
+export const withTimeout = <L, A>(
+  fa: TaskValidation<L, A>,
+  onTimeout: validation.Validation<L, A>,
+  millis: number
+): TaskValidation<L, A> => ...
+```
+
+**Example**
+
+```ts
+import { TaskValidation, withTimeout } from 'fp-ts-contrib/lib/TaskValidation'
+import { delay } from 'fp-ts/lib/Task'
+import { success, failure } from 'fp-ts/lib/Validation'
+
+const completeAfter2s = new TaskValidation(delay(2000, success('result')))
+
+withTimeout(completeAfter2s, failure('timeout'), 3000).value.run() // Promise(success('result'))
+withTimeout(completeAfter2s, failure('timeout'), 1000).value.run() // Promise(failure('timeout'))
+withTimeout(completeAfter2s, success('timeout'), 1000).value.run() // Promise(success('timeout'))
 ```

--- a/docs/modules/TaskValidation.ts.md
+++ b/docs/modules/TaskValidation.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskValidation.ts
-nav_order: 18
+nav_order: 20
 parent: Modules
 ---
 
@@ -12,6 +12,7 @@ parent: Modules
 - [TaskValidation (class)](#taskvalidation-class)
   - [map (method)](#map-method)
   - [fold (method)](#fold-method)
+  - [withTimeout (method)](#withtimeout-method)
 - [URI (constant)](#uri-constant)
 - [taskValidation (constant)](#taskvalidation-constant)
 - [getApplicative (function)](#getapplicative-function)
@@ -51,6 +52,30 @@ map<B>(f: (a: A) => B): TaskValidation<L, B> { ... }
 
 ```ts
 fold<R>(failure: (l: L) => R, success: (a: A) => R): task.Task<R> { ... }
+```
+
+## withTimeout (method)
+
+Returns the `TaskValidation` result if it completes within a timeout, or a fallback value instead.
+
+**Signature**
+
+```ts
+withTimeout(onTimeout: validation.Validation<L, A>, millis: number) { ... }
+```
+
+**Example**
+
+```ts
+import { TaskValidation } from 'fp-ts-contrib/lib/TaskValidation'
+import { delay } from 'fp-ts/lib/Task'
+import { success, failure } from 'fp-ts/lib/Validation'
+
+const completeAfter2s = new TaskValidation(delay(2000, success('result')))
+
+completeAfter2s.withTimeout(failure('timeout'), 3000).value.run() // Promise(success('result'))
+completeAfter2s.withTimeout(failure('timeout'), 1000).value.run() // Promise(failure('timeout'))
+completeAfter2s.withTimeout(success('timeout'), 1000).value.run() // Promise(success('timeout'))
 ```
 
 # URI (constant)

--- a/docs/modules/TheseOption.ts.md
+++ b/docs/modules/TheseOption.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TheseOption.ts
-nav_order: 19
+nav_order: 21
 parent: Modules
 ---
 

--- a/docs/modules/time.ts.md
+++ b/docs/modules/time.ts.md
@@ -1,6 +1,6 @@
 ---
 title: time.ts
-nav_order: 20
+nav_order: 22
 parent: Modules
 ---
 

--- a/src/Task/withTimeout.ts
+++ b/src/Task/withTimeout.ts
@@ -1,0 +1,20 @@
+import { getRaceMonoid, Task, delay } from 'fp-ts/lib/Task'
+
+/**
+ * Returns the task result if it completes within a timeout, or a fallback value instead.
+ *
+ * @example
+ * import { withTimeout } from 'fp-ts-contrib/lib/Task/withTimeout'
+ * import { delay } from 'fp-ts/lib/Task'
+ *
+ * const completeAfter2s = delay(2000, 'result')
+ *
+ * withTimeout(completeAfter2s, 'timeout', 3000).run() // Promise('result')
+ * withTimeout(completeAfter2s, 'timeout', 1000).run() // Promise('timeout')
+ *
+ * @since 0.0.6
+ */
+export const withTimeout = <A>(t: Task<A>, onTimeout: A, millis: number): Task<A> => {
+  const timeoutTask = delay(millis, onTimeout)
+  return getRaceMonoid<A>().concat(t, timeoutTask)
+}

--- a/src/TaskEither/withTimeout.ts
+++ b/src/TaskEither/withTimeout.ts
@@ -1,0 +1,24 @@
+import { TaskEither } from 'fp-ts/lib/TaskEither'
+import { Either } from 'fp-ts/lib/Either'
+import { withTimeout as withTimeoutTask } from '../Task/withTimeout'
+
+/**
+ * Returns the `TaskEither` result if it completes within a timeout, or a fallback value instead.
+ *
+ * @example
+ * import { withTimeout } from 'fp-ts-contrib/lib/TaskEither/withTimeout'
+ * import { TaskEither } from 'fp-ts/lib/TaskEither'
+ * import { delay } from 'fp-ts/lib/Task'
+ * import { right, left } from 'fp-ts/lib/Either'
+ *
+ * const completeAfter2s = new TaskEither(delay(2000, right('result')))
+ *
+ * withTimeout(completeAfter2s, left('timeout'), 3000).run() // Promise(right('result'))
+ * withTimeout(completeAfter2s, left('timeout'), 1000).run() // Promise(left('timeout'))
+ * withTimeout(completeAfter2s, right('timeout'), 1000).run() // Promise(right('timeout'))
+ *
+ * @since 0.0.6
+ */
+export const withTimeout = <A, L>(t: TaskEither<L, A>, onTimeout: Either<L, A>, millis: number): TaskEither<L, A> => {
+  return new TaskEither(withTimeoutTask(t.value, onTimeout, millis))
+}

--- a/src/TaskOption.ts
+++ b/src/TaskOption.ts
@@ -3,6 +3,7 @@ import { Option, fromEither, none as optionNone, some as optionSome } from 'fp-t
 import * as optionT from 'fp-ts/lib/OptionT'
 import { Task, task, tryCatch as tryCatchTask } from 'fp-ts/lib/Task'
 import { Lazy, identity } from 'fp-ts/lib/function'
+import { withTimeout } from './Task/withTimeout'
 
 declare module 'fp-ts/lib/HKT' {
   interface URI2HKT<A> {
@@ -41,6 +42,23 @@ export class TaskOption<A> {
   }
   getOrElse(a: A): Task<A> {
     return this.fold(a, identity)
+  }
+  /**
+   *  Returns the `TaskOption` result if it completes within a timeout, or a fallback value instead.
+   *
+   * @example
+   * import { TaskOption  } from 'fp-ts-contrib/lib/TaskOption'
+   * import { delay } from 'fp-ts/lib/Task'
+   * import { some, none } from 'fp-ts/lib/Option'
+   *
+   * const completeAfter2s = new TaskOption(delay(2000, some('result')))
+   *
+   * completeAfter2s.withTimeout(some('timeout'), 3000).run() // Promise(some('result'))
+   * completeAfter2s.withTimeout(none, 1000).run()            // Promise(none)
+   * completeAfter2s.withTimeout(some('timeout'), 1000).run() // Promise(some('timeout'))
+   */
+  withTimeout(onTimeout: Option<A>, millis: number) {
+    return new TaskOption(withTimeout(this.value, onTimeout, millis))
   }
 }
 

--- a/src/TaskValidation.ts
+++ b/src/TaskValidation.ts
@@ -4,7 +4,7 @@ import { Semigroup } from 'fp-ts/lib/Semigroup'
 import * as task from 'fp-ts/lib/Task'
 import * as validation from 'fp-ts/lib/Validation'
 import { phantom } from 'fp-ts/lib/function'
-import { withTimeout } from './Task/withTimeout'
+import { withTimeout as withTimeoutTask } from './Task/withTimeout'
 
 declare module 'fp-ts/lib/HKT' {
   interface URI2HKT2<L, A> {
@@ -29,27 +29,32 @@ export class TaskValidation<L, A> {
   fold<R>(failure: (l: L) => R, success: (a: A) => R): task.Task<R> {
     return this.value.map(v => v.fold(failure, success))
   }
-  /**
-   *  Returns the `TaskValidation` result if it completes within a timeout, or a fallback value instead.
-   *
-   * @example
-   * import { TaskValidation  } from 'fp-ts-contrib/lib/TaskValidation'
-   * import { delay } from 'fp-ts/lib/Task'
-   * import { success, failure } from 'fp-ts/lib/Validation'
-   *
-   * const completeAfter2s = new TaskValidation(delay(2000, success('result')))
-   *
-   * completeAfter2s.withTimeout(failure('timeout'), 3000).value.run() // Promise(success('result'))
-   * completeAfter2s.withTimeout(failure('timeout'), 1000).value.run() // Promise(failure('timeout'))
-   * completeAfter2s.withTimeout(success('timeout'), 1000).value.run() // Promise(success('timeout'))
-   */
-  withTimeout(onTimeout: validation.Validation<L, A>, millis: number) {
-    return new TaskValidation(withTimeout(this.value, onTimeout, millis))
-  }
 }
 
 const map = <L, A, B>(fa: TaskValidation<L, A>, f: (a: A) => B): TaskValidation<L, B> => {
   return fa.map(f)
+}
+
+/**
+ *  Returns the `TaskValidation` result if it completes within a timeout, or a fallback value instead.
+ *
+ * @example
+ * import { TaskValidation, withTimeout } from 'fp-ts-contrib/lib/TaskValidation'
+ * import { delay } from 'fp-ts/lib/Task'
+ * import { success, failure } from 'fp-ts/lib/Validation'
+ *
+ * const completeAfter2s = new TaskValidation(delay(2000, success('result')))
+ *
+ * withTimeout(completeAfter2s, failure('timeout'), 3000).value.run() // Promise(success('result'))
+ * withTimeout(completeAfter2s, failure('timeout'), 1000).value.run() // Promise(failure('timeout'))
+ * withTimeout(completeAfter2s, success('timeout'), 1000).value.run() // Promise(success('timeout'))
+ */
+export const withTimeout = <L, A>(
+  fa: TaskValidation<L, A>,
+  onTimeout: validation.Validation<L, A>,
+  millis: number
+): TaskValidation<L, A> => {
+  return new TaskValidation(withTimeoutTask(fa.value, onTimeout, millis))
 }
 
 export const getApplicative = <L>(S: Semigroup<L>): Applicative2C<URI, L> => {

--- a/test/Task.ts
+++ b/test/Task.ts
@@ -1,0 +1,16 @@
+import { withTimeout } from '../src/Task/withTimeout'
+import { delay } from 'fp-ts/lib/Task'
+
+describe('Task', () => {
+  describe('withTimeout', () => {
+    it('should return successfully withing the timeout', () => {
+      const t = withTimeout(delay(100, 'value'), 'fallback', 500)
+      return t.run().then(v => expect(v).toEqual('value'))
+    })
+
+    it('should return the fallback value on timeout', () => {
+      const t = withTimeout(delay(500, 'value'), 'fallback', 100)
+      return t.run().then(v => expect(v).toEqual('fallback'))
+    })
+  })
+})

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -1,0 +1,18 @@
+import { withTimeout } from '../src/TaskEither/withTimeout'
+import { delay } from 'fp-ts/lib/Task'
+import { TaskEither } from 'fp-ts/lib/TaskEither'
+import { right, left } from 'fp-ts/lib/Either'
+
+describe('TaskEither', () => {
+  describe('withTimeout', () => {
+    it('should return successfully within the timeout', () => {
+      const t = withTimeout(new TaskEither(delay(100, right('value'))), right('fallback'), 500)
+      return t.run().then(v => expect(v).toEqual(right('value')))
+    })
+
+    it('should return the fallback value on timeout', () => {
+      const t = withTimeout(new TaskEither(delay(500, right('value'))), left(new Error('timeout')), 100)
+      return t.run().then(v => expect(v).toEqual(left(new Error('timeout'))))
+    })
+  })
+})

--- a/test/TaskOption.ts
+++ b/test/TaskOption.ts
@@ -1,4 +1,12 @@
-import { TaskOption, taskOption, none as taskOptionNone, fromOption, fromTask, tryCatch } from '../src/TaskOption'
+import {
+  TaskOption,
+  taskOption,
+  none as taskOptionNone,
+  fromOption,
+  fromTask,
+  tryCatch,
+  withTimeout
+} from '../src/TaskOption'
 import { delay, Task } from 'fp-ts/lib/Task'
 import { some, none } from 'fp-ts/lib/Option'
 
@@ -67,12 +75,12 @@ describe('TaskOption', () => {
 
   describe('withTimeout', () => {
     it('should return successfully within the timeout', () => {
-      const t = new TaskOption(delay(100, some('value'))).withTimeout(some('fallback'), 500)
+      const t = withTimeout(new TaskOption(delay(100, some('value'))), some('fallback'), 500)
       return t.run().then(v => expect(v).toEqual(some('value')))
     })
 
     it('should return the fallback value on timeout', () => {
-      const t = new TaskOption(delay(500, some('value'))).withTimeout(some('fallback'), 100)
+      const t = withTimeout(new TaskOption(delay(500, some('value'))), some('fallback'), 100)
       return t.run().then(v => expect(v).toEqual(some('fallback')))
     })
   })

--- a/test/TaskOption.ts
+++ b/test/TaskOption.ts
@@ -1,0 +1,17 @@
+import { TaskOption } from '../src/TaskOption'
+import { delay } from 'fp-ts/lib/Task'
+import { some } from 'fp-ts/lib/Option'
+
+describe('TaskOption', () => {
+  describe('withTimeout', () => {
+    it('should return successfully within the timeout', () => {
+      const t = new TaskOption(delay(100, some('value'))).withTimeout(some('fallback'), 500)
+      return t.run().then(v => expect(v).toEqual(some('value')))
+    })
+
+    it('should return the fallback value on timeout', () => {
+      const t = new TaskOption(delay(500, some('value'))).withTimeout(some('fallback'), 100)
+      return t.run().then(v => expect(v).toEqual(some('fallback')))
+    })
+  })
+})

--- a/test/TaskOption.ts
+++ b/test/TaskOption.ts
@@ -1,8 +1,70 @@
-import { TaskOption } from '../src/TaskOption'
-import { delay } from 'fp-ts/lib/Task'
-import { some } from 'fp-ts/lib/Option'
+import { TaskOption, taskOption, none as taskOptionNone, fromOption, fromTask, tryCatch } from '../src/TaskOption'
+import { delay, Task } from 'fp-ts/lib/Task'
+import { some, none } from 'fp-ts/lib/Option'
 
 describe('TaskOption', () => {
+  it('map', () => {
+    const double = (n: number): number => n * 2
+    return taskOption
+      .map(taskOption.of(1), double)
+      .run()
+      .then(e => expect(e).toEqual(some(2)))
+  })
+
+  it('ap', () => {
+    const double = (n: number): number => n * 2
+    const fab = taskOption.of(double)
+    const fa = taskOption.of(1)
+    return Promise.all([fa.ap(fab).run(), fab.ap_(fa).run(), taskOption.ap(fab, fa).run()]).then(([e1, e2, e3]) => {
+      expect(e1).toEqual(some(2))
+      expect(e1).toEqual(e2)
+      expect(e1).toEqual(e3)
+    })
+  })
+
+  it('chain', () => {
+    const te1 = taskOption.chain(taskOption.of('foo'), a => (a.length > 2 ? taskOption.of(a.length) : taskOptionNone))
+    const te2 = taskOption.chain(taskOption.of<string>('a'), a =>
+      a.length > 2 ? taskOption.of(a.length) : taskOptionNone
+    )
+    return Promise.all([te1.run(), te2.run()]).then(([e1, e2]) => {
+      expect(e1).toEqual(some(3))
+      expect(e2).toEqual(none)
+    })
+  })
+
+  it('fold', () => {
+    const g = (n: number): boolean => n > 2
+    const te1 = taskOption.of<number>(1).fold(false, g)
+    const te2 = taskOptionNone.fold(true, g)
+    return Promise.all([te1.run(), te2.run()]).then(([b1, b2]) => {
+      expect(b1).toEqual(false)
+      expect(b2).toEqual(true)
+    })
+  })
+
+  it('getOrElse', () => {
+    const v: number = 42
+    const te1 = taskOption.of<number>(1).getOrElse(v)
+    const te2 = fromOption<number>(none).getOrElse(v)
+    return Promise.all([te1.run(), te2.run()]).then(([b1, b2]) => {
+      expect(b1).toEqual(1)
+      expect(b2).toEqual(42)
+    })
+  })
+
+  it('fromTask', () => {
+    const to1 = fromTask(new Task(() => Promise.resolve(none)))
+    return Promise.all([to1.run, taskOptionNone.run]).then(([b1, b2]) => {
+      expect(b1).toEqual(b2)
+    })
+  })
+
+  it('tryCatch', () => {
+    const to1 = tryCatch(() => Promise.reject())
+    return to1.run().then(b1 => expect(b1).toEqual(none))
+  })
+
   describe('withTimeout', () => {
     it('should return successfully within the timeout', () => {
       const t = new TaskOption(delay(100, some('value'))).withTimeout(some('fallback'), 500)

--- a/test/TaskValidation.ts
+++ b/test/TaskValidation.ts
@@ -1,4 +1,4 @@
-import { TaskValidation, taskValidation, getApplicative } from '../src/TaskValidation'
+import { TaskValidation, taskValidation, getApplicative, withTimeout } from '../src/TaskValidation'
 import { delay, Task } from 'fp-ts/lib/Task'
 import { success, failure } from 'fp-ts/lib/Validation'
 import { getSemigroup, NonEmptyArray, make } from 'fp-ts/lib/NonEmptyArray2v'
@@ -29,12 +29,12 @@ describe('TaskValidation', () => {
 
   describe('withTimeout', () => {
     it('should return successfully within the timeout', () => {
-      const t = new TaskValidation(delay(100, success('value'))).withTimeout(failure('fallback'), 500)
+      const t = withTimeout(new TaskValidation(delay(100, success('value'))), failure('fallback'), 500)
       return t.value.run().then(v => expect(v).toEqual(success('value')))
     })
 
     it('should return the fallback value on timeout', () => {
-      const t = new TaskValidation(delay(500, success('value'))).withTimeout(failure('fallback'), 100)
+      const t = withTimeout(new TaskValidation(delay(500, success('value'))), failure('fallback'), 100)
       return t.value.run().then(v => expect(v).toEqual(failure('fallback')))
     })
   })

--- a/test/TaskValidation.ts
+++ b/test/TaskValidation.ts
@@ -1,8 +1,32 @@
-import { TaskValidation } from '../src/TaskValidation'
-import { delay } from 'fp-ts/lib/Task'
+import { TaskValidation, taskValidation, getApplicative } from '../src/TaskValidation'
+import { delay, Task } from 'fp-ts/lib/Task'
 import { success, failure } from 'fp-ts/lib/Validation'
+import { getSemigroup, NonEmptyArray, make } from 'fp-ts/lib/NonEmptyArray2v'
 
 describe('TaskValidation', () => {
+  const taskValidationNelApplicative = getApplicative(getSemigroup<string>())
+
+  it('map', () => {
+    const double = (n: number): number => n * 2
+    return taskValidation
+      .map(taskValidationNelApplicative.of(1), double)
+      .value.run()
+      .then(e => expect(e).toEqual(success(2)))
+  })
+
+  it('fold', () => {
+    const f = (s: NonEmptyArray<string>): boolean => s.length < 2
+    const g = (n: number): boolean => n > 2
+    const te1 = taskValidationNelApplicative.of<number>(1).fold(f, g)
+    const te2 = new TaskValidation<NonEmptyArray<string>, number>(
+      new Task(() => Promise.resolve(failure(make<string>('failure', []))))
+    ).fold(f, g)
+    return Promise.all([te1.run(), te2.run()]).then(([b1, b2]) => {
+      expect(b1).toEqual(false)
+      expect(b2).toEqual(true)
+    })
+  })
+
   describe('withTimeout', () => {
     it('should return successfully within the timeout', () => {
       const t = new TaskValidation(delay(100, success('value'))).withTimeout(failure('fallback'), 500)
@@ -12,6 +36,20 @@ describe('TaskValidation', () => {
     it('should return the fallback value on timeout', () => {
       const t = new TaskValidation(delay(500, success('value'))).withTimeout(failure('fallback'), 100)
       return t.value.run().then(v => expect(v).toEqual(failure('fallback')))
+    })
+  })
+
+  describe('getApplicative', () => {
+    it('ap', () => {
+      const double = (n: number): number => n * 2
+      const fa = taskValidationNelApplicative.of(1)
+      const fab = taskValidationNelApplicative.of(double)
+      return taskValidationNelApplicative
+        .ap(fab, fa)
+        .value.run()
+        .then(e1 => {
+          expect(e1).toEqual(success(2))
+        })
     })
   })
 })

--- a/test/TaskValidation.ts
+++ b/test/TaskValidation.ts
@@ -1,0 +1,17 @@
+import { TaskValidation } from '../src/TaskValidation'
+import { delay } from 'fp-ts/lib/Task'
+import { success, failure } from 'fp-ts/lib/Validation'
+
+describe('TaskValidation', () => {
+  describe('withTimeout', () => {
+    it('should return successfully within the timeout', () => {
+      const t = new TaskValidation(delay(100, success('value'))).withTimeout(failure('fallback'), 500)
+      return t.value.run().then(v => expect(v).toEqual(success('value')))
+    })
+
+    it('should return the fallback value on timeout', () => {
+      const t = new TaskValidation(delay(500, success('value'))).withTimeout(failure('fallback'), 100)
+      return t.value.run().then(v => expect(v).toEqual(failure('fallback')))
+    })
+  })
+})


### PR DESCRIPTION
Add the `withTimeout` combinator for both `Task` and `TaskEither`.

Examples:

```ts
import { withTimeout } from 'fp-ts-contrib/lib/Task'
import { delay } from 'fp-ts/lib/Task'

withTimeout(delay(100, 'value'), 'fallback', 500)) // will yield 'value' when run
withTimeout(delay(500, 'value'), 'fallback', 100)) // will yield 'fallback' when run
```

```ts
import { withTimeout } from 'fp-ts-contrib/lib/TaskEither'
import { delay } from 'fp-ts/lib/Task'
import { right } from 'fp-ts/lib/Either'

withTimeout(new TaskEither(delay(100, right('value'))), 'fallback', 500) // will yield right('value') when run
withTimeout(new TaskEither(delay(500, right('value'))), 'fallback', 100) // will yield left('fallback') when run
```