### PR TITLE
Add RegExp module

### DIFF
--- a/docs/modules/RegExp.ts.md
+++ b/docs/modules/RegExp.ts.md
@@ -31,6 +31,18 @@ Returns the list of subexpression matches, or `None` if the match fails.
 export function match(r: RegExp): (s: string) => O.Option<RegExpMatchArray> { ... }
 ```
 
+**Example**
+
+```ts
+import * as O from 'fp-ts/lib/Option'
+import { match } from 'fp-ts-contrib/lib/RegExp'
+import { pipe } from 'fp-ts/lib/pipeable'
+
+const myMatch = match(/^(\d)(\w)$/)
+assert.deepStrictEqual(pipe('2e', myMatch, O.map(Array.from)), O.some(['2e', '2', 'e']))
+assert.deepStrictEqual(myMatch('foo'), O.none)
+```
+
 Added in v0.1.8
 
 # split (function)
@@ -42,6 +54,16 @@ should identify one delimiter.
 
 ```ts
 export function split(r: RegExp): (s: string) => NonEmptyArray<string> { ... }
+```
+
+**Example**
+
+```ts
+import { split } from 'fp-ts-contrib/lib/RegExp'
+
+const splitByHash = split(/#/)
+assert.deepStrictEqual(splitByHash('foo#bar#beer'), ['foo', 'bar', 'beer'])
+assert.deepStrictEqual(splitByHash('noHashes'), ['noHashes'])
 ```
 
 Added in v0.1.8
@@ -57,6 +79,15 @@ with the replacement string.
 export function sub(r: RegExp, replacement: string): (s: string) => string { ... }
 ```
 
+**Example**
+
+```ts
+import { sub } from 'fp-ts-contrib/lib/RegExp'
+
+const sanitiseSpaces = sub(/\s/g, '_')
+assert.strictEqual(sanitiseSpaces('foo bar owl'), 'foo_bar_owl')
+```
+
 Added in v0.1.8
 
 # test (function)
@@ -68,6 +99,16 @@ otherwise `false`.
 
 ```ts
 export function test(r: RegExp): Predicate<string> { ... }
+```
+
+**Example**
+
+```ts
+import { test } from 'fp-ts-contrib/lib/RegExp'
+
+const myTest = test(/^(\d)(\w)$/)
+assert.strictEqual(myTest('6s'), true)
+assert.strictEqual(myTest('bar'), false)
 ```
 
 Added in v0.1.8

--- a/docs/modules/RegExp.ts.md
+++ b/docs/modules/RegExp.ts.md
@@ -1,0 +1,73 @@
+---
+title: RegExp.ts
+nav_order: 11
+parent: Modules
+---
+
+# Overview
+
+Provides regular expression matching.
+
+Adapted from https://hackage.haskell.org/package/regex-compat-0.95.1/docs/Text-Regex.html
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [match (function)](#match-function)
+- [split (function)](#split-function)
+- [sub (function)](#sub-function)
+- [test (function)](#test-function)
+
+---
+
+# match (function)
+
+Returns the list of subexpression matches, or `None` if the match fails.
+
+**Signature**
+
+```ts
+export function match(r: RegExp): (s: string) => O.Option<RegExpMatchArray> { ... }
+```
+
+Added in v0.1.8
+
+# split (function)
+
+Splits a string based on a regular expression. The regular expression
+should identify one delimiter.
+
+**Signature**
+
+```ts
+export function split(r: RegExp): (s: string) => NonEmptyArray<string> { ... }
+```
+
+Added in v0.1.8
+
+# sub (function)
+
+Replaces every occurance of the given regular expression
+with the replacement string.
+
+**Signature**
+
+```ts
+export function sub(r: RegExp, replacement: string): (s: string) => string { ... }
+```
+
+Added in v0.1.8
+
+# test (function)
+
+Returns `true` if the string matches the regular expression,
+otherwise `false`.
+
+**Signature**
+
+```ts
+export function test(r: RegExp): Predicate<string> { ... }
+```
+
+Added in v0.1.8

--- a/docs/modules/Semialign/NonEmptyArray.ts.md
+++ b/docs/modules/Semialign/NonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semialign/NonEmptyArray.ts
-nav_order: 12
+nav_order: 13
 parent: Modules
 ---
 

--- a/docs/modules/Semialign/index.ts.md
+++ b/docs/modules/Semialign/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semialign/index.ts
-nav_order: 11
+nav_order: 12
 parent: Modules
 ---
 

--- a/docs/modules/StateIO.ts.md
+++ b/docs/modules/StateIO.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateIO.ts
-nav_order: 13
+nav_order: 14
 parent: Modules
 ---
 

--- a/docs/modules/StateTaskEither.ts.md
+++ b/docs/modules/StateTaskEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateTaskEither.ts
-nav_order: 14
+nav_order: 15
 parent: Modules
 ---
 

--- a/docs/modules/Task/withTimeout.ts.md
+++ b/docs/modules/Task/withTimeout.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Task/withTimeout.ts
-nav_order: 15
+nav_order: 16
 parent: Modules
 ---
 

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskOption.ts
-nav_order: 16
+nav_order: 17
 parent: Modules
 ---
 

--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Zipper.ts
-nav_order: 18
+nav_order: 19
 parent: Modules
 ---
 

--- a/docs/modules/time.ts.md
+++ b/docs/modules/time.ts.md
@@ -1,6 +1,6 @@
 ---
 title: time.ts
-nav_order: 17
+nav_order: 18
 parent: Modules
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts-contrib",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts-contrib",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A community driven utility package for fp-ts",
   "files": [
     "lib",

--- a/src/RegExp.ts
+++ b/src/RegExp.ts
@@ -10,6 +10,16 @@ import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
 
 /**
  * Returns the list of subexpression matches, or `None` if the match fails.
+ *
+ * @example
+ * import * as O from 'fp-ts/lib/Option'
+ * import { match } from 'fp-ts-contrib/lib/RegExp'
+ * import { pipe } from 'fp-ts/lib/pipeable'
+ *
+ * const myMatch = match(/^(\d)(\w)$/)
+ * assert.deepStrictEqual(pipe('2e', myMatch, O.map(Array.from)), O.some(['2e', '2', 'e']))
+ * assert.deepStrictEqual(myMatch('foo'), O.none)
+ *
  * @since 0.1.8
  */
 export function match(r: RegExp): (s: string) => O.Option<RegExpMatchArray> {
@@ -19,6 +29,14 @@ export function match(r: RegExp): (s: string) => O.Option<RegExpMatchArray> {
 /**
  * Returns `true` if the string matches the regular expression,
  * otherwise `false`.
+ *
+ * @example
+ * import { test } from 'fp-ts-contrib/lib/RegExp'
+ *
+ * const myTest = test(/^(\d)(\w)$/)
+ * assert.strictEqual(myTest('6s'), true)
+ * assert.strictEqual(myTest('bar'), false)
+ *
  * @since 0.1.8
  */
 export function test(r: RegExp): Predicate<string> {
@@ -28,6 +46,13 @@ export function test(r: RegExp): Predicate<string> {
 /**
  * Replaces every occurance of the given regular expression
  * with the replacement string.
+ *
+ * @example
+ * import { sub } from 'fp-ts-contrib/lib/RegExp'
+ *
+ * const sanitiseSpaces = sub(/\s/g, '_')
+ * assert.strictEqual(sanitiseSpaces('foo bar owl'), 'foo_bar_owl')
+ *
  * @since 0.1.8
  */
 export function sub(r: RegExp, replacement: string): (s: string) => string {
@@ -37,6 +62,14 @@ export function sub(r: RegExp, replacement: string): (s: string) => string {
 /**
  * Splits a string based on a regular expression. The regular expression
  * should identify one delimiter.
+ *
+ * @example
+ * import { split } from 'fp-ts-contrib/lib/RegExp'
+ *
+ * const splitByHash = split(/#/)
+ * assert.deepStrictEqual(splitByHash('foo#bar#beer'), ['foo', 'bar', 'beer'])
+ * assert.deepStrictEqual(splitByHash('noHashes'), ['noHashes'])
+ *
  * @since 0.1.8
  */
 export function split(r: RegExp): (s: string) => NonEmptyArray<string> {

--- a/src/RegExp.ts
+++ b/src/RegExp.ts
@@ -1,0 +1,44 @@
+/**
+ * @file Provides regular expression matching.
+ *
+ * Adapted from https://hackage.haskell.org/package/regex-compat-0.95.1/docs/Text-Regex.html
+ */
+
+import * as O from 'fp-ts/lib/Option'
+import { Predicate } from 'fp-ts/lib/function'
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
+
+/**
+ * Returns the list of subexpression matches, or `None` if the match fails.
+ * @since 0.1.8
+ */
+export function match(r: RegExp): (s: string) => O.Option<RegExpMatchArray> {
+  return s => O.fromNullable(s.match(r))
+}
+
+/**
+ * Returns `true` if the string matches the regular expression,
+ * otherwise `false`.
+ * @since 0.1.8
+ */
+export function test(r: RegExp): Predicate<string> {
+  return s => r.test(s)
+}
+
+/**
+ * Replaces every occurance of the given regular expression
+ * with the replacement string.
+ * @since 0.1.8
+ */
+export function sub(r: RegExp, replacement: string): (s: string) => string {
+  return s => s.replace(r, replacement)
+}
+
+/**
+ * Splits a string based on a regular expression. The regular expression
+ * should identify one delimiter.
+ * @since 0.1.8
+ */
+export function split(r: RegExp): (s: string) => NonEmptyArray<string> {
+  return s => s.split(r) as any
+}

--- a/test/RegExp.ts
+++ b/test/RegExp.ts
@@ -1,0 +1,29 @@
+import * as assert from 'assert'
+import * as O from 'fp-ts/lib/Option'
+import * as RX from '../src/RegExp'
+import { pipe } from 'fp-ts/lib/pipeable'
+
+describe('RegExp', () => {
+  it('match', () => {
+    const myMatch = RX.match(/^(\d)(\w)$/)
+    assert.deepStrictEqual(pipe('2e', myMatch, O.map(Array.from)), O.some(['2e', '2', 'e']))
+    assert.deepStrictEqual(myMatch('foo'), O.none)
+  })
+
+  it('test', () => {
+    const myTest = RX.test(/^(\d)(\w)$/)
+    assert.strictEqual(myTest('6s'), true)
+    assert.strictEqual(myTest('bar'), false)
+  })
+
+  it('sub', () => {
+    const sanitiseSpaces = RX.sub(/\s/g, '_')
+    assert.strictEqual(sanitiseSpaces('foo bar owl'), 'foo_bar_owl')
+  })
+
+  it('split', () => {
+    const splitByHash = RX.split(/#/)
+    assert.deepStrictEqual(splitByHash('foo#bar#beer'), ['foo', 'bar', 'beer'])
+    assert.deepStrictEqual(splitByHash('noHashes'), ['noHashes'])
+  })
+})


### PR DESCRIPTION
This PR adds a `RegExp` module, providing these matching functions:
- `match`
- `test`
- `sub`
- `split`