### PR TITLE
Add Free monad

### DIFF
--- a/docs/modules/Free.ts.md
+++ b/docs/modules/Free.ts.md
@@ -34,7 +34,7 @@ export interface FoldFree2<M extends URIS2> {
 }
 ```
 
-Added in v0.1.2
+Added in v0.1.3
 
 # FoldFree2C (interface)
 
@@ -47,7 +47,7 @@ export interface FoldFree2C<M extends URIS2, L> {
 }
 ```
 
-Added in v0.1.2
+Added in v0.1.3
 
 # FoldFree3 (interface)
 
@@ -61,7 +61,7 @@ export interface FoldFree3<M extends URIS3> {
 }
 ```
 
-Added in v0.1.2
+Added in v0.1.3
 
 # Free (type alias)
 
@@ -71,7 +71,7 @@ Added in v0.1.2
 export type Free<F, A> = Pure<F, A> | Impure<F, A, any>
 ```
 
-Added in v0.1.2
+Added in v0.1.3
 
 # URI (type alias)
 
@@ -81,7 +81,7 @@ Added in v0.1.2
 export type URI = typeof URI
 ```
 
-Added in v0.1.2
+Added in v0.1.3
 
 # URI (constant)
 
@@ -91,9 +91,11 @@ Added in v0.1.2
 export const URI = ...
 ```
 
-Added in v0.1.2
+Added in v0.1.3
 
 # free (constant)
+
+Monad instance for Free
 
 **Signature**
 
@@ -101,9 +103,11 @@ Added in v0.1.2
 export const free: Monad2<URI> = ...
 ```
 
-Added in v0.1.2
+Added in v0.1.3
 
 # foldFree (function)
+
+Perform folding of a free monad using given natural transformation as an interpreter
 
 **Signature**
 
@@ -117,7 +121,7 @@ export function foldFree<M extends URIS>(
 export function foldFree<M>(M: Monad<M>): <F, A>(nt: <X>(fa: HKT<F, X>) => HKT<M, X>, fa: Free<F, A>) => HKT<M, A> { ... }
 ```
 
-Added in v0.1.2
+Added in v0.1.3
 
 # hoistFree (function)
 
@@ -138,9 +142,11 @@ export function hoistFree<F extends URIS = never, G extends URIS = never>(
 export function hoistFree<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(fa: Free<F, A>) => Free<G, A> { ... }
 ```
 
-Added in v0.1.2
+Added in v0.1.3
 
 # isImpure (function)
+
+Check if given Free instance is Impure
 
 **Signature**
 
@@ -148,9 +154,11 @@ Added in v0.1.2
 export const isImpure = <F, A>(fa: Free<F, A>): fa is Impure<F, A, any> => ...
 ```
 
-Added in v0.1.2
+Added in v0.1.3
 
 # isPure (function)
+
+Check if given Free instance is Pure
 
 **Signature**
 
@@ -158,7 +166,7 @@ Added in v0.1.2
 export const isPure = <F, A>(fa: Free<F, A>): fa is Pure<F, A> => ...
 ```
 
-Added in v0.1.2
+Added in v0.1.3
 
 # liftF (function)
 
@@ -170,4 +178,4 @@ Lift an impure value described by the generating type constructor `F` into the f
 export const liftF = <F, A>(fa: HKT<F, A>): Free<F, A> => impure(fa, a => ...
 ```
 
-Added in v0.1.2
+Added in v0.1.3

--- a/docs/modules/Free.ts.md
+++ b/docs/modules/Free.ts.md
@@ -1,0 +1,173 @@
+---
+title: Free.ts
+nav_order: 8
+parent: Modules
+---
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [FoldFree2 (interface)](#foldfree2-interface)
+- [FoldFree2C (interface)](#foldfree2c-interface)
+- [FoldFree3 (interface)](#foldfree3-interface)
+- [Free (type alias)](#free-type-alias)
+- [URI (type alias)](#uri-type-alias)
+- [URI (constant)](#uri-constant)
+- [free (constant)](#free-constant)
+- [foldFree (function)](#foldfree-function)
+- [hoistFree (function)](#hoistfree-function)
+- [isImpure (function)](#isimpure-function)
+- [isPure (function)](#ispure-function)
+- [liftF (function)](#liftf-function)
+
+---
+
+# FoldFree2 (interface)
+
+**Signature**
+
+```ts
+export interface FoldFree2<M extends URIS2> {
+  <F extends URIS2, L, A>(nt: <X>(fa: Kind2<F, L, X>) => Kind2<M, L, X>, fa: Free<F, A>): Kind2<M, L, A>
+  <F extends URIS, L, A>(nt: <X>(fa: Kind<F, X>) => Kind2<M, L, X>, fa: Free<F, A>): Kind2<M, L, A>
+}
+```
+
+Added in v0.1.2
+
+# FoldFree2C (interface)
+
+**Signature**
+
+```ts
+export interface FoldFree2C<M extends URIS2, L> {
+  <F extends URIS2, A>(nt: <X>(fa: Kind2<F, L, X>) => Kind2<M, L, X>, fa: Free<F, A>): Kind2<M, L, A>
+  <F extends URIS, A>(nt: <X>(fa: Kind<F, X>) => Kind2<M, L, X>, fa: Free<F, A>): Kind2<M, L, A>
+}
+```
+
+Added in v0.1.2
+
+# FoldFree3 (interface)
+
+**Signature**
+
+```ts
+export interface FoldFree3<M extends URIS3> {
+  <F extends URIS3, U, L, A>(nt: <X>(fa: Kind3<F, U, L, X>) => Kind3<M, U, L, X>, fa: Free<F, A>): Kind3<M, U, L, A>
+  <F extends URIS2, U, L, A>(nt: <X>(fa: Kind2<F, L, X>) => Kind3<M, U, L, X>, fa: Free<F, A>): Kind3<M, U, L, A>
+  <F extends URIS, U, L, A>(nt: <X>(fa: Kind<F, X>) => Kind3<M, U, L, X>, fa: Free<F, A>): Kind3<M, U, L, A>
+}
+```
+
+Added in v0.1.2
+
+# Free (type alias)
+
+**Signature**
+
+```ts
+export type Free<F, A> = Pure<F, A> | Impure<F, A, any>
+```
+
+Added in v0.1.2
+
+# URI (type alias)
+
+**Signature**
+
+```ts
+export type URI = typeof URI
+```
+
+Added in v0.1.2
+
+# URI (constant)
+
+**Signature**
+
+```ts
+export const URI = ...
+```
+
+Added in v0.1.2
+
+# free (constant)
+
+**Signature**
+
+```ts
+export const free: Monad2<URI> = ...
+```
+
+Added in v0.1.2
+
+# foldFree (function)
+
+**Signature**
+
+```ts
+export function foldFree<M extends URIS3>(M: Monad3<M>): FoldFree3<M>
+export function foldFree<M extends URIS2>(M: Monad2<M>): FoldFree2<M>
+export function foldFree<M extends URIS2, L>(M: Monad2C<M, L>): FoldFree2C<M, L>
+export function foldFree<M extends URIS>(
+  M: Monad1<M>
+): <F extends URIS, A>(nt: <X>(fa: Kind<F, X>) => Kind<M, X>, fa: Free<F, A>) => Kind<M, A>
+export function foldFree<M>(M: Monad<M>): <F, A>(nt: <X>(fa: HKT<F, X>) => HKT<M, X>, fa: Free<F, A>) => HKT<M, A> { ... }
+```
+
+Added in v0.1.2
+
+# hoistFree (function)
+
+Use a natural transformation to change the generating type constructor of a free monad
+
+**Signature**
+
+```ts
+export function hoistFree<F extends URIS3 = never, G extends URIS3 = never>(
+  nt: <U, L, A>(fa: Kind3<F, U, L, A>) => Kind3<G, U, L, A>
+): <A>(fa: Free<F, A>) => Free<G, A>
+export function hoistFree<F extends URIS2 = never, G extends URIS2 = never>(
+  nt: <L, A>(fa: Kind2<F, L, A>) => Kind2<G, L, A>
+): <A>(fa: Free<F, A>) => Free<G, A>
+export function hoistFree<F extends URIS = never, G extends URIS = never>(
+  nt: <A>(fa: Kind<F, A>) => Kind<G, A>
+): <A>(fa: Free<F, A>) => Free<G, A>
+export function hoistFree<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(fa: Free<F, A>) => Free<G, A> { ... }
+```
+
+Added in v0.1.2
+
+# isImpure (function)
+
+**Signature**
+
+```ts
+export const isImpure = <F, A>(fa: Free<F, A>): fa is Impure<F, A, any> => ...
+```
+
+Added in v0.1.2
+
+# isPure (function)
+
+**Signature**
+
+```ts
+export const isPure = <F, A>(fa: Free<F, A>): fa is Pure<F, A> => ...
+```
+
+Added in v0.1.2
+
+# liftF (function)
+
+Lift an impure value described by the generating type constructor `F` into the free monad
+
+**Signature**
+
+```ts
+export const liftF = <F, A>(fa: HKT<F, A>): Free<F, A> => impure(fa, a => ...
+```
+
+Added in v0.1.2

--- a/docs/modules/ReaderIO.ts.md
+++ b/docs/modules/ReaderIO.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReaderIO.ts
-nav_order: 9
+nav_order: 10
 parent: Modules
 ---
 

--- a/docs/modules/Semialign/NonEmptyArray.ts.md
+++ b/docs/modules/Semialign/NonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semialign/NonEmptyArray.ts
-nav_order: 11
+nav_order: 12
 parent: Modules
 ---
 

--- a/docs/modules/Semialign/index.ts.md
+++ b/docs/modules/Semialign/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semialign/index.ts
-nav_order: 10
+nav_order: 11
 parent: Modules
 ---
 

--- a/docs/modules/StateIO.ts.md
+++ b/docs/modules/StateIO.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateIO.ts
-nav_order: 12
+nav_order: 13
 parent: Modules
 ---
 

--- a/docs/modules/StateTaskEither.ts.md
+++ b/docs/modules/StateTaskEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateTaskEither.ts
-nav_order: 13
+nav_order: 14
 parent: Modules
 ---
 

--- a/docs/modules/Task/withTimeout.ts.md
+++ b/docs/modules/Task/withTimeout.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Task/withTimeout.ts
-nav_order: 14
+nav_order: 15
 parent: Modules
 ---
 

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskOption.ts
-nav_order: 15
+nav_order: 16
 parent: Modules
 ---
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: index.ts
-nav_order: 8
+nav_order: 9
 parent: Modules
 ---
 

--- a/docs/modules/time.ts.md
+++ b/docs/modules/time.ts.md
@@ -1,6 +1,6 @@
 ---
 title: time.ts
-nav_order: 16
+nav_order: 17
 parent: Modules
 ---
 

--- a/src/Free.ts
+++ b/src/Free.ts
@@ -1,0 +1,178 @@
+import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from 'fp-ts/lib/HKT'
+import { Monad, Monad1, Monad2, Monad2C, Monad3 } from 'fp-ts/lib/Monad'
+import { pipeable } from 'fp-ts/lib/pipeable'
+
+/**
+ * @since 0.1.2
+ */
+export const URI = 'Free'
+
+/**
+ * @since 0.1.2
+ */
+export type URI = typeof URI
+
+declare module 'fp-ts/lib/HKT' {
+  interface URItoKind2<E, A> {
+    Free: Free<E, A>
+  }
+}
+
+/**
+ * @data
+ * @constructor Pure
+ * @constructor Impure
+ * @since 0.1.2
+ */
+export type Free<F, A> = Pure<F, A> | Impure<F, A, any>
+
+interface Pure<_F, A> {
+  readonly _tag: 'Pure'
+  readonly value: A
+}
+
+interface Impure<F, A, X> {
+  readonly _tag: 'Impure'
+  readonly fx: HKT<F, X>
+  readonly f: (x: X) => Free<F, A>
+}
+
+const impure = <F, A, X>(fx: HKT<F, X>, f: (x: X) => Free<F, A>): Free<F, A> => ({ _tag: 'Impure', fx, f })
+
+/**
+ * @since 0.1.2
+ */
+export const isPure = <F, A>(fa: Free<F, A>): fa is Pure<F, A> => fa._tag === 'Pure'
+
+/**
+ * @since 0.1.2
+ */
+export const isImpure = <F, A>(fa: Free<F, A>): fa is Impure<F, A, any> => fa._tag === 'Impure'
+
+/**
+ * Lift an impure value described by the generating type constructor `F` into the free monad
+ *
+ * @since 0.1.2
+ */
+export const liftF = <F, A>(fa: HKT<F, A>): Free<F, A> => impure(fa, a => free.of(a))
+
+const substFree = <F, G>(f: <A>(fa: HKT<F, A>) => Free<G, A>): (<A>(fa: Free<F, A>) => Free<G, A>) => {
+  function go<A>(fa: Free<F, A>): Free<G, A> {
+    switch (fa._tag) {
+      case 'Pure':
+        return free.of(fa.value)
+      case 'Impure':
+        return free.chain(f(fa.fx), x => go(fa.f(x)))
+    }
+  }
+  return go
+}
+
+/**
+ * Use a natural transformation to change the generating type constructor of a free monad
+ *
+ * @since 0.1.2
+ */
+export function hoistFree<F extends URIS3 = never, G extends URIS3 = never>(
+  nt: <U, L, A>(fa: Kind3<F, U, L, A>) => Kind3<G, U, L, A>
+): <A>(fa: Free<F, A>) => Free<G, A>
+export function hoistFree<F extends URIS2 = never, G extends URIS2 = never>(
+  nt: <L, A>(fa: Kind2<F, L, A>) => Kind2<G, L, A>
+): <A>(fa: Free<F, A>) => Free<G, A>
+export function hoistFree<F extends URIS = never, G extends URIS = never>(
+  nt: <A>(fa: Kind<F, A>) => Kind<G, A>
+): <A>(fa: Free<F, A>) => Free<G, A>
+export function hoistFree<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(fa: Free<F, A>) => Free<G, A>
+export function hoistFree<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(fa: Free<F, A>) => Free<G, A> {
+  return substFree(fa => liftF(nt(fa)))
+}
+
+/**
+ * @since 0.1.2
+ */
+export interface FoldFree3<M extends URIS3> {
+  <F extends URIS3, U, L, A>(nt: <X>(fa: Kind3<F, U, L, X>) => Kind3<M, U, L, X>, fa: Free<F, A>): Kind3<M, U, L, A>
+  <F extends URIS2, U, L, A>(nt: <X>(fa: Kind2<F, L, X>) => Kind3<M, U, L, X>, fa: Free<F, A>): Kind3<M, U, L, A>
+  <F extends URIS, U, L, A>(nt: <X>(fa: Kind<F, X>) => Kind3<M, U, L, X>, fa: Free<F, A>): Kind3<M, U, L, A>
+}
+
+/**
+ * @since 0.1.2
+ */
+export interface FoldFree2<M extends URIS2> {
+  <F extends URIS2, L, A>(nt: <X>(fa: Kind2<F, L, X>) => Kind2<M, L, X>, fa: Free<F, A>): Kind2<M, L, A>
+  <F extends URIS, L, A>(nt: <X>(fa: Kind<F, X>) => Kind2<M, L, X>, fa: Free<F, A>): Kind2<M, L, A>
+}
+
+/**
+ * @since 0.1.2
+ */
+export interface FoldFree2C<M extends URIS2, L> {
+  <F extends URIS2, A>(nt: <X>(fa: Kind2<F, L, X>) => Kind2<M, L, X>, fa: Free<F, A>): Kind2<M, L, A>
+  <F extends URIS, A>(nt: <X>(fa: Kind<F, X>) => Kind2<M, L, X>, fa: Free<F, A>): Kind2<M, L, A>
+}
+
+/**
+ * @since 0.1.2
+ */
+export function foldFree<M extends URIS3>(M: Monad3<M>): FoldFree3<M>
+export function foldFree<M extends URIS2>(M: Monad2<M>): FoldFree2<M>
+export function foldFree<M extends URIS2, L>(M: Monad2C<M, L>): FoldFree2C<M, L>
+export function foldFree<M extends URIS>(
+  M: Monad1<M>
+): <F extends URIS, A>(nt: <X>(fa: Kind<F, X>) => Kind<M, X>, fa: Free<F, A>) => Kind<M, A>
+export function foldFree<M>(M: Monad<M>): <F, A>(nt: <X>(fa: HKT<F, X>) => HKT<M, X>, fa: Free<F, A>) => HKT<M, A>
+export function foldFree<M>(M: Monad<M>): <F, A>(nt: any, fa: Free<F, A>) => HKT<M, A> {
+  return (nt, fa) => {
+    if (isPure(fa)) {
+      return M.of(fa.value)
+    } else {
+      return M.chain(nt(fa.fx), x => foldFree(M)(nt, fa.f(x)))
+    }
+  }
+}
+
+/**
+ * @since 0.1.2
+ */
+export const free: Monad2<URI> = {
+  URI,
+  /**
+   * @since 0.1.2
+   */
+  of: <F, A>(value: A): Free<F, A> => ({ _tag: 'Pure', value }),
+  /**
+   * @since 0.1.2
+   */
+  chain: <F, A, B>(ma: Free<F, A>, f: (a: A) => Free<F, B>): Free<F, B> =>
+    isPure(ma) ? f(ma.value) : impure(ma.fx, x => free.chain(ma.f(x), f)),
+  /**
+   * @since 0.1.2
+   */
+  map: (fa, f) => (isPure(fa) ? free.of(f(fa.value)) : impure(fa.fx, x => free.map(fa.f(x), f))),
+  /**
+   * @since 0.1.2
+   */
+  ap: (fab, fa) => free.chain(fab, f => free.map(fa, f))
+}
+
+const { ap, chain, map, flatten } = pipeable(free)
+
+export {
+  /**
+   * @since 0.1.2
+   */
+  ap,
+  /**
+   * @since 0.1.2
+   */
+  chain,
+  /**
+   * @since 0.1.2
+   */
+  map,
+  /**
+   * @since 0.1.2
+   */
+  flatten
+}

--- a/src/Free.ts
+++ b/src/Free.ts
@@ -3,12 +3,12 @@ import { Monad, Monad1, Monad2, Monad2C, Monad3 } from 'fp-ts/lib/Monad'
 import { pipeable } from 'fp-ts/lib/pipeable'
 
 /**
- * @since 0.1.2
+ * @since 0.1.3
  */
 export const URI = 'Free'
 
 /**
- * @since 0.1.2
+ * @since 0.1.3
  */
 export type URI = typeof URI
 
@@ -22,7 +22,7 @@ declare module 'fp-ts/lib/HKT' {
  * @data
  * @constructor Pure
  * @constructor Impure
- * @since 0.1.2
+ * @since 0.1.3
  */
 export type Free<F, A> = Pure<F, A> | Impure<F, A, any>
 
@@ -40,19 +40,23 @@ interface Impure<F, A, X> {
 const impure = <F, A, X>(fx: HKT<F, X>, f: (x: X) => Free<F, A>): Free<F, A> => ({ _tag: 'Impure', fx, f })
 
 /**
- * @since 0.1.2
+ * Check if given Free instance is Pure
+ *
+ * @since 0.1.3
  */
 export const isPure = <F, A>(fa: Free<F, A>): fa is Pure<F, A> => fa._tag === 'Pure'
 
 /**
- * @since 0.1.2
+ * Check if given Free instance is Impure
+ *
+ * @since 0.1.3
  */
 export const isImpure = <F, A>(fa: Free<F, A>): fa is Impure<F, A, any> => fa._tag === 'Impure'
 
 /**
  * Lift an impure value described by the generating type constructor `F` into the free monad
  *
- * @since 0.1.2
+ * @since 0.1.3
  */
 export const liftF = <F, A>(fa: HKT<F, A>): Free<F, A> => impure(fa, a => free.of(a))
 
@@ -71,7 +75,7 @@ const substFree = <F, G>(f: <A>(fa: HKT<F, A>) => Free<G, A>): (<A>(fa: Free<F, 
 /**
  * Use a natural transformation to change the generating type constructor of a free monad
  *
- * @since 0.1.2
+ * @since 0.1.3
  */
 export function hoistFree<F extends URIS3 = never, G extends URIS3 = never>(
   nt: <U, L, A>(fa: Kind3<F, U, L, A>) => Kind3<G, U, L, A>
@@ -88,7 +92,7 @@ export function hoistFree<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(fa: Fr
 }
 
 /**
- * @since 0.1.2
+ * @since 0.1.3
  */
 export interface FoldFree3<M extends URIS3> {
   <F extends URIS3, U, L, A>(nt: <X>(fa: Kind3<F, U, L, X>) => Kind3<M, U, L, X>, fa: Free<F, A>): Kind3<M, U, L, A>
@@ -97,7 +101,7 @@ export interface FoldFree3<M extends URIS3> {
 }
 
 /**
- * @since 0.1.2
+ * @since 0.1.3
  */
 export interface FoldFree2<M extends URIS2> {
   <F extends URIS2, L, A>(nt: <X>(fa: Kind2<F, L, X>) => Kind2<M, L, X>, fa: Free<F, A>): Kind2<M, L, A>
@@ -105,7 +109,7 @@ export interface FoldFree2<M extends URIS2> {
 }
 
 /**
- * @since 0.1.2
+ * @since 0.1.3
  */
 export interface FoldFree2C<M extends URIS2, L> {
   <F extends URIS2, A>(nt: <X>(fa: Kind2<F, L, X>) => Kind2<M, L, X>, fa: Free<F, A>): Kind2<M, L, A>
@@ -113,7 +117,9 @@ export interface FoldFree2C<M extends URIS2, L> {
 }
 
 /**
- * @since 0.1.2
+ * Perform folding of a free monad using given natural transformation as an interpreter
+ *
+ * @since 0.1.3
  */
 export function foldFree<M extends URIS3>(M: Monad3<M>): FoldFree3<M>
 export function foldFree<M extends URIS2>(M: Monad2<M>): FoldFree2<M>
@@ -133,25 +139,27 @@ export function foldFree<M>(M: Monad<M>): <F, A>(nt: any, fa: Free<F, A>) => HKT
 }
 
 /**
- * @since 0.1.2
+ * Monad instance for Free
+ *
+ * @since 0.1.3
  */
 export const free: Monad2<URI> = {
   URI,
   /**
-   * @since 0.1.2
+   * @since 0.1.3
    */
   of: <F, A>(value: A): Free<F, A> => ({ _tag: 'Pure', value }),
   /**
-   * @since 0.1.2
+   * @since 0.1.3
    */
   chain: <F, A, B>(ma: Free<F, A>, f: (a: A) => Free<F, B>): Free<F, B> =>
     isPure(ma) ? f(ma.value) : impure(ma.fx, x => free.chain(ma.f(x), f)),
   /**
-   * @since 0.1.2
+   * @since 0.1.3
    */
   map: (fa, f) => (isPure(fa) ? free.of(f(fa.value)) : impure(fa.fx, x => free.map(fa.f(x), f))),
   /**
-   * @since 0.1.2
+   * @since 0.1.3
    */
   ap: (fab, fa) => free.chain(fab, f => free.map(fa, f))
 }
@@ -160,19 +168,19 @@ const { ap, chain, map, flatten } = pipeable(free)
 
 export {
   /**
-   * @since 0.1.2
+   * @since 0.1.3
    */
   ap,
   /**
-   * @since 0.1.2
+   * @since 0.1.3
    */
   chain,
   /**
-   * @since 0.1.2
+   * @since 0.1.3
    */
   map,
   /**
-   * @since 0.1.2
+   * @since 0.1.3
    */
   flatten
 }

--- a/test/Free.ts
+++ b/test/Free.ts
@@ -1,0 +1,100 @@
+import * as assert from 'assert'
+import { identity, FunctionN } from 'fp-ts/lib/function'
+import { Semigroup, semigroupSum } from 'fp-ts/lib/Semigroup'
+import { Identity, identity as id, URI as IdURI } from 'fp-ts/lib/Identity'
+
+import { liftF, foldFree, free, hoistFree, isImpure } from '../src/Free'
+import { Do } from '../src/Do'
+
+const URI = 'Expr'
+type URI = typeof URI
+
+class Add<A> {
+  readonly _URI!: URI
+  readonly _A!: A
+  readonly _tag: 'Add' = 'Add'
+  constructor(readonly M: Semigroup<A>, readonly a: A, readonly b: A, readonly next: (result: A) => A) {}
+}
+class Lit<A> {
+  readonly _URI!: URI
+  readonly _A!: A
+  readonly _tag: 'Lit' = 'Lit'
+  constructor(readonly value: A, readonly next: (result: A) => A) {}
+}
+type ExprF<A> = Add<A> | Lit<A>
+
+declare module 'fp-ts/lib/HKT' {
+  interface URItoKind<A> {
+    Expr: ExprF<A>
+  }
+}
+
+describe('Free', () => {
+  describe('Monad properties', () => {
+    it('of', () => {
+      const fa = free.of<IdURI, number>(42)
+      assert.strictEqual(fa._tag, 'Pure')
+    })
+
+    it('ap', () => {
+      const fa = free.of<IdURI, number>(41)
+      const fab = free.of<IdURI, FunctionN<[number], number>>(x => x + 1)
+      const fb = free.ap(fab, fa)
+      assert.strictEqual(fb._tag, 'Pure')
+
+      const result = foldFree(id)(identity, fb)
+      assert.strictEqual(result, 42)
+    })
+
+    it('map', () => {
+      const fa = free.of<IdURI, number>(41)
+      const fb = free.map(fa, x => x + 1)
+      assert.strictEqual(fb._tag, 'Pure')
+
+      const result = foldFree(id)(identity, fb)
+      assert.strictEqual(result, 42)
+    })
+
+    it('chain', () => {
+      const fa = free.of<IdURI, number>(41)
+      const fb = free.chain(fa, x => free.of(x + 1))
+      assert.strictEqual(fb._tag, 'Pure')
+
+      const result = foldFree(id)(identity, fb)
+      assert.strictEqual(result, 42)
+    })
+  })
+
+  describe('Expression tree example', () => {
+    const add = <A>(M: Semigroup<A>) => (a: A, b: A) => liftF(new Add(M, a, b, identity))
+    const lit = <A>(a: A) => liftF(new Lit(a, identity))
+
+    const program = Do(free)
+      .bind('two', lit(2))
+      .bind('three', lit(3))
+      .bindL('sum', ({ two, three }) => add(semigroupSum)(two, three))
+      .return(({ sum }) => sum)
+
+    assert.strictEqual(isImpure(program), true)
+
+    const idEval = <A>(fa: ExprF<A>): Identity<A> => {
+      switch (fa._tag) {
+        case 'Lit':
+          return id.of(fa.next(fa.value))
+        case 'Add':
+          return id.of(fa.next(fa.M.concat(fa.a, fa.b)))
+      }
+    }
+
+    it('foldFree', () => {
+      const result = foldFree(id)(idEval, program)
+      assert.equal(result, 5)
+    })
+
+    it('hoistFree', () => {
+      const programId = hoistFree<URI, IdURI>(idEval)(program)
+      const result = foldFree(id)(identity, programId)
+      assert.equal(result, 5)
+    })
+  })
+})


### PR DESCRIPTION
A naïve classless port from v1, exposing a pipeable interface.

#### Additional context

Free overall is considered a not-so-good approach performance-wise, so I suggest taking a look at either possibility of implementing Church-encoded Free monads, or using Oleg Kiselyov's Freer monads (http://okmij.org/ftp/Haskell/extensible/more.pdf).

I would like to discuss design decisions for this module, so I can understand all concerns and code a better implementation of Free.