### PR TITLE
Add filterA

### DIFF
--- a/docs/modules/Free.ts.md
+++ b/docs/modules/Free.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Free.ts
-nav_order: 9
+nav_order: 10
 parent: Modules
 ---
 

--- a/docs/modules/IOOption.ts.md
+++ b/docs/modules/IOOption.ts.md
@@ -1,6 +1,6 @@
 ---
 title: IOOption.ts
-nav_order: 11
+nav_order: 12
 parent: Modules
 ---
 

--- a/docs/modules/List.ts.md
+++ b/docs/modules/List.ts.md
@@ -1,6 +1,6 @@
 ---
 title: List.ts
-nav_order: 12
+nav_order: 13
 parent: Modules
 ---
 

--- a/docs/modules/ReaderIO.ts.md
+++ b/docs/modules/ReaderIO.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReaderIO.ts
-nav_order: 13
+nav_order: 14
 parent: Modules
 ---
 

--- a/docs/modules/RegExp.ts.md
+++ b/docs/modules/RegExp.ts.md
@@ -1,6 +1,6 @@
 ---
 title: RegExp.ts
-nav_order: 14
+nav_order: 15
 parent: Modules
 ---
 

--- a/docs/modules/Semialign/NonEmptyArray.ts.md
+++ b/docs/modules/Semialign/NonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semialign/NonEmptyArray.ts
-nav_order: 16
+nav_order: 17
 parent: Modules
 ---
 

--- a/docs/modules/Semialign/index.ts.md
+++ b/docs/modules/Semialign/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semialign/index.ts
-nav_order: 15
+nav_order: 16
 parent: Modules
 ---
 

--- a/docs/modules/StateEither.ts.md
+++ b/docs/modules/StateEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateEither.ts
-nav_order: 17
+nav_order: 18
 parent: Modules
 ---
 

--- a/docs/modules/StateIO.ts.md
+++ b/docs/modules/StateIO.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateIO.ts
-nav_order: 18
+nav_order: 19
 parent: Modules
 ---
 

--- a/docs/modules/StateTaskEither.ts.md
+++ b/docs/modules/StateTaskEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateTaskEither.ts
-nav_order: 19
+nav_order: 20
 parent: Modules
 ---
 

--- a/docs/modules/Task/getLine.ts.md
+++ b/docs/modules/Task/getLine.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Task/getLine.ts
-nav_order: 20
+nav_order: 21
 parent: Modules
 ---
 

--- a/docs/modules/Task/withTimeout.ts.md
+++ b/docs/modules/Task/withTimeout.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Task/withTimeout.ts
-nav_order: 21
+nav_order: 22
 parent: Modules
 ---
 

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskOption.ts
-nav_order: 22
+nav_order: 23
 parent: Modules
 ---
 

--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Zipper.ts
-nav_order: 24
+nav_order: 25
 parent: Modules
 ---
 

--- a/docs/modules/filterA.ts.md
+++ b/docs/modules/filterA.ts.md
@@ -6,7 +6,7 @@ parent: Modules
 
 # filterA overview
 
-Added in TODO
+Added in v0.1.15
 
 ---
 
@@ -18,7 +18,7 @@ Added in TODO
 
 # filterA
 
-TODO describe here
+This generalizes the array-based 'filter' function.
 
 **Signature**
 
@@ -37,7 +37,7 @@ export function filterA<F extends URIS>(
 ): <A>(p: (a: A) => Kind<F, boolean>) => (as: Array<A>) => Kind<F, Array<A>>
 export function filterA<F>(
     F: Applicative<F>
-): <A>(p: (a: A) => HKT<F, boolean>) => (as: Array<A>) => HKT<F, Array<A>> 
+): <A>(p: (a: A) => HKT<F, boolean>) => (as: Array<A>) => HKT<F, Array<A>>
 ```
 
 **Example**
@@ -53,4 +53,4 @@ const p = (n: number): IO<boolean> => io.of(n % 2 === 0)
 filterAIO(p)([1, 2, 3, 4, 5])() // [2, 4]
 ```
 
-Added in TODO
+Added in v0.1.15

--- a/docs/modules/filterA.ts.md
+++ b/docs/modules/filterA.ts.md
@@ -1,0 +1,56 @@
+---
+title: filterA.ts
+nav_order: 9
+parent: Modules
+---
+
+# filterA overview
+
+Added in TODO
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [filterA](#filterA)
+
+---
+
+# filterA
+
+TODO describe here
+
+**Signature**
+
+```ts
+export function filterA<F extends URIS4>(
+  F: Applicative4<F>
+): <M, U, L, A>(p: (a: A) => Kind4<F, M, U, L, boolean>) => (as: Array<A>) => Kind4<F, M, U, L, Array<A>>
+export function filterA<F extends URIS3>(
+  F: Applicative3<F>
+): <U, L, A>(p: (a: A) => Kind3<F, U, L, boolean>) => (as: Array<A>) => Kind3<F, U, L, Array<A>>
+export function filterA<F extends URIS2>(
+  F: Applicative2<F>
+): <L, A>(p: (a: A) => Kind2<F, L, boolean>) => (as: Array<A>) => Kind2<F, L, Array<A>>
+export function filterA<F extends URIS>(
+  F: Applicative1<F>
+): <A>(p: (a: A) => Kind<F, boolean>) => (as: Array<A>) => Kind<F, Array<A>>
+export function filterA<F>(
+    F: Applicative<F>
+): <A>(p: (a: A) => HKT<F, boolean>) => (as: Array<A>) => HKT<F, Array<A>> 
+```
+
+**Example**
+
+```ts
+import { io, IO } from 'fp-ts/lib/IO'
+import { filterA } from 'fp-ts-contrib/lib/filterA'
+
+const filterAIO = filterA(io)
+
+const p = (n: number): IO<boolean> => io.of(n % 2 === 0)
+
+filterAIO(p)([1, 2, 3, 4, 5])() // [2, 4]
+```
+
+Added in TODO

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: index.ts
-nav_order: 10
+nav_order: 11
 parent: Modules
 ---
 

--- a/docs/modules/time.ts.md
+++ b/docs/modules/time.ts.md
@@ -1,6 +1,6 @@
 ---
 title: time.ts
-nav_order: 23
+nav_order: 24
 parent: Modules
 ---
 

--- a/src/filterA.ts
+++ b/src/filterA.ts
@@ -1,5 +1,5 @@
 /**
- * @since TODO
+ * @since 0.1.15
  */
 import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from 'fp-ts/lib/HKT'
 import { Applicative, Applicative1, Applicative2, Applicative3, Applicative4 } from 'fp-ts/lib/Applicative'
@@ -7,7 +7,7 @@ import * as A from 'fp-ts/lib/Array'
 import * as O from 'fp-ts/lib/Option'
 
 /**
- * TODO describe here
+ * This generalizes the array-based `filter` function.
  *
  * @example
  * import { io, IO } from 'fp-ts/lib/IO'
@@ -17,9 +17,9 @@ import * as O from 'fp-ts/lib/Option'
  *
  * const p = (n: number): IO<boolean> => io.of(n % 2 === 0)
  *
- * filterAIO(p)([1, 2, 3, 4, 5])() // [2, 4]
+ * assert.deepStrictEqual(filterAIO(p)([1, 2, 3, 4, 5])(), [2, 4])
  *
- * @since TODO
+ * @since 0.1.15
  */
 export function filterA<F extends URIS4>(
   F: Applicative4<F>

--- a/src/filterA.ts
+++ b/src/filterA.ts
@@ -1,0 +1,43 @@
+/**
+ * @since TODO
+ */
+import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from 'fp-ts/lib/HKT'
+import { Applicative, Applicative1, Applicative2, Applicative3, Applicative4 } from 'fp-ts/lib/Applicative'
+import * as A from 'fp-ts/lib/Array'
+import * as O from 'fp-ts/lib/Option'
+
+/**
+ * TODO describe here
+ *
+ * @example
+ * import { io, IO } from 'fp-ts/lib/IO'
+ * import { filterA } from 'fp-ts-contrib/lib/filterA'
+ *
+ * const filterAIO = filterA(io)
+ *
+ * const p = (n: number): IO<boolean> => io.of(n % 2 === 0)
+ *
+ * filterAIO(p)([1, 2, 3, 4, 5])() // [2, 4]
+ *
+ * @since TODO
+ */
+export function filterA<F extends URIS4>(
+  F: Applicative4<F>
+): <M, U, L, A>(p: (a: A) => Kind4<F, M, U, L, boolean>) => (as: Array<A>) => Kind4<F, M, U, L, Array<A>>
+
+export function filterA<F extends URIS3>(
+  F: Applicative3<F>
+): <U, L, A>(p: (a: A) => Kind3<F, U, L, boolean>) => (as: Array<A>) => Kind3<F, U, L, Array<A>>
+
+export function filterA<F extends URIS2>(
+  F: Applicative2<F>
+): <L, A>(p: (a: A) => Kind2<F, L, boolean>) => (as: Array<A>) => Kind2<F, L, Array<A>>
+
+export function filterA<F extends URIS>(
+  F: Applicative1<F>
+): <A>(p: (a: A) => Kind<F, boolean>) => (as: Array<A>) => Kind<F, Array<A>>
+
+export function filterA<F>(F: Applicative<F>): <A>(p: (a: A) => HKT<F, boolean>) => (as: Array<A>) => HKT<F, Array<A>> {
+  const wither = A.array.wither(F)
+  return p => as => wither(as, a => F.map(p(a), b => (b ? O.some(a) : O.none)))
+}

--- a/test/filterA.ts
+++ b/test/filterA.ts
@@ -1,0 +1,12 @@
+import * as assert from 'assert'
+import { filterA } from '../src/filterA'
+import { io, IO } from 'fp-ts/lib/IO'
+
+describe('filterA', () => {
+  it('should filter in the lifted context', () => {
+    const filterAIO = filterA(io)
+    const p = (n: number): IO<boolean> => io.of(n % 2 === 0)
+    const result = filterAIO(p)([1, 2, 3, 4, 5])
+    assert.deepStrictEqual(result(), [2, 4])
+  })
+})


### PR DESCRIPTION
This PR adds the `filterA` module which allows you to filter an array with an applicative predicate, for example if you have to make calls with `IO` or `Task` in said predicate.

Not added versions or descriptions yet, just wondering if the implementation looks good at this point. If/when we're happy with that I'll add those final bits. :slightly_smiling_face: 

Cheers!