### PR TITLE
docs(recipes): Introduce Recipes section of the docs

### DIFF
--- a/docs/recipes/AccumulateIOEither.md
+++ b/docs/recipes/AccumulateIOEither.md
@@ -1,0 +1,32 @@
+---
+title: Accumulate IOEither
+parent: Recipes
+---
+
+#### Question
+
+Given `Array<IOEither<E, A>>`.
+
+Count how many lefts and rights. Result should be
+`IO<{ success: number, failure: number }>` (or `IO<[number, number]>`).
+
+#### Answer
+
+Using `wilt` (from
+[Witherable](https://gcanti.github.io/fp-ts/modules/Witherable.ts.html)):
+
+```ts
+import { array } from 'fp-ts/lib/Array'
+import { identity } from 'fp-ts/lib/function'
+import { io, IO } from 'fp-ts/lib/IO'
+import { IOEither } from 'fp-ts/lib/IOEither'
+import { Separated } from 'fp-ts/lib/Compactable'
+
+declare const xs: Array<IOEither<Error, number>>
+
+const result: IO<Separated<Error[], number[]>> = array.wilt(io)(xs, identity)
+```
+
+#### Source
+
+[#typescript of FP Slack ](https://fpchat-invite.herokuapp.com/).

--- a/docs/recipes/index.md
+++ b/docs/recipes/index.md
@@ -1,0 +1,14 @@
+---
+title: Recipes
+has_children: true
+permalink: /docs/recipes
+nav_order: 3
+---
+
+Very often people ask the question:
+
+> How do you do X in fp-ts (io-ts/monocle-ts/etc)?
+
+This is a curated list of those questions with a corresponding answer. Examples
+and solutions to _common_ problems using the
+[fp-ts](https://gcanti.github.io/fp-ts/) ecosystem.

--- a/docs/recipes/sequenceVSsequenceT.md
+++ b/docs/recipes/sequenceVSsequenceT.md
@@ -7,7 +7,7 @@ parent: Recipes
 
 **Array of Options to Option of Array?**
 
-Why does `sequenceT` doesn't work here?
+Why doesn't `sequenceT` work here?
 
 ```ts
 import { sequenceT } from './Apply';

--- a/docs/recipes/sequenceVSsequenceT.md
+++ b/docs/recipes/sequenceVSsequenceT.md
@@ -1,0 +1,68 @@
+---
+title: sequence vs sequenceT
+parent: Recipes
+---
+
+#### Question
+
+**Array of Options to Option of Array?**
+
+Why does `sequenceT` doesn't work here?
+
+```ts
+import { sequenceT } from './Apply';
+import { some, option, none } from './Option'
+
+const sequenceTOption = sequenceT(option)
+
+const arrayOfOptions = [some(1), none]
+
+sequenceTOption(...arrayOfOptions) // type error
+```
+
+#### Answer
+
+`sequence` and `sequenceT` (`sequenceS`) are different:
+
+- `sequence` comes from [Traversable](https://gcanti.github.io/fp-ts/modules/Traversable.ts.html)
+  and works with (homogeneous) arrays.
+- `sequenceT` (`sequenceS`) comes from
+  [Apply](https://gcanti.github.io/fp-ts/modules/Apply.ts.html) and works with
+  non empty tuples (non empty structs) i.e the types can be different.
+
+So with `sequenceT` (`sequenceS`) you can do:
+
+```ts
+import { sequenceT, sequenceS } from 'fp-ts/lib/Apply'
+import * as O from 'fp-ts/lib/Option'
+
+// Option<number> -----v         v---- Option<string>
+sequenceT(O.option)(O.some(1), O.some('a'))
+
+//      Option<number> -----v             v---- Option<string>
+sequenceS(O.option)({ a: O.some(1), b: O.some('a') })
+```
+
+However with `sequence` you can't do this:
+
+```
+import * as O from 'fp-ts/lib/Option'
+import * as A from 'fp-ts/lib/Array'
+
+//                                        v--- error: Type 'string' is not assignable to type 'number'
+A.array.sequence(O.option)([O.some(1), O.some('a')])
+```
+
+But it does work on homogeneous lists:
+
+```ts
+// this is ok since they are all `Option<number>`s
+A.array.sequence(O.option)([O.some(1), O.some(2)]) 
+```
+
+When using `sequenceT` (`sequenceS`) we need at least one element because Apply
+doesn't have the `of` operation, so we can't lift `[]` (`{}`).
+
+#### Source
+
+[fp-ts/issues/1140](https://github.com/gcanti/fp-ts/issues/1140)


### PR DESCRIPTION
Resolves #54 

Introduce "Recipes" section on the docs. The goal of this section is to have a curated list of questions and answers that are (more or less) common and could benefit people working with fp-ts _et al_.

I think PR is a good starting point for Recipes. A few ideas to iterate on this:

- Use a _[docs-ts](https://github.com/gcanti/docs-ts) like_ way of type checking and generating the recipes instead.
- Improve the content of `docs/recipes/index.md` to explain how people can collaborate.