### PR TITLE
Feature/tree shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
       - Add `Monad` instance (@IMax153)
       - Add `Alt` instance (@IMax153)
       - Add `Alternative` instance (@IMax153)
+  - `Free`
+    - split "mega" `free` instance into individual typeclass instances (@IMax153)
+      - Add `Functor` instance (@IMax153)
+      - Add `Applicative` instance (@IMax153)
+      - Add `Apply` instance (@IMax153)
 
 - **Polish**
   - standardize export declarations in all modules (@IMax153)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@
       - Add `Applicative` instance (@IMax153)
       - Add `Apply` instance (@IMax153)
       - Add `Monad` instance (@IMax153)
+  - `StateEither`
+    - split "mega" `stateEither` instance into individual typeclass instances (@IMax153)
+      - Add `Functor` instance (@IMax153)
+      - Add `Applicative` instance (@IMax153)
+      - Add `Apply` instance (@IMax153)
+      - Add `Monad` instance (@IMax153)
+      - Add `MonadThrow` instance (@IMax153)
 
 - **Polish**
   - standardize export declarations in all modules (@IMax153)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@
       - Add `Apply` instance (@IMax153)
       - Add `Monad` instance (@IMax153)
       - Add `MonadThrow` instance (@IMax153)
+  - `StateIO`
+    - split "mega" `stateIO` instance into individual typeclass instances (@IMax153)
+      - Add `Functor` instance (@IMax153)
+      - Add `Applicative` instance (@IMax153)
+      - Add `Apply` instance (@IMax153)
+      - Add `Monad` instance (@IMax153)
 
 - **Polish**
   - standardize export declarations in all modules (@IMax153)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 - **Internal**
   - remove pipeable from all modules (@IMax153)
   - add tests for `StateIO` (@IMax153)
+  - add tests for `StateTaskEither` (@IMax153)
 
 # 0.1.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 
 - **Internal**
   - remove pipeable from all modules (@IMax153)
+  - add tests for `StateIO` (@IMax153)
 
 # 0.1.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@
 **Note**: Gaps between patch versions are faulty/broken releases.
 **Note**: A feature tagged as Experimental is in a high state of flux, you're at risk of it changing without notice.
 
+# 0.1.18
+
+- **New Feature**
+  - `ArrayOption`
+    - add `zero` method (@IMax153)
+    - split "mega" `arrayOption` instance into individual typeclass instances (@IMax153)
+      - Add `Functor` instance (@IMax153)
+      - Add `Applicative` instance (@IMax153)
+      - Add `Apply` instance (@IMax153)
+      - Add `Monad` instance (@IMax153)
+      - Add `Alt` instance (@IMax153)
+      - Add `Alternative` instance (@IMax153)
+
+- **Polish**
+  - standardize export declarations in all modules (@IMax153)
+  - add category tags to all module exports (@IMax153)
+
+- **Internal**
+  - remove pipeable from all modules (@IMax153)
+
 # 0.1.17
 
 - **New Feature**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@
       - Add `Functor` instance (@IMax153)
       - Add `Applicative` instance (@IMax153)
       - Add `Apply` instance (@IMax153)
+  - `IOOption`
+    - add `zero` method (@IMax153)
+    - split "mega" `ioOption` instance into individual typeclass instances (@IMax153)
+      - Add `Functor` instance (@IMax153)
+      - Add `Applicative` instance (@IMax153)
+      - Add `Apply` instance (@IMax153)
+      - Add `Monad` instance (@IMax153)
+      - Add `Alt` instance (@IMax153)
+      - Add `Alternative` instance (@IMax153)
+      - Add `Compactable` instance (@IMax153)
+      - Add `Filterable` instance (@IMax153)
 
 - **Polish**
   - standardize export declarations in all modules (@IMax153)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,15 @@
       - Add `Alternative` instance (@IMax153)
       - Add `Compactable` instance (@IMax153)
       - Add `Filterable` instance (@IMax153)
+  - `Zipper`
+    - split "mega" `zipper` instance into individual typeclass instances (@IMax153)
+      - Add `Functor` instance (@IMax153)
+      - Add `FunctorWithIndex` instance (@IMax153)
+      - Add `Applicative` instance (@IMax153)
+      - Add `Apply` instance (@IMax153)
+      - Add `Foldable` instance (@IMax153)
+      - Add `Traversable` instance (@IMax153)
+      - Add `Comonad` instance (@IMax153)
 
 - **Polish**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@
       - Add `Alternative` instance (@IMax153)
       - Add `Compactable` instance (@IMax153)
       - Add `Filterable` instance (@IMax153)
+  - `List`
+    - split "mega" `list` instance into individual typeclass instances (@IMax153)
+      - Add `Functor` instance (@IMax153)
+      - Add `Foldable` instance (@IMax153)
+      - Add `Traversable` instance (@IMax153)
 
 - **Polish**
   - standardize export declarations in all modules (@IMax153)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 # 0.1.18
 
 - **New Feature**
+
   - `ArrayOption`
     - add `zero` method (@IMax153)
     - split "mega" `arrayOption` instance into individual typeclass instances (@IMax153)
@@ -65,8 +66,24 @@
       - Add `Applicative` instance (@IMax153)
       - Add `Apply` instance (@IMax153)
       - Add `Monad` instance (@IMax153)
+  - `StateTaskEither`
+    - split "mega" `stateTaskEither` instance into individual typeclass instances (@IMax153)
+      - Add `Functor` instance (@IMax153)
+      - Add `Applicative` instance (@IMax153)
+      - Add `Apply` instance (@IMax153)
+      - Add `Monad` instance (@IMax153)
+  - `TaskOption`
+    - split "mega" `taskOption` instance into individual typeclass instances (@IMax153)
+      - Add `Functor` instance (@IMax153)
+      - Add `Applicative` instance (@IMax153)
+      - Add `Apply` instance (@IMax153)
+      - Add `Monad` instance (@IMax153)
+      - Add `Alternative` instance (@IMax153)
+      - Add `Compactable` instance (@IMax153)
+      - Add `Filterable` instance (@IMax153)
 
 - **Polish**
+
   - standardize export declarations in all modules (@IMax153)
   - add category tags to all module exports (@IMax153)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@
       - Add `Functor` instance (@IMax153)
       - Add `Foldable` instance (@IMax153)
       - Add `Traversable` instance (@IMax153)
+  - `ReaderIO`
+    - split "mega" `readerIO` instance into individual typeclass instances (@IMax153)
+      - Add `Functor` instance (@IMax153)
+      - Add `Applicative` instance (@IMax153)
+      - Add `Apply` instance (@IMax153)
+      - Add `Monad` instance (@IMax153)
 
 - **Polish**
   - standardize export declarations in all modules (@IMax153)

--- a/docs/modules/Align/Array.ts.md
+++ b/docs/modules/Align/Array.ts.md
@@ -4,7 +4,7 @@ nav_order: 1
 parent: Modules
 ---
 
-# Array overview
+## Array overview
 
 Added in v0.1.0
 
@@ -12,27 +12,30 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [alignArray](#alignarray)
-- [lpadZip](#lpadzip)
-- [lpadZipWith](#lpadzipwith)
-- [rpadZip](#rpadzip)
-- [rpadZipWith](#rpadzipwith)
+- [utils](#utils)
+  - [alignArray](#alignarray)
+  - [lpadZip](#lpadzip)
+  - [lpadZipWith](#lpadzipwith)
+  - [rpadZip](#rpadzip)
+  - [rpadZipWith](#rpadzipwith)
 
 ---
 
-# alignArray
+# utils
+
+## alignArray
 
 `Align` instance for `Array`.
 
 **Signature**
 
 ```ts
-export const alignArray: Align1<URI> = ...
+export declare const alignArray: Align1<'Array'>
 ```
 
 Added in v0.1.0
 
-# lpadZip
+## lpadZip
 
 Takes two arrays and returns an array of corresponding pairs. If the left input array is short, it will be
 padded using `none`.
@@ -42,7 +45,7 @@ It is similar to `zip`, but it doesn't discard elements when the left input arra
 **Signature**
 
 ```ts
-export function lpadZip<A, B>(xs: Array<A>, ys: Array<B>): Array<[Option<A>, B]> { ... }
+export declare function lpadZip<A, B>(xs: Array<A>, ys: Array<B>): Array<[Option<A>, B]>
 ```
 
 **Example**
@@ -64,7 +67,7 @@ assert.deepStrictEqual(lpadZip([1, 2, 3], ['a', 'b']), [
 
 Added in v0.1.0
 
-# lpadZipWith
+## lpadZipWith
 
 Apply a function to pairs of elements at the same index in two arrays, collecting the results in a new array. If the
 left input array is short, it will be padded using `none`.
@@ -74,7 +77,7 @@ It is similar to `zipWith`, but it doesn't discard elements when the left input 
 **Signature**
 
 ```ts
-export function lpadZipWith<A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: Option<A>, b: B) => C): Array<C> { ... }
+export declare function lpadZipWith<A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: Option<A>, b: B) => C): Array<C>
 ```
 
 **Example**
@@ -98,7 +101,7 @@ assert.deepStrictEqual(lpadZipWith([1, 2, 3, 4], ['a', 'b', 'c'], f), ['1a', '2b
 
 Added in v0.1.0
 
-# rpadZip
+## rpadZip
 
 Takes two arrays and returns an array of corresponding pairs. If the right input array is short, it will be
 padded using `none`.
@@ -108,7 +111,7 @@ It is similar to `zip`, but it doesn't discard elements when the right input arr
 **Signature**
 
 ```ts
-export function rpadZip<A, B>(xs: Array<A>, ys: Array<B>): Array<[A, Option<B>]> { ... }
+export declare function rpadZip<A, B>(xs: Array<A>, ys: Array<B>): Array<[A, Option<B>]>
 ```
 
 **Example**
@@ -130,7 +133,7 @@ assert.deepStrictEqual(rpadZip([1, 2], ['a', 'b', 'c']), [
 
 Added in v0.1.0
 
-# rpadZipWith
+## rpadZipWith
 
 Apply a function to pairs of elements at the same index in two arrays, collecting the results in a new array. If the
 right input array is short, it will be padded using `none`.
@@ -140,7 +143,7 @@ It is similar to `zipWith`, but it doesn't discard elements when the right input
 **Signature**
 
 ```ts
-export function rpadZipWith<A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: A, b: Option<B>) => C): Array<C> { ... }
+export declare function rpadZipWith<A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: A, b: Option<B>) => C): Array<C>
 ```
 
 **Example**

--- a/docs/modules/Align/Array.ts.md
+++ b/docs/modules/Align/Array.ts.md
@@ -45,7 +45,7 @@ It is similar to `zip`, but it doesn't discard elements when the left input arra
 **Signature**
 
 ```ts
-export declare function lpadZip<A, B>(xs: Array<A>, ys: Array<B>): Array<[Option<A>, B]>
+export declare const lpadZip: <A, B>(xs: A[], ys: B[]) => [Option<A>, B][]
 ```
 
 **Example**
@@ -77,7 +77,7 @@ It is similar to `zipWith`, but it doesn't discard elements when the left input 
 **Signature**
 
 ```ts
-export declare function lpadZipWith<A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: Option<A>, b: B) => C): Array<C>
+export declare const lpadZipWith: <A, B, C>(xs: A[], ys: B[], f: (a: Option<A>, b: B) => C) => C[]
 ```
 
 **Example**
@@ -111,7 +111,7 @@ It is similar to `zip`, but it doesn't discard elements when the right input arr
 **Signature**
 
 ```ts
-export declare function rpadZip<A, B>(xs: Array<A>, ys: Array<B>): Array<[A, Option<B>]>
+export declare const rpadZip: <A, B>(xs: A[], ys: B[]) => [A, Option<B>][]
 ```
 
 **Example**
@@ -143,7 +143,7 @@ It is similar to `zipWith`, but it doesn't discard elements when the right input
 **Signature**
 
 ```ts
-export declare function rpadZipWith<A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: A, b: Option<B>) => C): Array<C>
+export declare const rpadZipWith: <A, B, C>(xs: A[], ys: B[], f: (a: A, b: Option<B>) => C) => C[]
 ```
 
 **Example**

--- a/docs/modules/Align/Option.ts.md
+++ b/docs/modules/Align/Option.ts.md
@@ -4,7 +4,7 @@ nav_order: 3
 parent: Modules
 ---
 
-# Option overview
+## Option overview
 
 Added in v0.1.0
 
@@ -12,18 +12,21 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [alignOption](#alignoption)
+- [utils](#utils)
+  - [alignOption](#alignoption)
 
 ---
 
-# alignOption
+# utils
+
+## alignOption
 
 `Align` instance for `Option`.
 
 **Signature**
 
 ```ts
-export const alignOption: Align1<URI> = ...
+export declare const alignOption: Align1<'Option'>
 ```
 
 Added in v0.1.0

--- a/docs/modules/Align/Record.ts.md
+++ b/docs/modules/Align/Record.ts.md
@@ -59,7 +59,7 @@ Added in v0.1.0
 **Signature**
 
 ```ts
-export declare function nil<A>(): Record<string, A>
+export declare const nil: <A>() => Record<string, A>
 ```
 
 Added in v0.1.0

--- a/docs/modules/Align/Record.ts.md
+++ b/docs/modules/Align/Record.ts.md
@@ -4,7 +4,7 @@ nav_order: 4
 parent: Modules
 ---
 
-# Record overview
+## Record overview
 
 Added in v0.1.0
 
@@ -12,51 +12,54 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [align](#align)
-- [alignWith](#alignwith)
-- [nil](#nil)
+- [utils](#utils)
+  - [align](#align)
+  - [alignWith](#alignwith)
+  - [nil](#nil)
 
 ---
 
-# align
+# utils
+
+## align
 
 **Signature**
 
 ```ts
-export function align<K extends string, P extends string, A, B>(
+export declare function align<K extends string, P extends string, A, B>(
   fa: Record<K, A>,
   fb: Record<P, B>
 ): Record<K | P, These<A, B>>
-export function align<A, B>(fa: Record<string, A>, fb: Record<string, B>): Record<string, These<A, B>> { ... }
+export declare function align<A, B>(fa: Record<string, A>, fb: Record<string, B>): Record<string, These<A, B>>
 ```
 
 Added in v0.1.0
 
-# alignWith
+## alignWith
 
 **Signature**
 
 ```ts
-export function alignWith<K extends string, P extends string, A, B, C>(
+export declare function alignWith<K extends string, P extends string, A, B, C>(
   fa: Record<K, A>,
   fb: Record<P, B>,
   f: (x: These<A, B>) => C
 ): Record<K | P, C>
-export function alignWith<A, B, C>(
+export declare function alignWith<A, B, C>(
   fa: Record<string, A>,
   fb: Record<string, B>,
   f: (x: These<A, B>) => C
-): Record<string, C> { ... }
+): Record<string, C>
 ```
 
 Added in v0.1.0
 
-# nil
+## nil
 
 **Signature**
 
 ```ts
-export function nil<A>(): Record<string, A> { ... }
+export declare function nil<A>(): Record<string, A>
 ```
 
 Added in v0.1.0

--- a/docs/modules/Align/index.ts.md
+++ b/docs/modules/Align/index.ts.md
@@ -4,7 +4,7 @@ nav_order: 2
 parent: Modules
 ---
 
-# index overview
+## index overview
 
 The `Align` type class extends the `Semialign` type class with a value `nil`, which
 acts as a unit in regards to `align`.
@@ -22,18 +22,21 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [Align (interface)](#align-interface)
-- [Align1 (interface)](#align1-interface)
-- [Align2 (interface)](#align2-interface)
-- [Align2C (interface)](#align2c-interface)
-- [Align3 (interface)](#align3-interface)
-- [padZip](#padzip)
-- [padZipWith](#padzipwith)
-- [salign](#salign)
+- [utils](#utils)
+  - [Align (interface)](#align-interface)
+  - [Align1 (interface)](#align1-interface)
+  - [Align2 (interface)](#align2-interface)
+  - [Align2C (interface)](#align2c-interface)
+  - [Align3 (interface)](#align3-interface)
+  - [padZip](#padzip)
+  - [padZipWith](#padzipwith)
+  - [salign](#salign)
 
 ---
 
-# Align (interface)
+# utils
+
+## Align (interface)
 
 **Signature**
 
@@ -45,7 +48,7 @@ export interface Align<F> extends Semialign<F> {
 
 Added in v0.1.0
 
-# Align1 (interface)
+## Align1 (interface)
 
 **Signature**
 
@@ -57,7 +60,7 @@ export interface Align1<F extends URIS> extends Semialign1<F> {
 
 Added in v0.1.0
 
-# Align2 (interface)
+## Align2 (interface)
 
 **Signature**
 
@@ -69,7 +72,7 @@ export interface Align2<F extends URIS2> extends Semialign2<F> {
 
 Added in v0.1.0
 
-# Align2C (interface)
+## Align2C (interface)
 
 **Signature**
 
@@ -81,7 +84,7 @@ export interface Align2C<F extends URIS2, L> extends Semialign2C<F, L> {
 
 Added in v0.1.0
 
-# Align3 (interface)
+## Align3 (interface)
 
 **Signature**
 
@@ -93,7 +96,7 @@ export interface Align3<F extends URIS3> extends Semialign3<F> {
 
 Added in v0.1.0
 
-# padZip
+## padZip
 
 Align two structures, using `none` to fill blanks.
 
@@ -102,19 +105,19 @@ It is similar to `zip`, but it doesn't discard elements.
 **Signature**
 
 ```ts
-export function padZip<F extends URIS3, L>(
+export declare function padZip<F extends URIS3, L>(
   F: Align3<F>
 ): <U, L, A, B>(fa: Kind3<F, U, L, A>, fb: Kind3<F, U, L, B>) => Kind3<F, U, L, [Option<A>, Option<B>]>
-export function padZip<F extends URIS2>(
+export declare function padZip<F extends URIS2>(
   F: Align2<F>
 ): <L, A, B>(fa: Kind2<F, L, A>, fb: Kind2<F, L, B>) => Kind2<F, L, [Option<A>, Option<B>]>
-export function padZip<F extends URIS2, L>(
+export declare function padZip<F extends URIS2, L>(
   F: Align2C<F, L>
 ): <A, B>(fa: Kind2<F, L, A>, fb: Kind2<F, L, B>) => Kind2<F, L, [Option<A>, Option<B>]>
-export function padZip<F extends URIS>(
+export declare function padZip<F extends URIS>(
   F: Align1<F>
 ): <A, B>(fa: Kind<F, A>, fb: Kind<F, B>) => Kind<F, [Option<A>, Option<B>]>
-export function padZip<F>(F: Align<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, [Option<A>, Option<B>]> { ... }
+export declare function padZip<F>(F: Align<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, [Option<A>, Option<B>]>
 ```
 
 **Example**
@@ -133,7 +136,7 @@ assert.deepStrictEqual(padZip(alignArray)([1, 2, 3], [4, 5]), [
 
 Added in v0.1.0
 
-# padZipWith
+## padZipWith
 
 Align two structures by applying a function to each pair of aligned elements, using `none` to fill blanks.
 
@@ -142,25 +145,25 @@ It is similar to `zipWith`, but it doesn't discard elements.
 **Signature**
 
 ```ts
-export function padZipWith<F extends URIS3, L>(
+export declare function padZipWith<F extends URIS3, L>(
   F: Align3<F>
 ): <U, L, A, B, C>(
   fa: Kind3<F, U, L, A>,
   fb: Kind3<F, U, L, B>,
   f: (a: Option<A>, b: Option<B>) => C
 ) => Kind3<F, U, L, C>
-export function padZipWith<F extends URIS2>(
+export declare function padZipWith<F extends URIS2>(
   F: Align2<F>
 ): <L, A, B, C>(fa: Kind2<F, L, A>, fb: Kind2<F, L, B>, f: (a: Option<A>, b: Option<B>) => C) => Kind2<F, L, C>
-export function padZipWith<F extends URIS2, L>(
+export declare function padZipWith<F extends URIS2, L>(
   F: Align2C<F, L>
 ): <A, B, C>(fa: Kind2<F, L, A>, fb: Kind2<F, L, B>, f: (a: Option<A>, b: Option<B>) => C) => Kind2<F, L, C>
-export function padZipWith<F extends URIS>(
+export declare function padZipWith<F extends URIS>(
   F: Align1<F>
 ): <A, B, C>(fa: Kind<F, A>, fb: Kind<F, B>, f: (a: Option<A>, b: Option<B>) => C) => Kind<F, C>
-export function padZipWith<F>(
+export declare function padZipWith<F>(
   F: Align<F>
-): <A, B, C>(fa: HKT<F, A>, fb: HKT<F, B>, f: (a: Option<A>, b: Option<B>) => C) => HKT<F, C> { ... }
+): <A, B, C>(fa: HKT<F, A>, fb: HKT<F, B>, f: (a: Option<A>, b: Option<B>) => C) => HKT<F, C>
 ```
 
 **Example**
@@ -190,27 +193,30 @@ assert.deepStrictEqual(padZipWith(alignArray)([1], ['a', 'b'], f), ['1a', '*b'])
 
 Added in v0.1.0
 
-# salign
+## salign
 
 Align two structures, using a semigroup for combining values.
 
 **Signature**
 
 ```ts
-export function salign<F extends URIS3, A, L>(
+export declare function salign<F extends URIS3, A, L>(
   F: Align3<F>,
   S: Semigroup<A>
 ): <U, L>(fx: Kind3<F, U, L, A>, fy: Kind3<F, U, L, A>) => Kind3<F, U, L, A>
-export function salign<F extends URIS2, A>(
+export declare function salign<F extends URIS2, A>(
   F: Align2<F>,
   S: Semigroup<A>
 ): <L>(fx: Kind2<F, L, A>, fy: Kind2<F, L, A>) => Kind2<F, L, A>
-export function salign<F extends URIS2, A, L>(
+export declare function salign<F extends URIS2, A, L>(
   F: Align2C<F, L>,
   S: Semigroup<A>
 ): (fx: Kind2<F, L, A>, fy: Kind2<F, L, A>) => Kind2<F, L, A>
-export function salign<F extends URIS, A>(F: Align1<F>, S: Semigroup<A>): (fx: Kind<F, A>, fy: Kind<F, A>) => Kind<F, A>
-export function salign<F, A>(F: Align<F>, S: Semigroup<A>): (fx: HKT<F, A>, fy: HKT<F, A>) => HKT<F, A> { ... }
+export declare function salign<F extends URIS, A>(
+  F: Align1<F>,
+  S: Semigroup<A>
+): (fx: Kind<F, A>, fy: Kind<F, A>) => Kind<F, A>
+export declare function salign<F, A>(F: Align<F>, S: Semigroup<A>): (fx: HKT<F, A>, fy: HKT<F, A>) => HKT<F, A>
 ```
 
 **Example**

--- a/docs/modules/ArrayOption.ts.md
+++ b/docs/modules/ArrayOption.ts.md
@@ -4,7 +4,7 @@ nav_order: 5
 parent: Modules
 ---
 
-# ArrayOption overview
+## ArrayOption overview
 
 Added in v0.1.0
 
@@ -12,40 +12,313 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [ArrayOption (interface)](#arrayoption-interface)
-- [URI (type alias)](#uri-type-alias)
-- [URI](#uri)
-- [alt](#alt)
-- [ap](#ap)
-- [apFirst](#apfirst)
-- [apSecond](#apsecond)
-- [arrayOption](#arrayoption)
-- [chain](#chain)
-- [chainFirst](#chainfirst)
-- [chainOptionK](#chainoptionk)
-- [flatten](#flatten)
-- [fold](#fold)
-- [fromArray](#fromarray)
-- [fromOption](#fromoption)
-- [fromOptionK](#fromoptionk)
-- [getOrElse](#getorelse)
-- [map](#map)
-- [none](#none)
-- [some](#some)
+- [Alternative](#alternative)
+  - [alt](#alt)
+  - [zero](#zero)
+- [Applicative](#applicative)
+  - [of](#of)
+- [Apply](#apply)
+  - [ap](#ap)
+  - [apFirst](#apfirst)
+  - [apSecond](#apsecond)
+- [Functor](#functor)
+  - [map](#map)
+- [Monad](#monad)
+  - [chain](#chain)
+  - [chainFirst](#chainfirst)
+  - [chainOptionK](#chainoptionk)
+  - [flatten](#flatten)
+- [constructors](#constructors)
+  - [fromArray](#fromarray)
+  - [fromOption](#fromoption)
+  - [fromOptionK](#fromoptionk)
+  - [none](#none)
+  - [some](#some)
+- [destructors](#destructors)
+  - [fold](#fold)
+  - [getOrElse](#getorelse)
+- [instances](#instances)
+  - [Alt](#alt)
+  - [Alternative](#alternative-1)
+  - [Applicative](#applicative-1)
+  - [Apply](#apply-1)
+  - [Functor](#functor-1)
+  - [Monad](#monad-1)
+  - [URI](#uri)
+  - [URI (type alias)](#uri-type-alias)
+  - [arrayOption](#arrayoption)
+- [model](#model)
+  - [ArrayOption (interface)](#arrayoption-interface)
 
 ---
 
-# ArrayOption (interface)
+# Alternative
+
+## alt
 
 **Signature**
 
 ```ts
-export interface ArrayOption<A> extends Array<Option<A>> {}
+export declare const alt: <A>(that: () => ArrayOption<A>) => (fa: ArrayOption<A>) => ArrayOption<A>
+```
+
+Added in v0.1.18
+
+## zero
+
+**Signature**
+
+```ts
+export declare const zero: <A>() => ArrayOption<A>
+```
+
+Added in v0.1.18
+
+# Applicative
+
+## of
+
+**Signature**
+
+```ts
+export declare const of: <A>(a: A) => ArrayOption<A>
+```
+
+Added in v0.1.18
+
+# Apply
+
+## ap
+
+**Signature**
+
+```ts
+export declare const ap: <A>(fa: ArrayOption<A>) => <B>(fab: ArrayOption<(a: A) => B>) => ArrayOption<B>
+```
+
+Added in v0.1.18
+
+## apFirst
+
+**Signature**
+
+```ts
+export declare const apFirst: <B>(fb: ArrayOption<B>) => <A>(fa: ArrayOption<A>) => ArrayOption<A>
+```
+
+Added in v0.1.18
+
+## apSecond
+
+**Signature**
+
+```ts
+export declare const apSecond: <B>(fb: ArrayOption<B>) => <A>(fa: ArrayOption<A>) => ArrayOption<B>
+```
+
+Added in v0.1.18
+
+# Functor
+
+## map
+
+**Signature**
+
+```ts
+export declare const map: <A, B>(f: (a: A) => B) => (fa: ArrayOption<A>) => ArrayOption<B>
+```
+
+Added in v0.1.18
+
+# Monad
+
+## chain
+
+**Signature**
+
+```ts
+export declare const chain: <A, B>(f: (a: A) => ArrayOption<B>) => (fa: ArrayOption<A>) => ArrayOption<B>
+```
+
+Added in v0.1.18
+
+## chainFirst
+
+**Signature**
+
+```ts
+export declare const chainFirst: <A, B>(f: (a: A) => ArrayOption<B>) => (ma: ArrayOption<A>) => ArrayOption<A>
+```
+
+Added in v0.1.18
+
+## chainOptionK
+
+**Signature**
+
+```ts
+export declare const chainOptionK: <A, B>(f: (a: A) => Option<B>) => (ma: ArrayOption<A>) => ArrayOption<B>
+```
+
+Added in v0.1.10
+
+## flatten
+
+**Signature**
+
+```ts
+export declare const flatten: <A>(mma: ArrayOption<ArrayOption<A>>) => ArrayOption<A>
+```
+
+Added in v0.1.18
+
+# constructors
+
+## fromArray
+
+**Signature**
+
+```ts
+export declare const fromArray: <A>(as: A[]) => ArrayOption<A>
 ```
 
 Added in v0.1.0
 
-# URI (type alias)
+## fromOption
+
+**Signature**
+
+```ts
+export declare const fromOption: <A>(ma: Option<A>) => ArrayOption<A>
+```
+
+Added in v0.1.0
+
+## fromOptionK
+
+**Signature**
+
+```ts
+export declare const fromOptionK: <A extends unknown[], B>(f: (...a: A) => Option<B>) => (...a: A) => ArrayOption<B>
+```
+
+Added in v0.1.10
+
+## none
+
+**Signature**
+
+```ts
+export declare const none: ArrayOption<never>
+```
+
+Added in v0.1.0
+
+## some
+
+**Signature**
+
+```ts
+export declare const some: <A>(a: A) => ArrayOption<A>
+```
+
+Added in v0.1.0
+
+# destructors
+
+## fold
+
+**Signature**
+
+```ts
+export declare const fold: <A, B>(onNone: () => B[], onSome: (a: A) => B[]) => (as: ArrayOption<A>) => B[]
+```
+
+Added in v0.1.0
+
+## getOrElse
+
+**Signature**
+
+```ts
+export declare const getOrElse: <A>(onNone: () => A[]) => (as: ArrayOption<A>) => A[]
+```
+
+Added in v0.1.0
+
+# instances
+
+## Alt
+
+**Signature**
+
+```ts
+export declare const Alt: Alt1<'ArrayOption'>
+```
+
+Added in v0.1.18
+
+## Alternative
+
+**Signature**
+
+```ts
+export declare const Alternative: Alternative1<'ArrayOption'>
+```
+
+Added in v0.1.18
+
+## Applicative
+
+**Signature**
+
+```ts
+export declare const Applicative: Applicative1<'ArrayOption'>
+```
+
+Added in v0.1.18
+
+## Apply
+
+**Signature**
+
+```ts
+export declare const Apply: Apply1<'ArrayOption'>
+```
+
+Added in v0.1.18
+
+## Functor
+
+**Signature**
+
+```ts
+export declare const Functor: Functor1<'ArrayOption'>
+```
+
+Added in v0.1.18
+
+## Monad
+
+**Signature**
+
+```ts
+export declare const Monad: Monad1<'ArrayOption'>
+```
+
+Added in v0.1.18
+
+## URI
+
+**Signature**
+
+```ts
+export declare const URI: 'ArrayOption'
+```
+
+Added in v0.1.0
+
+## URI (type alias)
 
 **Signature**
 
@@ -55,182 +328,24 @@ export type URI = typeof URI
 
 Added in v0.1.0
 
-# URI
+## arrayOption
 
 **Signature**
 
 ```ts
-export const URI: "ArrayOption" = ...
+export declare const arrayOption: Monad1<'ArrayOption'> & Alt1<'ArrayOption'>
 ```
 
 Added in v0.1.0
 
-# alt
+# model
+
+## ArrayOption (interface)
 
 **Signature**
 
 ```ts
-<A>(that: () => ArrayOption<A>) => (fa: ArrayOption<A>) => ArrayOption<A>
-```
-
-Added in v0.1.0
-
-# ap
-
-**Signature**
-
-```ts
-<A>(fa: ArrayOption<A>) => <B>(fab: ArrayOption<(a: A) => B>) => ArrayOption<B>
-```
-
-Added in v0.1.0
-
-# apFirst
-
-**Signature**
-
-```ts
-<B>(fb: ArrayOption<B>) => <A>(fa: ArrayOption<A>) => ArrayOption<A>
-```
-
-Added in v0.1.0
-
-# apSecond
-
-**Signature**
-
-```ts
-<B>(fb: ArrayOption<B>) => <A>(fa: ArrayOption<A>) => ArrayOption<B>
-```
-
-Added in v0.1.0
-
-# arrayOption
-
-**Signature**
-
-```ts
-export const arrayOption: Monad1<URI> & Alt1<URI> = ...
-```
-
-Added in v0.1.0
-
-# chain
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => ArrayOption<B>) => (ma: ArrayOption<A>) => ArrayOption<B>
-```
-
-Added in v0.1.0
-
-# chainFirst
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => ArrayOption<B>) => (ma: ArrayOption<A>) => ArrayOption<A>
-```
-
-Added in v0.1.0
-
-# chainOptionK
-
-**Signature**
-
-```ts
-export function chainOptionK<A, B>(f: (a: A) => Option<B>): (ma: ArrayOption<A>) => ArrayOption<B> { ... }
-```
-
-Added in v0.1.10
-
-# flatten
-
-**Signature**
-
-```ts
-<A>(mma: ArrayOption<ArrayOption<A>>) => ArrayOption<A>
-```
-
-Added in v0.1.0
-
-# fold
-
-**Signature**
-
-```ts
-export function fold<A, B>(onNone: () => Array<B>, onSome: (a: A) => Array<B>): (as: ArrayOption<A>) => Array<B> { ... }
-```
-
-Added in v0.1.0
-
-# fromArray
-
-**Signature**
-
-```ts
-export const fromArray: <A>(as: Array<A>) => ArrayOption<A> = ...
-```
-
-Added in v0.1.0
-
-# fromOption
-
-**Signature**
-
-```ts
-export const fromOption: <A>(ma: Option<A>) => ArrayOption<A> = ...
-```
-
-Added in v0.1.0
-
-# fromOptionK
-
-**Signature**
-
-```ts
-export function fromOptionK<A extends Array<unknown>, B>(f: (...a: A) => Option<B>): (...a: A) => ArrayOption<B> { ... }
-```
-
-Added in v0.1.10
-
-# getOrElse
-
-**Signature**
-
-```ts
-export function getOrElse<A>(onNone: () => Array<A>): (as: ArrayOption<A>) => Array<A> { ... }
-```
-
-Added in v0.1.0
-
-# map
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => B) => (fa: ArrayOption<A>) => ArrayOption<B>
-```
-
-Added in v0.1.0
-
-# none
-
-**Signature**
-
-```ts
-export const none: ArrayOption<never> = ...
-```
-
-Added in v0.1.0
-
-# some
-
-**Signature**
-
-```ts
-export const some: <A>(a: A) => ArrayOption<A> = ...
+export interface ArrayOption<A> extends Array<Option<A>> {}
 ```
 
 Added in v0.1.0

--- a/docs/modules/Do.ts.md
+++ b/docs/modules/Do.ts.md
@@ -4,7 +4,7 @@ nav_order: 8
 parent: Modules
 ---
 
-# Do overview
+## Do overview
 
 This module provides a simuation of Haskell do notation.
 
@@ -14,17 +14,54 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [Do0 (interface)](#do0-interface)
-- [Do1 (interface)](#do1-interface)
-- [Do2 (interface)](#do2-interface)
-- [Do2C (interface)](#do2c-interface)
-- [Do3 (interface)](#do3-interface)
-- [Do3C (interface)](#do3c-interface)
-- [Do](#do)
+- [utils](#utils)
+  - [Do](#do)
+  - [Do0 (interface)](#do0-interface)
+  - [Do1 (interface)](#do1-interface)
+  - [Do2 (interface)](#do2-interface)
+  - [Do2C (interface)](#do2c-interface)
+  - [Do3 (interface)](#do3-interface)
+  - [Do3C (interface)](#do3c-interface)
 
 ---
 
-# Do0 (interface)
+# utils
+
+## Do
+
+This function provides a simulation of Haskell do notation. The `bind` / `bindL` functions contributes to a threaded
+scope that is available to each subsequent step. The `do` / `doL` functions can be used to perform computations that
+add nothing to the scope. The `return` function lifts the given callback to the monad context. Finally the `done`
+function returns the scope.
+
+**Signature**
+
+```ts
+export declare function Do<M extends URIS3>(M: Monad3<M>): Do3<M, {}>
+export declare function Do<M extends URIS2>(M: Monad2<M>): Do2<M, {}>
+export declare function Do<M extends URIS2, L>(M: Monad2C<M, L>): Do2C<M, {}, L>
+export declare function Do<M extends URIS>(M: Monad1<M>): Do1<M, {}>
+export declare function Do<M>(M: Monad<M>): Do0<M, {}>
+```
+
+**Example**
+
+```ts
+import { option, some } from 'fp-ts/lib/Option'
+import { Do } from 'fp-ts-contrib/lib/Do'
+
+// x: Option<number>
+const x = Do(option) // <- a monad instance
+  .bindL('foo', () => some('bar'))
+  .bindL('baz', () => some(4))
+  .return(({ foo, baz }) => foo.length + baz)
+
+assert.deepStrictEqual(x, some(7))
+```
+
+Added in v0.0.2
+
+## Do0 (interface)
 
 **Signature**
 
@@ -49,7 +86,7 @@ export interface Do0<M, S extends object> {
 
 Added in v0.1.0
 
-# Do1 (interface)
+## Do1 (interface)
 
 **Signature**
 
@@ -74,7 +111,7 @@ export interface Do1<M extends URIS, S extends object> {
 
 Added in v0.1.0
 
-# Do2 (interface)
+## Do2 (interface)
 
 **Signature**
 
@@ -102,7 +139,7 @@ export interface Do2<M extends URIS2, S extends object> {
 
 Added in v0.1.0
 
-# Do2C (interface)
+## Do2C (interface)
 
 **Signature**
 
@@ -130,7 +167,7 @@ export interface Do2C<M extends URIS2, S extends object, E> {
 
 Added in v0.1.0
 
-# Do3 (interface)
+## Do3 (interface)
 
 **Signature**
 
@@ -161,7 +198,7 @@ export interface Do3<M extends URIS3, S extends object> {
 
 Added in v0.1.0
 
-# Do3C (interface)
+## Do3C (interface)
 
 **Signature**
 
@@ -188,37 +225,3 @@ export interface Do3C<M extends URIS3, S extends object, R, E> {
 ```
 
 Added in v0.1.0
-
-# Do
-
-This function provides a simulation of Haskell do notation. The `bind` / `bindL` functions contributes to a threaded
-scope that is available to each subsequent step. The `do` / `doL` functions can be used to perform computations that
-add nothing to the scope. The `return` function lifts the given callback to the monad context. Finally the `done`
-function returns the scope.
-
-**Signature**
-
-```ts
-export function Do<M extends URIS3>(M: Monad3<M>): Do3<M, {}>
-export function Do<M extends URIS2>(M: Monad2<M>): Do2<M, {}>
-export function Do<M extends URIS2, L>(M: Monad2C<M, L>): Do2C<M, {}, L>
-export function Do<M extends URIS>(M: Monad1<M>): Do1<M, {}>
-export function Do<M>(M: Monad<M>): Do0<M, {}> { ... }
-```
-
-**Example**
-
-```ts
-import { option, some } from 'fp-ts/lib/Option'
-import { Do } from 'fp-ts-contrib/lib/Do'
-
-// x: Option<number>
-const x = Do(option) // <- a monad instance
-  .bindL('foo', () => some('bar'))
-  .bindL('baz', () => some(4))
-  .return(({ foo, baz }) => foo.length + baz)
-
-assert.deepStrictEqual(x, some(7))
-```
-
-Added in v0.0.2

--- a/docs/modules/Free.ts.md
+++ b/docs/modules/Free.ts.md
@@ -4,7 +4,7 @@ nav_order: 10
 parent: Modules
 ---
 
-# Free overview
+## Free overview
 
 Added in v0.1.3
 
@@ -12,26 +12,137 @@ Added in v0.1.3
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [FoldFree2 (interface)](#foldfree2-interface)
-- [FoldFree2C (interface)](#foldfree2c-interface)
-- [FoldFree3 (interface)](#foldfree3-interface)
-- [Free (type alias)](#free-type-alias)
-- [URI (type alias)](#uri-type-alias)
-- [URI](#uri)
-- [ap](#ap)
-- [chain](#chain)
-- [flatten](#flatten)
-- [foldFree](#foldfree)
-- [free](#free)
-- [hoistFree](#hoistfree)
-- [isImpure](#isimpure)
-- [isPure](#ispure)
-- [liftF](#liftf)
-- [map](#map)
+- [Applicative](#applicative)
+  - [of](#of)
+- [Apply](#apply)
+  - [ap](#ap)
+- [Functor](#functor)
+  - [map](#map)
+- [Monad](#monad)
+  - [chain](#chain)
+  - [flatten](#flatten)
+- [combinators](#combinators)
+  - [hoistFree](#hoistfree)
+- [constructors](#constructors)
+  - [liftF](#liftf)
+- [destructors](#destructors)
+  - [FoldFree2 (interface)](#foldfree2-interface)
+  - [FoldFree2C (interface)](#foldfree2c-interface)
+  - [FoldFree3 (interface)](#foldfree3-interface)
+  - [foldFree](#foldfree)
+- [instances](#instances)
+  - [Applicative](#applicative-1)
+  - [Apply](#apply-1)
+  - [Functor](#functor-1)
+  - [URI](#uri)
+  - [URI (type alias)](#uri-type-alias)
+  - [free](#free)
+- [model](#model)
+  - [Free (type alias)](#free-type-alias)
+- [utils](#utils)
+  - [isImpure](#isimpure)
+  - [isPure](#ispure)
 
 ---
 
-# FoldFree2 (interface)
+# Applicative
+
+## of
+
+**Signature**
+
+```ts
+export declare const of: <F, A>(a: A) => Free<F, A>
+```
+
+Added in v0.1.18
+
+# Apply
+
+## ap
+
+**Signature**
+
+```ts
+export declare const ap: <F, A, B>(fa: Free<F, A>) => (fab: Free<F, (a: A) => B>) => Free<F, B>
+```
+
+Added in v0.1.18
+
+# Functor
+
+## map
+
+**Signature**
+
+```ts
+export declare const map: <A, B>(f: (a: A) => B) => <F>(fa: Free<F, A>) => Free<F, B>
+```
+
+Added in v0.1.18
+
+# Monad
+
+## chain
+
+**Signature**
+
+```ts
+export declare const chain: <F, A, B>(f: (a: A) => Free<F, B>) => (ma: Free<F, A>) => Free<F, B>
+```
+
+Added in v0.1.18
+
+## flatten
+
+**Signature**
+
+```ts
+export declare const flatten: <E, A>(mma: Free<E, Free<E, A>>) => Free<E, A>
+```
+
+Added in v0.1.18
+
+# combinators
+
+## hoistFree
+
+Use a natural transformation to change the generating type constructor of a free monad
+
+**Signature**
+
+```ts
+export declare function hoistFree<F extends URIS3 = never, G extends URIS3 = never>(
+  nt: <U, L, A>(fa: Kind3<F, U, L, A>) => Kind3<G, U, L, A>
+): <A>(fa: Free<F, A>) => Free<G, A>
+export declare function hoistFree<F extends URIS2 = never, G extends URIS2 = never>(
+  nt: <L, A>(fa: Kind2<F, L, A>) => Kind2<G, L, A>
+): <A>(fa: Free<F, A>) => Free<G, A>
+export declare function hoistFree<F extends URIS = never, G extends URIS = never>(
+  nt: <A>(fa: Kind<F, A>) => Kind<G, A>
+): <A>(fa: Free<F, A>) => Free<G, A>
+export declare function hoistFree<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(fa: Free<F, A>) => Free<G, A>
+```
+
+Added in v0.1.3
+
+# constructors
+
+## liftF
+
+Lift an impure value described by the generating type constructor `F` into the free monad
+
+**Signature**
+
+```ts
+export declare const liftF: <F, A>(fa: HKT<F, A>) => Free<F, A>
+```
+
+Added in v0.1.3
+
+# destructors
+
+## FoldFree2 (interface)
 
 **Signature**
 
@@ -44,7 +155,7 @@ export interface FoldFree2<M extends URIS2> {
 
 Added in v0.1.3
 
-# FoldFree2C (interface)
+## FoldFree2C (interface)
 
 **Signature**
 
@@ -57,7 +168,7 @@ export interface FoldFree2C<M extends URIS2, L> {
 
 Added in v0.1.3
 
-# FoldFree3 (interface)
+## FoldFree3 (interface)
 
 **Signature**
 
@@ -71,17 +182,69 @@ export interface FoldFree3<M extends URIS3> {
 
 Added in v0.1.3
 
-# Free (type alias)
+## foldFree
+
+Perform folding of a free monad using given natural transformation as an interpreter
 
 **Signature**
 
 ```ts
-export type Free<F, A> = Pure<F, A> | Impure<F, A, any>
+export declare function foldFree<M extends URIS3>(M: Monad3<M>): FoldFree3<M>
+export declare function foldFree<M extends URIS2>(M: Monad2<M>): FoldFree2<M>
+export declare function foldFree<M extends URIS2, L>(M: Monad2C<M, L>): FoldFree2C<M, L>
+export declare function foldFree<M extends URIS>(
+  M: Monad1<M>
+): <F extends URIS, A>(nt: <X>(fa: Kind<F, X>) => Kind<M, X>, fa: Free<F, A>) => Kind<M, A>
+export declare function foldFree<M>(
+  M: Monad<M>
+): <F, A>(nt: <X>(fa: HKT<F, X>) => HKT<M, X>, fa: Free<F, A>) => HKT<M, A>
 ```
 
 Added in v0.1.3
 
-# URI (type alias)
+# instances
+
+## Applicative
+
+**Signature**
+
+```ts
+export declare const Applicative: Applicative2<'Free'>
+```
+
+Added in v0.1.18
+
+## Apply
+
+**Signature**
+
+```ts
+export declare const Apply: Apply2<'Free'>
+```
+
+Added in v0.1.18
+
+## Functor
+
+**Signature**
+
+```ts
+export declare const Functor: Functor2<'Free'>
+```
+
+Added in v0.1.18
+
+## URI
+
+**Signature**
+
+```ts
+export declare const URI: 'Free'
+```
+
+Added in v0.1.3
+
+## URI (type alias)
 
 **Signature**
 
@@ -91,139 +254,52 @@ export type URI = typeof URI
 
 Added in v0.1.3
 
-# URI
-
-**Signature**
-
-```ts
-export const URI: "Free" = ...
-```
-
-Added in v0.1.3
-
-# ap
-
-**Signature**
-
-```ts
-<E, A>(fa: Free<E, A>) => <B>(fab: Free<E, (a: A) => B>) => Free<E, B>
-```
-
-Added in v0.1.3
-
-# chain
-
-**Signature**
-
-```ts
-<E, A, B>(f: (a: A) => Free<E, B>) => (ma: Free<E, A>) => Free<E, B>
-```
-
-Added in v0.1.3
-
-# flatten
-
-**Signature**
-
-```ts
-<E, A>(mma: Free<E, Free<E, A>>) => Free<E, A>
-```
-
-Added in v0.1.3
-
-# foldFree
-
-Perform folding of a free monad using given natural transformation as an interpreter
-
-**Signature**
-
-```ts
-export function foldFree<M extends URIS3>(M: Monad3<M>): FoldFree3<M>
-export function foldFree<M extends URIS2>(M: Monad2<M>): FoldFree2<M>
-export function foldFree<M extends URIS2, L>(M: Monad2C<M, L>): FoldFree2C<M, L>
-export function foldFree<M extends URIS>(
-  M: Monad1<M>
-): <F extends URIS, A>(nt: <X>(fa: Kind<F, X>) => Kind<M, X>, fa: Free<F, A>) => Kind<M, A>
-export function foldFree<M>(M: Monad<M>): <F, A>(nt: <X>(fa: HKT<F, X>) => HKT<M, X>, fa: Free<F, A>) => HKT<M, A> { ... }
-```
-
-Added in v0.1.3
-
-# free
+## free
 
 Monad instance for Free
 
 **Signature**
 
 ```ts
-export const free: Monad2<URI> = ...
+export declare const free: Monad2<'Free'>
 ```
 
 Added in v0.1.3
 
-# hoistFree
+# model
 
-Use a natural transformation to change the generating type constructor of a free monad
+## Free (type alias)
 
 **Signature**
 
 ```ts
-export function hoistFree<F extends URIS3 = never, G extends URIS3 = never>(
-  nt: <U, L, A>(fa: Kind3<F, U, L, A>) => Kind3<G, U, L, A>
-): <A>(fa: Free<F, A>) => Free<G, A>
-export function hoistFree<F extends URIS2 = never, G extends URIS2 = never>(
-  nt: <L, A>(fa: Kind2<F, L, A>) => Kind2<G, L, A>
-): <A>(fa: Free<F, A>) => Free<G, A>
-export function hoistFree<F extends URIS = never, G extends URIS = never>(
-  nt: <A>(fa: Kind<F, A>) => Kind<G, A>
-): <A>(fa: Free<F, A>) => Free<G, A>
-export function hoistFree<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(fa: Free<F, A>) => Free<G, A> { ... }
+export type Free<F, A> = Pure<F, A> | Impure<F, A, any>
 ```
 
 Added in v0.1.3
 
-# isImpure
+# utils
+
+## isImpure
 
 Check if given Free instance is Impure
 
 **Signature**
 
 ```ts
-export const isImpure = <F, A>(fa: Free<F, A>): fa is Impure<F, A, any> => ...
+export declare const isImpure: <F, A>(fa: Free<F, A>) => fa is Impure<F, A, any>
 ```
 
 Added in v0.1.3
 
-# isPure
+## isPure
 
 Check if given Free instance is Pure
 
 **Signature**
 
 ```ts
-export const isPure = <F, A>(fa: Free<F, A>): fa is Pure<F, A> => ...
-```
-
-Added in v0.1.3
-
-# liftF
-
-Lift an impure value described by the generating type constructor `F` into the free monad
-
-**Signature**
-
-```ts
-export const liftF = <F, A>(fa: HKT<F, A>): Free<F, A> => impure(fa, a => ...
-```
-
-Added in v0.1.3
-
-# map
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => B) => <E>(fa: Free<E, A>) => Free<E, B>
+export declare const isPure: <F, A>(fa: Free<F, A>) => fa is Pure<F, A>
 ```
 
 Added in v0.1.3

--- a/docs/modules/IOOption.ts.md
+++ b/docs/modules/IOOption.ts.md
@@ -4,7 +4,7 @@ nav_order: 12
 parent: Modules
 ---
 
-# IOOption overview
+## IOOption overview
 
 Added in v0.1.14
 
@@ -12,53 +12,479 @@ Added in v0.1.14
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [IOOption (interface)](#iooption-interface)
-- [URI (type alias)](#uri-type-alias)
-- [URI](#uri)
-- [alt](#alt)
-- [ap](#ap)
-- [apFirst](#apfirst)
-- [apSecond](#apsecond)
-- [chain](#chain)
-- [chainFirst](#chainfirst)
-- [chainOptionK](#chainoptionk)
-- [compact](#compact)
-- [filter](#filter)
-- [filterMap](#filtermap)
-- [flatten](#flatten)
-- [fold](#fold)
-- [fromIO](#fromio)
-- [fromIOEither](#fromioeither)
-- [fromNullable](#fromnullable)
-- [fromOption](#fromoption)
-- [fromOptionK](#fromoptionk)
-- [getApplyMonoid](#getapplymonoid)
-- [getApplySemigroup](#getapplysemigroup)
-- [getOrElse](#getorelse)
-- [ioOption](#iooption)
-- [map](#map)
-- [mapNullable](#mapnullable)
-- [none](#none)
-- [partition](#partition)
-- [partitionMap](#partitionmap)
-- [separate](#separate)
-- [some](#some)
-- [toNullable](#tonullable)
-- [toUndefined](#toundefined)
+- [Alt](#alt)
+  - [alt](#alt)
+- [Alternative](#alternative)
+  - [zero](#zero)
+- [Applicative](#applicative)
+  - [of](#of)
+- [Apply](#apply)
+  - [ap](#ap)
+  - [apFirst](#apfirst)
+  - [apSecond](#apsecond)
+- [Compactable](#compactable)
+  - [compact](#compact)
+  - [separate](#separate)
+- [Filterable](#filterable)
+  - [filter](#filter)
+  - [filterMap](#filtermap)
+  - [partition](#partition)
+  - [partitionMap](#partitionmap)
+- [Functor](#functor)
+  - [map](#map)
+- [Monad](#monad)
+  - [chain](#chain)
+  - [chainFirst](#chainfirst)
+  - [chainOptionK](#chainoptionk)
+  - [flatten](#flatten)
+- [combinators](#combinators)
+  - [mapNullable](#mapnullable)
+- [constructors](#constructors)
+  - [fromIO](#fromio)
+  - [fromIOEither](#fromioeither)
+  - [fromNullable](#fromnullable)
+  - [fromOption](#fromoption)
+  - [fromOptionK](#fromoptionk)
+  - [none](#none)
+  - [some](#some)
+- [destructors](#destructors)
+  - [fold](#fold)
+  - [getOrElse](#getorelse)
+  - [toNullable](#tonullable)
+  - [toUndefined](#toundefined)
+- [instances](#instances)
+  - [Alt](#alt-1)
+  - [Alternative](#alternative-1)
+  - [Applicative](#applicative-1)
+  - [Apply](#apply-1)
+  - [Compactable](#compactable-1)
+  - [Filterable](#filterable-1)
+  - [Functor](#functor-1)
+  - [Monad](#monad-1)
+  - [URI](#uri)
+  - [URI (type alias)](#uri-type-alias)
+  - [getApplyMonoid](#getapplymonoid)
+  - [getApplySemigroup](#getapplysemigroup)
+- [model](#model)
+  - [IOOption (interface)](#iooption-interface)
+- [utils](#utils)
+  - [ioOption](#iooption)
 
 ---
 
-# IOOption (interface)
+# Alt
+
+## alt
 
 **Signature**
 
 ```ts
-export interface IOOption<A> extends IO<Option<A>> {}
+export declare const alt: <A>(that: () => IOOption<A>) => (fa: IOOption<A>) => IOOption<A>
+```
+
+Added in v0.1.18
+
+# Alternative
+
+## zero
+
+**Signature**
+
+```ts
+export declare const zero: <A>() => IOOption<A>
+```
+
+Added in v0.1.18
+
+# Applicative
+
+## of
+
+**Signature**
+
+```ts
+export declare const of: <A>(a: A) => IOOption<A>
+```
+
+Added in v0.1.18
+
+# Apply
+
+## ap
+
+**Signature**
+
+```ts
+export declare const ap: <A>(fa: IOOption<A>) => <B>(fab: IOOption<(a: A) => B>) => IOOption<B>
+```
+
+Added in v0.1.18
+
+## apFirst
+
+**Signature**
+
+```ts
+export declare const apFirst: <B>(fb: IOOption<B>) => <A>(fa: IOOption<A>) => IOOption<A>
+```
+
+Added in v0.1.18
+
+## apSecond
+
+**Signature**
+
+```ts
+export declare const apSecond: <B>(fb: IOOption<B>) => <A>(fa: IOOption<A>) => IOOption<B>
+```
+
+Added in v0.1.18
+
+# Compactable
+
+## compact
+
+**Signature**
+
+```ts
+export declare const compact: <A>(fa: IOOption<O.Option<A>>) => IOOption<A>
+```
+
+Added in v0.1.18
+
+## separate
+
+**Signature**
+
+```ts
+export declare const separate: <A, B>(fa: IOOption<Either<A, B>>) => Separated<IOOption<A>, IOOption<B>>
+```
+
+Added in v0.1.18
+
+# Filterable
+
+## filter
+
+**Signature**
+
+```ts
+export declare const filter: {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: IOOption<A>) => IOOption<B>
+  <A>(predicate: Predicate<A>): (fa: IOOption<A>) => IOOption<A>
+}
+```
+
+Added in v0.1.18
+
+## filterMap
+
+**Signature**
+
+```ts
+export declare const filterMap: <A, B>(f: (a: A) => O.Option<B>) => (fa: IOOption<A>) => IOOption<B>
+```
+
+Added in v0.1.18
+
+## partition
+
+**Signature**
+
+```ts
+export declare const partition: {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: IOOption<A>) => Separated<IOOption<A>, IOOption<B>>
+  <A>(predicate: Predicate<A>): (fa: IOOption<A>) => Separated<IOOption<A>, IOOption<A>>
+}
+```
+
+Added in v0.1.18
+
+## partitionMap
+
+**Signature**
+
+```ts
+export declare const partitionMap: <A, B, C>(
+  f: (a: A) => Either<B, C>
+) => (fa: IOOption<A>) => Separated<IOOption<B>, IOOption<C>>
+```
+
+Added in v0.1.18
+
+# Functor
+
+## map
+
+**Signature**
+
+```ts
+export declare const map: <A, B>(f: (a: A) => B) => (fa: IOOption<A>) => IOOption<B>
+```
+
+Added in v0.1.18
+
+# Monad
+
+## chain
+
+**Signature**
+
+```ts
+export declare const chain: <A, B>(f: (a: A) => IOOption<B>) => (ma: IOOption<A>) => IOOption<B>
+```
+
+Added in v0.1.18
+
+## chainFirst
+
+**Signature**
+
+```ts
+export declare const chainFirst: <A, B>(f: (a: A) => IOOption<B>) => (ma: IOOption<A>) => IOOption<A>
+```
+
+Added in v0.1.18
+
+## chainOptionK
+
+**Signature**
+
+```ts
+export declare const chainOptionK: <A, B>(f: (a: A) => O.Option<B>) => (ma: IOOption<A>) => IOOption<B>
 ```
 
 Added in v0.1.14
 
-# URI (type alias)
+## flatten
+
+**Signature**
+
+```ts
+export declare const flatten: <A>(mma: IOOption<IOOption<A>>) => IOOption<A>
+```
+
+Added in v0.1.18
+
+# combinators
+
+## mapNullable
+
+**Signature**
+
+```ts
+export declare const mapNullable: <A, B>(f: (a: A) => B) => (ma: IOOption<A>) => IOOption<B>
+```
+
+Added in v0.1.14
+
+# constructors
+
+## fromIO
+
+**Signature**
+
+```ts
+export declare const fromIO: <A = never>(ma: IO<A>) => IOOption<A>
+```
+
+Added in v0.1.14
+
+## fromIOEither
+
+**Signature**
+
+```ts
+export declare const fromIOEither: <A>(ma: IOEither<any, A>) => IOOption<A>
+```
+
+Added in v0.1.14
+
+## fromNullable
+
+**Signature**
+
+```ts
+export declare const fromNullable: <A>(a: A) => IOOption<NonNullable<A>>
+```
+
+Added in v0.1.14
+
+## fromOption
+
+**Signature**
+
+```ts
+export declare const fromOption: <A = never>(ma: O.Option<A>) => IOOption<A>
+```
+
+Added in v0.1.14
+
+## fromOptionK
+
+**Signature**
+
+```ts
+export declare const fromOptionK: <A extends unknown[], B>(f: (...a: A) => O.Option<B>) => (...a: A) => IOOption<B>
+```
+
+Added in v0.1.14
+
+## none
+
+**Signature**
+
+```ts
+export declare const none: IOOption<never>
+```
+
+Added in v0.1.14
+
+## some
+
+**Signature**
+
+```ts
+export declare const some: <A = never>(a: A) => IOOption<A>
+```
+
+Added in v0.1.14
+
+# destructors
+
+## fold
+
+**Signature**
+
+```ts
+export declare const fold: <A, B>(onNone: () => IO<B>, onSome: (a: A) => IO<B>) => (ma: IOOption<A>) => IO<B>
+```
+
+Added in v0.1.14
+
+## getOrElse
+
+**Signature**
+
+```ts
+export declare const getOrElse: <A>(onNone: () => IO<A>) => (ma: IOOption<A>) => IO<A>
+```
+
+Added in v0.1.14
+
+## toNullable
+
+**Signature**
+
+```ts
+export declare const toNullable: <A>(ma: IOOption<A>) => IO<A>
+```
+
+Added in v0.1.14
+
+## toUndefined
+
+**Signature**
+
+```ts
+export declare const toUndefined: <A>(ma: IOOption<A>) => IO<A>
+```
+
+Added in v0.1.14
+
+# instances
+
+## Alt
+
+**Signature**
+
+```ts
+export declare const Alt: Alt1<'IOOption'>
+```
+
+Added in v0.1.18
+
+## Alternative
+
+**Signature**
+
+```ts
+export declare const Alternative: Alternative1<'IOOption'>
+```
+
+Added in v0.1.18
+
+## Applicative
+
+**Signature**
+
+```ts
+export declare const Applicative: Applicative1<'IOOption'>
+```
+
+Added in v0.1.18
+
+## Apply
+
+**Signature**
+
+```ts
+export declare const Apply: Apply1<'IOOption'>
+```
+
+Added in v0.1.18
+
+## Compactable
+
+**Signature**
+
+```ts
+export declare const Compactable: Compactable1<'IOOption'>
+```
+
+Added in v0.1.18
+
+## Filterable
+
+**Signature**
+
+```ts
+export declare const Filterable: Filterable1<'IOOption'>
+```
+
+Added in v0.1.18
+
+## Functor
+
+**Signature**
+
+```ts
+export declare const Functor: Functor1<'IOOption'>
+```
+
+Added in v0.1.18
+
+## Monad
+
+**Signature**
+
+```ts
+export declare const Monad: Monad1<'IOOption'>
+```
+
+Added in v0.1.18
+
+## URI
+
+**Signature**
+
+```ts
+export declare const URI: 'IOOption'
+```
+
+Added in v0.1.14
+
+## URI (type alias)
 
 **Signature**
 
@@ -68,312 +494,46 @@ export type URI = typeof URI
 
 Added in v0.1.14
 
-# URI
+## getApplyMonoid
 
 **Signature**
 
 ```ts
-export const URI: "IOOption" = ...
+export declare const getApplyMonoid: <A>(M: Monoid<A>) => Monoid<IOOption<A>>
 ```
 
 Added in v0.1.14
 
-# alt
+## getApplySemigroup
 
 **Signature**
 
 ```ts
-<A>(that: () => IOOption<A>) => (fa: IOOption<A>) => IOOption<A>
+export declare const getApplySemigroup: <A>(S: Semigroup<A>) => Semigroup<IOOption<A>>
 ```
 
 Added in v0.1.14
 
-# ap
+# model
+
+## IOOption (interface)
 
 **Signature**
 
 ```ts
-<A>(fa: IOOption<A>) => <B>(fab: IOOption<(a: A) => B>) => IOOption<B>
+export interface IOOption<A> extends IO<Option<A>> {}
 ```
 
 Added in v0.1.14
 
-# apFirst
+# utils
+
+## ioOption
 
 **Signature**
 
 ```ts
-<B>(fb: IOOption<B>) => <A>(fa: IOOption<A>) => IOOption<A>
-```
-
-Added in v0.1.14
-
-# apSecond
-
-**Signature**
-
-```ts
-<B>(fb: IOOption<B>) => <A>(fa: IOOption<A>) => IOOption<B>
-```
-
-Added in v0.1.14
-
-# chain
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => IOOption<B>) => (ma: IOOption<A>) => IOOption<B>
-```
-
-Added in v0.1.14
-
-# chainFirst
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => IOOption<B>) => (ma: IOOption<A>) => IOOption<A>
-```
-
-Added in v0.1.14
-
-# chainOptionK
-
-**Signature**
-
-```ts
-export function chainOptionK<A, B>(f: (a: A) => Option<B>): (ma: IOOption<A>) => IOOption<B> { ... }
-```
-
-Added in v0.1.14
-
-# compact
-
-**Signature**
-
-```ts
-<A>(fa: IOOption<O.Option<A>>) => IOOption<A>
-```
-
-Added in v0.1.14
-
-# filter
-
-**Signature**
-
-```ts
-{ <A, B>(refinement: Refinement<A, B>): (fa: IOOption<A>) => IOOption<B>; <A>(predicate: Predicate<A>): (fa: IOOption<A>) => IOOption<A>; }
-```
-
-Added in v0.1.14
-
-# filterMap
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => O.Option<B>) => (fa: IOOption<A>) => IOOption<B>
-```
-
-Added in v0.1.14
-
-# flatten
-
-**Signature**
-
-```ts
-<A>(mma: IOOption<IOOption<A>>) => IOOption<A>
-```
-
-Added in v0.1.14
-
-# fold
-
-**Signature**
-
-```ts
-export function fold<A, B>(onNone: () => IO<B>, onSome: (a: A) => IO<B>): (ma: IOOption<A>) => IO<B> { ... }
-```
-
-Added in v0.1.14
-
-# fromIO
-
-**Signature**
-
-```ts
-export const fromIO: <A = never>(ma: IO<A>) => IOOption<A> = ...
-```
-
-Added in v0.1.14
-
-# fromIOEither
-
-**Signature**
-
-```ts
-export function fromIOEither<A>(ma: IOEither<any, A>): IOOption<A> { ... }
-```
-
-Added in v0.1.14
-
-# fromNullable
-
-**Signature**
-
-```ts
-export function fromNullable<A>(a: A): IOOption<NonNullable<A>> { ... }
-```
-
-Added in v0.1.14
-
-# fromOption
-
-**Signature**
-
-```ts
-export const fromOption: <A = never>(ma: Option<A>) => IOOption<A> = ...
-```
-
-Added in v0.1.14
-
-# fromOptionK
-
-**Signature**
-
-```ts
-export function fromOptionK<A extends Array<unknown>, B>(f: (...a: A) => Option<B>): (...a: A) => IOOption<B> { ... }
-```
-
-Added in v0.1.14
-
-# getApplyMonoid
-
-**Signature**
-
-```ts
-export function getApplyMonoid<A>(M: Monoid<A>): Monoid<IOOption<A>> { ... }
-```
-
-Added in v0.1.14
-
-# getApplySemigroup
-
-**Signature**
-
-```ts
-export function getApplySemigroup<A>(S: Semigroup<A>): Semigroup<IOOption<A>> { ... }
-```
-
-Added in v0.1.14
-
-# getOrElse
-
-**Signature**
-
-```ts
-export function getOrElse<A>(onNone: () => IO<A>): (ma: IOOption<A>) => IO<A> { ... }
-```
-
-Added in v0.1.14
-
-# ioOption
-
-**Signature**
-
-```ts
-export const ioOption: Monad1<URI> & Alt1<URI> & MonadIO1<URI> & Filterable1<URI> = ...
-```
-
-Added in v0.1.14
-
-# map
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => B) => (fa: IOOption<A>) => IOOption<B>
-```
-
-Added in v0.1.14
-
-# mapNullable
-
-**Signature**
-
-```ts
-export function mapNullable<A, B>(f: (a: A) => B | null | undefined): (ma: IOOption<A>) => IOOption<B> { ... }
-```
-
-Added in v0.1.14
-
-# none
-
-**Signature**
-
-```ts
-export const none: IOOption<never> = ...
-```
-
-Added in v0.1.14
-
-# partition
-
-**Signature**
-
-```ts
-{ <A, B>(refinement: Refinement<A, B>): (fa: IOOption<A>) => Separated<IOOption<A>, IOOption<B>>; <A>(predicate: Predicate<A>): (fa: IOOption<A>) => Separated<IOOption<A>, IOOption<A>>; }
-```
-
-Added in v0.1.14
-
-# partitionMap
-
-**Signature**
-
-```ts
-<A, B, C>(f: (a: A) => Either<B, C>) => (fa: IOOption<A>) => Separated<IOOption<B>, IOOption<C>>
-```
-
-Added in v0.1.14
-
-# separate
-
-**Signature**
-
-```ts
-<A, B>(fa: IOOption<Either<A, B>>) => Separated<IOOption<A>, IOOption<B>>
-```
-
-Added in v0.1.14
-
-# some
-
-**Signature**
-
-```ts
-export const some: <A = never>(a: A) => IOOption<A> = ...
-```
-
-Added in v0.1.14
-
-# toNullable
-
-**Signature**
-
-```ts
-export function toNullable<A>(ma: IOOption<A>): IO<A | null> { ... }
-```
-
-Added in v0.1.14
-
-# toUndefined
-
-**Signature**
-
-```ts
-export function toUndefined<A>(ma: IOOption<A>): IO<A | undefined> { ... }
+export declare const ioOption: Monad1<'IOOption'> & Alt1<'IOOption'> & MonadIO1<'IOOption'> & Filterable1<'IOOption'>
 ```
 
 Added in v0.1.14

--- a/docs/modules/List.ts.md
+++ b/docs/modules/List.ts.md
@@ -4,7 +4,7 @@ nav_order: 13
 parent: Modules
 ---
 
-# List overview
+## List overview
 
 Adapted from https://github.com/purescript/purescript-lists
 
@@ -14,101 +14,57 @@ Added in v0.1.8
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [Cons (interface)](#cons-interface)
-- [Nil (interface)](#nil-interface)
-- [List (type alias)](#list-type-alias)
-- [URI (type alias)](#uri-type-alias)
-- [URI](#uri)
-- [cons](#cons)
-- [dropLeft](#dropleft)
-- [dropLeftWhile](#dropleftwhile)
-- [findIndex](#findindex)
-- [foldLeft](#foldleft)
-- [foldMap](#foldmap)
-- [fromArray](#fromarray)
-- [getEq](#geteq)
-- [head](#head)
-- [isCons](#iscons)
-- [isNil](#isnil)
-- [list](#list)
-- [map](#map)
-- [nil](#nil)
-- [of](#of)
-- [reduce](#reduce)
-- [reduceRight](#reduceright)
-- [reverse](#reverse)
-- [tail](#tail)
-- [toArray](#toarray)
-- [toReversedArray](#toreversedarray)
+- [Applicative](#applicative)
+  - [of](#of)
+- [Foldable](#foldable)
+  - [foldMap](#foldmap)
+  - [reduce](#reduce)
+  - [reduceRight](#reduceright)
+- [Functor](#functor)
+  - [map](#map)
+- [combinators](#combinators)
+  - [dropLeft](#dropleft)
+  - [reverse](#reverse)
+- [constructors](#constructors)
+  - [cons](#cons)
+  - [fromArray](#fromarray)
+  - [nil](#nil)
+- [destructors](#destructors)
+  - [foldLeft](#foldleft)
+  - [head](#head)
+  - [tail](#tail)
+  - [toArray](#toarray)
+  - [toReversedArray](#toreversedarray)
+- [instances](#instances)
+  - [Foldable](#foldable-1)
+  - [Functor](#functor-1)
+  - [Traversable](#traversable)
+  - [URI](#uri)
+  - [URI (type alias)](#uri-type-alias)
+  - [getEq](#geteq)
+  - [list](#list)
+- [model](#model)
+  - [Cons (interface)](#cons-interface)
+  - [List (type alias)](#list-type-alias)
+  - [Nil (interface)](#nil-interface)
+- [utils](#utils)
+  - [dropLeftWhile](#dropleftwhile)
+  - [findIndex](#findindex)
+  - [isCons](#iscons)
+  - [isNil](#isnil)
 
 ---
 
-# Cons (interface)
+# Applicative
+
+## of
+
+Creates a list with a single element.
 
 **Signature**
 
 ```ts
-export interface Cons<A> {
-  readonly type: 'Cons'
-  readonly head: A
-  readonly tail: List<A>
-  readonly length: number
-}
-```
-
-Added in v0.1.8
-
-# Nil (interface)
-
-**Signature**
-
-```ts
-export interface Nil {
-  readonly type: 'Nil'
-  readonly length: 0
-}
-```
-
-Added in v0.1.8
-
-# List (type alias)
-
-**Signature**
-
-```ts
-export type List<A> = Nil | Cons<A>
-```
-
-Added in v0.1.8
-
-# URI (type alias)
-
-**Signature**
-
-```ts
-export type URI = typeof URI
-```
-
-Added in v0.1.8
-
-# URI
-
-**Signature**
-
-```ts
-export const URI: "List" = ...
-```
-
-Added in v0.1.8
-
-# cons
-
-Attaches an element to the front of a list.
-
-**Signature**
-
-```ts
-export function cons<A>(head: A, tail: List<A>): List<A> { ... }
+export declare const of: <A>(head: A) => List<A>
 ```
 
 **Example**
@@ -116,19 +72,65 @@ export function cons<A>(head: A, tail: List<A>): List<A> { ... }
 ```ts
 import * as L from 'fp-ts-contrib/lib/List'
 
-assert.deepStrictEqual(L.cons('a', L.nil), { type: 'Cons', head: 'a', tail: L.nil, length: 1 })
+assert.deepStrictEqual(L.of('a'), L.cons('a', L.nil))
 ```
 
 Added in v0.1.8
 
-# dropLeft
+# Foldable
+
+## foldMap
+
+**Signature**
+
+```ts
+export declare const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: List<A>) => M
+```
+
+Added in v0.1.18
+
+## reduce
+
+**Signature**
+
+```ts
+export declare const reduce: <A, B>(b: B, f: (b: B, a: A) => B) => (fa: List<A>) => B
+```
+
+Added in v0.1.18
+
+## reduceRight
+
+**Signature**
+
+```ts
+export declare const reduceRight: <A, B>(b: B, f: (a: A, b: B) => B) => (fa: List<A>) => B
+```
+
+Added in v0.1.18
+
+# Functor
+
+## map
+
+**Signature**
+
+```ts
+export declare const map: <A, B>(f: (a: A) => B) => (fa: List<A>) => List<B>
+```
+
+Added in v0.1.18
+
+# combinators
+
+## dropLeft
 
 Drops the specified number of elements from the front of a list.
 
 **Signature**
 
 ```ts
-export function dropLeft(n: number): <A>(fa: List<A>) => List<A> { ... }
+export declare const dropLeft: (n: number) => <A>(fa: List<A>) => List<A>
 ```
 
 **Example**
@@ -143,15 +145,329 @@ assert.deepStrictEqual(L.dropLeft(3)(L.cons(1, L.of(2))), L.nil)
 
 Added in v0.1.8
 
-# dropLeftWhile
+## reverse
+
+Reverse a list.
+
+**Signature**
+
+```ts
+export declare const reverse: <A>(fa: List<A>) => List<A>
+```
+
+**Example**
+
+```ts
+import * as L from 'fp-ts-contrib/lib/List'
+
+assert.deepStrictEqual(L.reverse(L.cons(1, L.cons(2, L.of(3)))), L.cons(3, L.cons(2, L.of(1))))
+```
+
+Added in v0.1.8
+
+# constructors
+
+## cons
+
+Attaches an element to the front of a list.
+
+**Signature**
+
+```ts
+export declare const cons: <A>(head: A, tail: List<A>) => List<A>
+```
+
+**Example**
+
+```ts
+import * as L from 'fp-ts-contrib/lib/List'
+
+assert.deepStrictEqual(L.cons('a', L.nil), { type: 'Cons', head: 'a', tail: L.nil, length: 1 })
+```
+
+Added in v0.1.8
+
+## fromArray
+
+Creates a list from an array
+
+**Signature**
+
+```ts
+export declare const fromArray: <A>(as: A[]) => List<A>
+```
+
+**Example**
+
+```ts
+import * as L from 'fp-ts-contrib/lib/List'
+
+assert.deepStrictEqual(L.fromArray([]), L.nil)
+assert.deepStrictEqual(L.fromArray(['a', 'b']), L.cons('a', L.of('b')))
+```
+
+Added in v0.1.8
+
+## nil
+
+**Signature**
+
+```ts
+export declare const nil: List<never>
+```
+
+Added in v0.1.8
+
+# destructors
+
+## foldLeft
+
+Breaks a list into its first element and the remaining elements.
+
+**Signature**
+
+```ts
+export declare const foldLeft: <A, B>(onNil: () => B, onCons: (head: A, tail: List<A>) => B) => (fa: List<A>) => B
+```
+
+**Example**
+
+```ts
+import * as L from 'fp-ts-contrib/lib/List'
+
+const len: <A>(as: L.List<A>) => number = L.foldLeft(
+  () => 0,
+  (_, tail) => 1 + len(tail)
+)
+assert.deepStrictEqual(len(L.cons('a', L.of('b'))), 2)
+```
+
+Added in v0.1.8
+
+## head
+
+Gets the first element in a list, or `None` if the list is empty.
+
+**Signature**
+
+```ts
+export declare const head: <A>(fa: List<A>) => O.Option<A>
+```
+
+**Example**
+
+```ts
+import * as O from 'fp-ts/lib/Option'
+import * as L from 'fp-ts-contrib/lib/List'
+
+assert.deepStrictEqual(L.head(L.nil), O.none)
+assert.deepStrictEqual(L.head(L.cons('x', L.of('a'))), O.some('x'))
+```
+
+Added in v0.1.8
+
+## tail
+
+Gets all but the first element of a list, or `None` if the list is empty.
+
+**Signature**
+
+```ts
+export declare const tail: <A>(fa: List<A>) => O.Option<List<A>>
+```
+
+**Example**
+
+```ts
+import * as O from 'fp-ts/lib/Option'
+import * as L from 'fp-ts-contrib/lib/List'
+
+assert.deepStrictEqual(L.tail(L.nil), O.none)
+assert.deepStrictEqual(L.tail(L.of('a')), O.some(L.nil))
+assert.deepStrictEqual(L.tail(L.cons('x', L.of('a'))), O.some(L.of('a')))
+```
+
+Added in v0.1.8
+
+## toArray
+
+Gets an array from a list.
+
+**Signature**
+
+```ts
+export declare const toArray: <A>(fa: List<A>) => A[]
+```
+
+**Example**
+
+```ts
+import * as L from 'fp-ts-contrib/lib/List'
+
+assert.deepStrictEqual(L.toArray(L.cons('a', L.of('b'))), ['a', 'b'])
+```
+
+Added in v0.1.8
+
+## toReversedArray
+
+Gets an array from a list in a reversed order.
+
+**Signature**
+
+```ts
+export declare const toReversedArray: <A>(fa: List<A>) => A[]
+```
+
+**Example**
+
+```ts
+import * as L from 'fp-ts-contrib/lib/List'
+
+assert.deepStrictEqual(L.toReversedArray(L.cons('a', L.of('b'))), ['b', 'a'])
+```
+
+Added in v0.1.8
+
+# instances
+
+## Foldable
+
+**Signature**
+
+```ts
+export declare const Foldable: Foldable1<'List'>
+```
+
+Added in v0.1.18
+
+## Functor
+
+**Signature**
+
+```ts
+export declare const Functor: Functor1<'List'>
+```
+
+Added in v0.1.18
+
+## Traversable
+
+**Signature**
+
+```ts
+export declare const Traversable: Traversable1<'List'>
+```
+
+Added in v0.1.18
+
+## URI
+
+**Signature**
+
+```ts
+export declare const URI: 'List'
+```
+
+Added in v0.1.8
+
+## URI (type alias)
+
+**Signature**
+
+```ts
+export type URI = typeof URI
+```
+
+Added in v0.1.8
+
+## getEq
+
+Derives an `Eq` over the `List` of a given element type from the `Eq` of that type.
+The derived `Eq` defines two lists as equal if all elements of both lists
+are compared equal pairwise with the given `E`. In case of lists of different
+lengths, the result is non equality.
+
+**Signature**
+
+```ts
+export declare const getEq: <A>(E: Eq.Eq<A>) => Eq.Eq<List<A>>
+```
+
+**Example**
+
+```ts
+import { eqString } from 'fp-ts/lib/Eq'
+import * as L from 'fp-ts-contrib/lib/List'
+
+const E = L.getEq(eqString)
+assert.strictEqual(E.equals(L.cons('a', L.of('b')), L.cons('a', L.of('b'))), true)
+assert.strictEqual(E.equals(L.of('x'), L.nil), false)
+```
+
+Added in v0.1.8
+
+## list
+
+**Signature**
+
+```ts
+export declare const list: Functor1<'List'> & Foldable1<'List'> & Traversable1<'List'>
+```
+
+Added in v0.1.8
+
+# model
+
+## Cons (interface)
+
+**Signature**
+
+```ts
+export interface Cons<A> {
+  readonly type: 'Cons'
+  readonly head: A
+  readonly tail: List<A>
+  readonly length: number
+}
+```
+
+Added in v0.1.8
+
+## List (type alias)
+
+**Signature**
+
+```ts
+export type List<A> = Nil | Cons<A>
+```
+
+Added in v0.1.8
+
+## Nil (interface)
+
+**Signature**
+
+```ts
+export interface Nil {
+  readonly type: 'Nil'
+  readonly length: 0
+}
+```
+
+Added in v0.1.8
+
+# utils
+
+## dropLeftWhile
 
 Drops those elements from the front of a list which match a predicate.
 
 **Signature**
 
 ```ts
-export function dropLeftWhile<A, B extends A>(refinement: Refinement<A, B>): (fa: List<A>) => List<B>
-export function dropLeftWhile<A>(predicate: Predicate<A>): (fa: List<A>) => List<A> { ... }
+export declare function dropLeftWhile<A, B extends A>(refinement: Refinement<A, B>): (fa: List<A>) => List<B>
+export declare function dropLeftWhile<A>(predicate: Predicate<A>): (fa: List<A>) => List<A>
 ```
 
 **Example**
@@ -167,14 +483,14 @@ assert.deepStrictEqual(L.dropLeftWhile(isLTThree)(L.cons(1, L.of(2))), L.nil)
 
 Added in v0.1.8
 
-# findIndex
+## findIndex
 
 Finds the first index for which a predicate holds.
 
 **Signature**
 
 ```ts
-export function findIndex<A>(predicate: Predicate<A>): (fa: List<A>) => O.Option<number> { ... }
+export declare const findIndex: <A>(predicate: Predicate<A>) => (fa: List<A>) => O.Option<number>
 ```
 
 **Example**
@@ -192,117 +508,14 @@ assert.deepStrictEqual(findIndexEven(L.of(1)), O.none)
 
 Added in v0.1.8
 
-# foldLeft
-
-Breaks a list into its first element and the remaining elements.
-
-**Signature**
-
-```ts
-export function foldLeft<A, B>(onNil: () => B, onCons: (head: A, tail: List<A>) => B): (fa: List<A>) => B { ... }
-```
-
-**Example**
-
-```ts
-import * as L from 'fp-ts-contrib/lib/List'
-
-const len: <A>(as: L.List<A>) => number = L.foldLeft(
-  () => 0,
-  (_, tail) => 1 + len(tail)
-)
-assert.deepStrictEqual(len(L.cons('a', L.of('b'))), 2)
-```
-
-Added in v0.1.8
-
-# foldMap
-
-**Signature**
-
-```ts
-;<M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: List<A>) => M
-```
-
-Added in v0.1.8
-
-# fromArray
-
-Creates a list from an array
-
-**Signature**
-
-```ts
-export function fromArray<A>(as: Array<A>): List<A> { ... }
-```
-
-**Example**
-
-```ts
-import * as L from 'fp-ts-contrib/lib/List'
-
-assert.deepStrictEqual(L.fromArray([]), L.nil)
-assert.deepStrictEqual(L.fromArray(['a', 'b']), L.cons('a', L.of('b')))
-```
-
-Added in v0.1.8
-
-# getEq
-
-Derives an `Eq` over the `List` of a given element type from the `Eq` of that type.
-The derived `Eq` defines two lists as equal if all elements of both lists
-are compared equal pairwise with the given `E`. In case of lists of different
-lengths, the result is non equality.
-
-**Signature**
-
-```ts
-export function getEq<A>(E: Eq.Eq<A>): Eq.Eq<List<A>> { ... }
-```
-
-**Example**
-
-```ts
-import { eqString } from 'fp-ts/lib/Eq'
-import * as L from 'fp-ts-contrib/lib/List'
-
-const E = L.getEq(eqString)
-assert.strictEqual(E.equals(L.cons('a', L.of('b')), L.cons('a', L.of('b'))), true)
-assert.strictEqual(E.equals(L.of('x'), L.nil), false)
-```
-
-Added in v0.1.8
-
-# head
-
-Gets the first element in a list, or `None` if the list is empty.
-
-**Signature**
-
-```ts
-export function head<A>(fa: List<A>): O.Option<A> { ... }
-```
-
-**Example**
-
-```ts
-import * as O from 'fp-ts/lib/Option'
-import * as L from 'fp-ts-contrib/lib/List'
-
-assert.deepStrictEqual(L.head(L.nil), O.none)
-assert.deepStrictEqual(L.head(L.cons('x', L.of('a'))), O.some('x'))
-```
-
-Added in v0.1.8
-
-# isCons
+## isCons
 
 Tests whether a list is a non empty list.
 
 **Signature**
 
 ```ts
-export function isCons<A>(a: List<A>): a is Cons<A> { ... }
+export declare const isCons: <A>(a: List<A>) => a is Cons<A>
 ```
 
 **Example**
@@ -316,14 +529,14 @@ assert.strictEqual(L.isCons(L.of(1)), true)
 
 Added in v0.1.8
 
-# isNil
+## isNil
 
 Tests whether a list is an empty list.
 
 **Signature**
 
 ```ts
-export function isNil<A>(a: List<A>): a is Nil { ... }
+export declare const isNil: <A>(a: List<A>) => a is Nil
 ```
 
 **Example**
@@ -333,159 +546,6 @@ import * as L from 'fp-ts-contrib/lib/List'
 
 assert.strictEqual(L.isNil(L.nil), true)
 assert.strictEqual(L.isNil(L.of(6)), false)
-```
-
-Added in v0.1.8
-
-# list
-
-**Signature**
-
-```ts
-export const list: Functor1<URI> & Foldable1<URI> & Traversable1<URI> = ...
-```
-
-Added in v0.1.8
-
-# map
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => B) => (fa: List<A>) => List<B>
-```
-
-Added in v0.1.8
-
-# nil
-
-**Signature**
-
-```ts
-export const nil: List<never> = ...
-```
-
-Added in v0.1.8
-
-# of
-
-Creates a list with a single element.
-
-**Signature**
-
-```ts
-export function of<A>(head: A): List<A> { ... }
-```
-
-**Example**
-
-```ts
-import * as L from 'fp-ts-contrib/lib/List'
-
-assert.deepStrictEqual(L.of('a'), L.cons('a', L.nil))
-```
-
-Added in v0.1.8
-
-# reduce
-
-**Signature**
-
-```ts
-;<A, B>(b: B, f: (b: B, a: A) => B) => (fa: List<A>) => B
-```
-
-Added in v0.1.8
-
-# reduceRight
-
-**Signature**
-
-```ts
-;<A, B>(b: B, f: (a: A, b: B) => B) => (fa: List<A>) => B
-```
-
-Added in v0.1.8
-
-# reverse
-
-Reverse a list.
-
-**Signature**
-
-```ts
-export function reverse<A>(fa: List<A>): List<A> { ... }
-```
-
-**Example**
-
-```ts
-import * as L from 'fp-ts-contrib/lib/List'
-
-assert.deepStrictEqual(L.reverse(L.cons(1, L.cons(2, L.of(3)))), L.cons(3, L.cons(2, L.of(1))))
-```
-
-Added in v0.1.8
-
-# tail
-
-Gets all but the first element of a list, or `None` if the list is empty.
-
-**Signature**
-
-```ts
-export function tail<A>(fa: List<A>): O.Option<List<A>> { ... }
-```
-
-**Example**
-
-```ts
-import * as O from 'fp-ts/lib/Option'
-import * as L from 'fp-ts-contrib/lib/List'
-
-assert.deepStrictEqual(L.tail(L.nil), O.none)
-assert.deepStrictEqual(L.tail(L.of('a')), O.some(L.nil))
-assert.deepStrictEqual(L.tail(L.cons('x', L.of('a'))), O.some(L.of('a')))
-```
-
-Added in v0.1.8
-
-# toArray
-
-Gets an array from a list.
-
-**Signature**
-
-```ts
-export function toArray<A>(fa: List<A>): Array<A> { ... }
-```
-
-**Example**
-
-```ts
-import * as L from 'fp-ts-contrib/lib/List'
-
-assert.deepStrictEqual(L.toArray(L.cons('a', L.of('b'))), ['a', 'b'])
-```
-
-Added in v0.1.8
-
-# toReversedArray
-
-Gets an array from a list in a reversed order.
-
-**Signature**
-
-```ts
-export function toReversedArray<A>(fa: List<A>): Array<A> { ... }
-```
-
-**Example**
-
-```ts
-import * as L from 'fp-ts-contrib/lib/List'
-
-assert.deepStrictEqual(L.toReversedArray(L.cons('a', L.of('b'))), ['b', 'a'])
 ```
 
 Added in v0.1.8

--- a/docs/modules/List.ts.md
+++ b/docs/modules/List.ts.md
@@ -22,6 +22,8 @@ Added in v0.1.8
   - [reduceRight](#reduceright)
 - [Functor](#functor)
   - [map](#map)
+- [Traversable](#traversable)
+  - [sequence](#sequence)
 - [combinators](#combinators)
   - [dropLeft](#dropleft)
   - [reverse](#reverse)
@@ -38,7 +40,7 @@ Added in v0.1.8
 - [instances](#instances)
   - [Foldable](#foldable-1)
   - [Functor](#functor-1)
-  - [Traversable](#traversable)
+  - [Traversable](#traversable-1)
   - [URI](#uri)
   - [URI (type alias)](#uri-type-alias)
   - [getEq](#geteq)
@@ -117,6 +119,18 @@ Added in v0.1.18
 
 ```ts
 export declare const map: <A, B>(f: (a: A) => B) => (fa: List<A>) => List<B>
+```
+
+Added in v0.1.18
+
+# Traversable
+
+## sequence
+
+**Signature**
+
+```ts
+export declare const sequence: Sequence1<'List'>
 ```
 
 Added in v0.1.18

--- a/docs/modules/ReaderIO.ts.md
+++ b/docs/modules/ReaderIO.ts.md
@@ -4,7 +4,7 @@ nav_order: 14
 parent: Modules
 ---
 
-# ReaderIO overview
+## ReaderIO overview
 
 Added in v0.1.0
 
@@ -12,29 +12,279 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [ReaderIO (interface)](#readerio-interface)
-- [URI (type alias)](#uri-type-alias)
-- [URI](#uri)
-- [ap](#ap)
-- [apFirst](#apfirst)
-- [apSecond](#apsecond)
-- [ask](#ask)
-- [asks](#asks)
-- [chain](#chain)
-- [chainFirst](#chainfirst)
-- [chainIOK](#chainiok)
-- [flatten](#flatten)
-- [fromIO](#fromio)
-- [fromIOK](#fromiok)
-- [fromReader](#fromreader)
-- [local](#local)
-- [map](#map)
-- [readerIO](#readerio)
-- [run](#run)
+- [Applicative](#applicative)
+  - [of](#of)
+- [Apply](#apply)
+  - [ap](#ap)
+  - [apFirst](#apfirst)
+  - [apSecond](#apsecond)
+- [Functor](#functor)
+  - [map](#map)
+- [Monad](#monad)
+  - [chain](#chain)
+  - [chainFirst](#chainfirst)
+  - [chainIOK](#chainiok)
+  - [flatten](#flatten)
+- [combinators](#combinators)
+  - [local](#local)
+- [constructors](#constructors)
+  - [ask](#ask)
+  - [asks](#asks)
+  - [fromIO](#fromio)
+  - [fromIOK](#fromiok)
+  - [fromReader](#fromreader)
+- [instances](#instances)
+  - [Applicative](#applicative-1)
+  - [Apply](#apply-1)
+  - [Functor](#functor-1)
+  - [Monad](#monad-1)
+  - [URI](#uri)
+  - [URI (type alias)](#uri-type-alias)
+  - [readerIO](#readerio)
+- [model](#model)
+  - [ReaderIO (interface)](#readerio-interface)
+- [utils](#utils)
+  - [run](#run)
 
 ---
 
-# ReaderIO (interface)
+# Applicative
+
+## of
+
+**Signature**
+
+```ts
+export declare const of: <E, A>(a: A) => ReaderIO<E, A>
+```
+
+Added in v0.1.18
+
+# Apply
+
+## ap
+
+**Signature**
+
+```ts
+export declare const ap: <E, A>(fa: ReaderIO<E, A>) => <B>(fab: ReaderIO<E, (a: A) => B>) => ReaderIO<E, B>
+```
+
+Added in v0.1.18
+
+## apFirst
+
+**Signature**
+
+```ts
+export declare const apFirst: <E, B>(fb: ReaderIO<E, B>) => <A>(fa: ReaderIO<E, A>) => ReaderIO<E, A>
+```
+
+Added in v0.1.18
+
+## apSecond
+
+**Signature**
+
+```ts
+export declare const apSecond: <E, B>(fb: ReaderIO<E, B>) => <A>(fa: ReaderIO<E, A>) => ReaderIO<E, B>
+```
+
+Added in v0.1.18
+
+# Functor
+
+## map
+
+**Signature**
+
+```ts
+export declare const map: <A, B>(f: (a: A) => B) => <E>(fa: ReaderIO<E, A>) => ReaderIO<E, B>
+```
+
+Added in v0.1.18
+
+# Monad
+
+## chain
+
+**Signature**
+
+```ts
+export declare const chain: <E, A, B>(f: (a: A) => ReaderIO<E, B>) => (ma: ReaderIO<E, A>) => ReaderIO<E, B>
+```
+
+Added in v0.1.18
+
+## chainFirst
+
+**Signature**
+
+```ts
+export declare const chainFirst: <E, A, B>(f: (a: A) => ReaderIO<E, B>) => (ma: ReaderIO<E, A>) => ReaderIO<E, A>
+```
+
+Added in v0.1.18
+
+## chainIOK
+
+**Signature**
+
+```ts
+export declare const chainIOK: <A, B>(f: (a: A) => I.IO<B>) => <R>(ma: ReaderIO<R, A>) => ReaderIO<R, B>
+```
+
+Added in v0.1.10
+
+## flatten
+
+**Signature**
+
+```ts
+export declare const flatten: <E, A>(mma: ReaderIO<E, ReaderIO<E, A>>) => ReaderIO<E, A>
+```
+
+Added in v0.1.18
+
+# combinators
+
+## local
+
+**Signature**
+
+```ts
+export declare const local: <Q, R>(f: (f: Q) => R) => <A>(ma: ReaderIO<R, A>) => ReaderIO<Q, A>
+```
+
+Added in v0.1.0
+
+# constructors
+
+## ask
+
+**Signature**
+
+```ts
+export declare const ask: <R>() => ReaderIO<R, R>
+```
+
+Added in v0.1.0
+
+## asks
+
+**Signature**
+
+```ts
+export declare const asks: <R, A>(f: (r: R) => A) => ReaderIO<R, A>
+```
+
+Added in v0.1.0
+
+## fromIO
+
+**Signature**
+
+```ts
+export declare const fromIO: <R, A>(ma: I.IO<A>) => ReaderIO<R, A>
+```
+
+Added in v0.1.0
+
+## fromIOK
+
+**Signature**
+
+```ts
+export declare const fromIOK: <A extends unknown[], B>(f: (...a: A) => I.IO<B>) => <R>(...a: A) => ReaderIO<R, B>
+```
+
+Added in v0.1.10
+
+## fromReader
+
+**Signature**
+
+```ts
+export declare const fromReader: <R, A>(ma: Reader<R, A>) => ReaderIO<R, A>
+```
+
+Added in v0.1.0
+
+# instances
+
+## Applicative
+
+**Signature**
+
+```ts
+export declare const Applicative: Applicative2<'ReaderIO'>
+```
+
+Added in v0.1.18
+
+## Apply
+
+**Signature**
+
+```ts
+export declare const Apply: Apply2<'ReaderIO'>
+```
+
+Added in v0.1.18
+
+## Functor
+
+**Signature**
+
+```ts
+export declare const Functor: Functor2<'ReaderIO'>
+```
+
+Added in v0.1.18
+
+## Monad
+
+**Signature**
+
+```ts
+export declare const Monad: Monad2<'ReaderIO'>
+```
+
+Added in v0.1.18
+
+## URI
+
+**Signature**
+
+```ts
+export declare const URI: 'ReaderIO'
+```
+
+Added in v0.1.0
+
+## URI (type alias)
+
+**Signature**
+
+```ts
+export type URI = typeof URI
+```
+
+Added in v0.1.0
+
+## readerIO
+
+**Signature**
+
+```ts
+export declare const readerIO: Monad2<'ReaderIO'>
+```
+
+Added in v0.1.0
+
+# model
+
+## ReaderIO (interface)
 
 **Signature**
 
@@ -46,182 +296,14 @@ export interface ReaderIO<R, A> {
 
 Added in v0.1.0
 
-# URI (type alias)
+# utils
+
+## run
 
 **Signature**
 
 ```ts
-export type URI = typeof URI
-```
-
-Added in v0.1.0
-
-# URI
-
-**Signature**
-
-```ts
-export const URI: "ReaderIO" = ...
-```
-
-Added in v0.1.0
-
-# ap
-
-**Signature**
-
-```ts
-<E, A>(fa: ReaderIO<E, A>) => <B>(fab: ReaderIO<E, (a: A) => B>) => ReaderIO<E, B>
-```
-
-Added in v0.1.0
-
-# apFirst
-
-**Signature**
-
-```ts
-<E, B>(fb: ReaderIO<E, B>) => <A>(fa: ReaderIO<E, A>) => ReaderIO<E, A>
-```
-
-Added in v0.1.0
-
-# apSecond
-
-**Signature**
-
-```ts
-<E, B>(fb: ReaderIO<E, B>) => <A>(fa: ReaderIO<E, A>) => ReaderIO<E, B>
-```
-
-Added in v0.1.0
-
-# ask
-
-**Signature**
-
-```ts
-export const ask: <R>() => ReaderIO<R, R> = ...
-```
-
-Added in v0.1.0
-
-# asks
-
-**Signature**
-
-```ts
-export const asks: <R, A>(f: (r: R) => A) => ReaderIO<R, A> = ...
-```
-
-Added in v0.1.0
-
-# chain
-
-**Signature**
-
-```ts
-<E, A, B>(f: (a: A) => ReaderIO<E, B>) => (ma: ReaderIO<E, A>) => ReaderIO<E, B>
-```
-
-Added in v0.1.0
-
-# chainFirst
-
-**Signature**
-
-```ts
-<E, A, B>(f: (a: A) => ReaderIO<E, B>) => (ma: ReaderIO<E, A>) => ReaderIO<E, A>
-```
-
-Added in v0.1.0
-
-# chainIOK
-
-**Signature**
-
-```ts
-export function chainIOK<A, B>(f: (a: A) => IO<B>): <R>(ma: ReaderIO<R, A>) => ReaderIO<R, B> { ... }
-```
-
-Added in v0.1.10
-
-# flatten
-
-**Signature**
-
-```ts
-<E, A>(mma: ReaderIO<E, ReaderIO<E, A>>) => ReaderIO<E, A>
-```
-
-Added in v0.1.0
-
-# fromIO
-
-**Signature**
-
-```ts
-export const fromIO: <R, A>(ma: IO<A>) => ReaderIO<R, A> = ...
-```
-
-Added in v0.1.0
-
-# fromIOK
-
-**Signature**
-
-```ts
-export function fromIOK<A extends Array<unknown>, B>(f: (...a: A) => IO<B>): <R>(...a: A) => ReaderIO<R, B> { ... }
-```
-
-Added in v0.1.10
-
-# fromReader
-
-**Signature**
-
-```ts
-export const fromReader: <R, A>(ma: Reader<R, A>) => ReaderIO<R, A> = ...
-```
-
-Added in v0.1.0
-
-# local
-
-**Signature**
-
-```ts
-export function local<Q, R>(f: (f: Q) => R): <A>(ma: ReaderIO<R, A>) => ReaderIO<Q, A> { ... }
-```
-
-Added in v0.1.0
-
-# map
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => B) => <E>(fa: ReaderIO<E, A>) => ReaderIO<E, B>
-```
-
-Added in v0.1.0
-
-# readerIO
-
-**Signature**
-
-```ts
-export const readerIO: Monad2<URI> = ...
-```
-
-Added in v0.1.0
-
-# run
-
-**Signature**
-
-```ts
-export function run<R, A>(ma: ReaderIO<R, A>, r: R): A { ... }
+export declare const run: <R, A>(ma: ReaderIO<R, A>, r: R) => A
 ```
 
 Added in v0.1.0

--- a/docs/modules/RegExp.ts.md
+++ b/docs/modules/RegExp.ts.md
@@ -4,7 +4,7 @@ nav_order: 15
 parent: Modules
 ---
 
-# RegExp overview
+## RegExp overview
 
 Provides regular expression matching.
 
@@ -16,21 +16,24 @@ Added in v0.1.8
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [match](#match)
-- [split](#split)
-- [sub](#sub)
-- [test](#test)
+- [utils](#utils)
+  - [match](#match)
+  - [split](#split)
+  - [sub](#sub)
+  - [test](#test)
 
 ---
 
-# match
+# utils
+
+## match
 
 Returns the list of subexpression matches, or `None` if the match fails.
 
 **Signature**
 
 ```ts
-export function match(r: RegExp): (s: string) => O.Option<RegExpMatchArray> { ... }
+export declare const match: (r: RegExp) => (s: string) => O.Option<RegExpMatchArray>
 ```
 
 **Example**
@@ -47,7 +50,7 @@ assert.deepStrictEqual(myMatch('foo'), O.none)
 
 Added in v0.1.8
 
-# split
+## split
 
 Splits a string based on a regular expression. The regular expression
 should identify one delimiter.
@@ -55,7 +58,7 @@ should identify one delimiter.
 **Signature**
 
 ```ts
-export function split(r: RegExp): (s: string) => NonEmptyArray<string> { ... }
+export declare const split: (r: RegExp) => (s: string) => NonEmptyArray<string>
 ```
 
 **Example**
@@ -70,7 +73,7 @@ assert.deepStrictEqual(splitByHash('noHashes'), ['noHashes'])
 
 Added in v0.1.8
 
-# sub
+## sub
 
 Replaces every occurance of the given regular expression
 with the replacement string.
@@ -78,7 +81,7 @@ with the replacement string.
 **Signature**
 
 ```ts
-export function sub(r: RegExp, replacement: string): (s: string) => string { ... }
+export declare const sub: (r: RegExp, replacement: string) => (s: string) => string
 ```
 
 **Example**
@@ -92,7 +95,7 @@ assert.strictEqual(sanitiseSpaces('foo bar owl'), 'foo_bar_owl')
 
 Added in v0.1.8
 
-# test
+## test
 
 Returns `true` if the string matches the regular expression,
 otherwise `false`.
@@ -100,7 +103,7 @@ otherwise `false`.
 **Signature**
 
 ```ts
-export function test(r: RegExp): Predicate<string> { ... }
+export declare const test: (r: RegExp) => Predicate<string>
 ```
 
 **Example**

--- a/docs/modules/Semialign/NonEmptyArray.ts.md
+++ b/docs/modules/Semialign/NonEmptyArray.ts.md
@@ -4,7 +4,7 @@ nav_order: 17
 parent: Modules
 ---
 
-# NonEmptyArray overview
+## NonEmptyArray overview
 
 Added in v0.1.0
 
@@ -12,18 +12,21 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [semialignNonEmptyArray](#semialignnonemptyarray)
+- [utils](#utils)
+  - [semialignNonEmptyArray](#semialignnonemptyarray)
 
 ---
 
-# semialignNonEmptyArray
+# utils
+
+## semialignNonEmptyArray
 
 `Semialign` instance for `NonEmptyArray`.
 
 **Signature**
 
 ```ts
-export const semialignNonEmptyArray: Semialign1<URI> = ...
+export declare const semialignNonEmptyArray: Semialign1<'NonEmptyArray'>
 ```
 
 Added in v0.1.0

--- a/docs/modules/Semialign/index.ts.md
+++ b/docs/modules/Semialign/index.ts.md
@@ -4,7 +4,7 @@ nav_order: 16
 parent: Modules
 ---
 
-# index overview
+## index overview
 
 The `Semialign` type class represents functors supporting a zip operation that takes the
 union of non-uniform shapes.
@@ -27,15 +27,18 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [Semialign (interface)](#semialign-interface)
-- [Semialign1 (interface)](#semialign1-interface)
-- [Semialign2 (interface)](#semialign2-interface)
-- [Semialign2C (interface)](#semialign2c-interface)
-- [Semialign3 (interface)](#semialign3-interface)
+- [utils](#utils)
+  - [Semialign (interface)](#semialign-interface)
+  - [Semialign1 (interface)](#semialign1-interface)
+  - [Semialign2 (interface)](#semialign2-interface)
+  - [Semialign2C (interface)](#semialign2c-interface)
+  - [Semialign3 (interface)](#semialign3-interface)
 
 ---
 
-# Semialign (interface)
+# utils
+
+## Semialign (interface)
 
 **Signature**
 
@@ -48,7 +51,7 @@ export interface Semialign<F> extends Functor<F> {
 
 Added in v0.1.0
 
-# Semialign1 (interface)
+## Semialign1 (interface)
 
 **Signature**
 
@@ -61,7 +64,7 @@ export interface Semialign1<F extends URIS> extends Functor1<F> {
 
 Added in v0.1.0
 
-# Semialign2 (interface)
+## Semialign2 (interface)
 
 **Signature**
 
@@ -74,7 +77,7 @@ export interface Semialign2<F extends URIS2> extends Functor2<F> {
 
 Added in v0.1.0
 
-# Semialign2C (interface)
+## Semialign2C (interface)
 
 **Signature**
 
@@ -87,7 +90,7 @@ export interface Semialign2C<F extends URIS2, L> extends Functor2C<F, L> {
 
 Added in v0.1.0
 
-# Semialign3 (interface)
+## Semialign3 (interface)
 
 **Signature**
 

--- a/docs/modules/StateEither.ts.md
+++ b/docs/modules/StateEither.ts.md
@@ -4,7 +4,7 @@ nav_order: 18
 parent: Modules
 ---
 
-# StateEither overview
+## StateEither overview
 
 Added in v0.1.12
 
@@ -12,37 +12,378 @@ Added in v0.1.12
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [StateEither (interface)](#stateeither-interface)
-- [URI (type alias)](#uri-type-alias)
-- [URI](#uri)
-- [ap](#ap)
-- [apFirst](#apfirst)
-- [apSecond](#apsecond)
-- [chain](#chain)
-- [chainEitherK](#chaineitherk)
-- [chainFirst](#chainfirst)
-- [evalState](#evalstate)
-- [execState](#execstate)
-- [filterOrElse](#filterorelse)
-- [flatten](#flatten)
-- [fromEither](#fromeither)
-- [fromEitherK](#fromeitherk)
-- [fromOption](#fromoption)
-- [fromPredicate](#frompredicate)
-- [get](#get)
-- [gets](#gets)
-- [left](#left)
-- [leftState](#leftstate)
-- [map](#map)
-- [modify](#modify)
-- [put](#put)
-- [right](#right)
-- [rightState](#rightstate)
-- [stateEither](#stateeither)
+- [Applicative](#applicative)
+  - [of](#of)
+- [Apply](#apply)
+  - [ap](#ap)
+  - [apFirst](#apfirst)
+  - [apSecond](#apsecond)
+- [Functor](#functor)
+  - [map](#map)
+- [Monad](#monad)
+  - [chain](#chain)
+  - [chainFirst](#chainfirst)
+  - [flatten](#flatten)
+- [combinators](#combinators)
+  - [filterOrElse](#filterorelse)
+- [constructors](#constructors)
+  - [fromEither](#fromeither)
+  - [fromEitherK](#fromeitherk)
+  - [fromOption](#fromoption)
+  - [fromPredicate](#frompredicate)
+  - [get](#get)
+  - [gets](#gets)
+  - [left](#left)
+  - [leftState](#leftstate)
+  - [modify](#modify)
+  - [put](#put)
+  - [right](#right)
+  - [rightState](#rightstate)
+- [instances](#instances)
+  - [Applicative](#applicative-1)
+  - [Apply](#apply-1)
+  - [Functor](#functor-1)
+  - [Monad](#monad-1)
+  - [MonadThrow](#monadthrow)
+  - [URI](#uri)
+  - [URI (type alias)](#uri-type-alias)
+  - [stateEither](#stateeither)
+- [model](#model)
+  - [StateEither (interface)](#stateeither-interface)
+- [utils](#utils)
+  - [chainEitherK](#chaineitherk)
+  - [evalState](#evalstate)
+  - [execState](#execstate)
 
 ---
 
-# StateEither (interface)
+# Applicative
+
+## of
+
+**Signature**
+
+```ts
+export declare const of: <R, E, A>(a: A) => StateEither<R, E, A>
+```
+
+Added in v0.1.18
+
+# Apply
+
+## ap
+
+**Signature**
+
+```ts
+export declare const ap: <R, E, A>(
+  fa: StateEither<R, E, A>
+) => <B>(fab: StateEither<R, E, (a: A) => B>) => StateEither<R, E, B>
+```
+
+Added in v0.1.18
+
+## apFirst
+
+**Signature**
+
+```ts
+export declare const apFirst: <R, E, B>(
+  fb: StateEither<R, E, B>
+) => <A>(fa: StateEither<R, E, A>) => StateEither<R, E, A>
+```
+
+Added in v0.1.18
+
+## apSecond
+
+**Signature**
+
+```ts
+export declare const apSecond: <R, E, B>(
+  fb: StateEither<R, E, B>
+) => <A>(fa: StateEither<R, E, A>) => StateEither<R, E, B>
+```
+
+Added in v0.1.18
+
+# Functor
+
+## map
+
+**Signature**
+
+```ts
+export declare const map: <A, B>(f: (a: A) => B) => <R, E>(fa: StateEither<R, E, A>) => StateEither<R, E, B>
+```
+
+Added in v0.1.18
+
+# Monad
+
+## chain
+
+**Signature**
+
+```ts
+export declare const chain: <R, E, A, B>(
+  f: (a: A) => StateEither<R, E, B>
+) => (ma: StateEither<R, E, A>) => StateEither<R, E, B>
+```
+
+Added in v0.1.18
+
+## chainFirst
+
+**Signature**
+
+```ts
+export declare const chainFirst: <R, E, A, B>(
+  f: (a: A) => StateEither<R, E, B>
+) => (ma: StateEither<R, E, A>) => StateEither<R, E, A>
+```
+
+Added in v0.1.18
+
+## flatten
+
+**Signature**
+
+```ts
+export declare const flatten: <R, E, A>(mma: StateEither<R, E, StateEither<R, E, A>>) => StateEither<R, E, A>
+```
+
+Added in v0.1.18
+
+# combinators
+
+## filterOrElse
+
+**Signature**
+
+```ts
+export declare const filterOrElse: {
+  <E, A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <R>(
+    ma: StateEither<R, E, A>
+  ) => StateEither<R, E, B>
+  <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <R>(ma: StateEither<R, E, A>) => StateEither<R, E, A>
+}
+```
+
+Added in v0.1.18
+
+# constructors
+
+## fromEither
+
+**Signature**
+
+```ts
+export declare const fromEither: <S, E, A>(ma: E.Either<E, A>) => StateEither<S, E, A>
+```
+
+Added in v0.1.0
+
+## fromEitherK
+
+**Signature**
+
+```ts
+export declare const fromEitherK: <E, A extends unknown[], B>(
+  f: (...a: A) => E.Either<E, B>
+) => <S>(...a: A) => StateEither<S, E, B>
+```
+
+Added in v0.1.12
+
+## fromOption
+
+**Signature**
+
+```ts
+export declare const fromOption: <E>(onNone: () => E) => <R, A>(ma: Option<A>) => StateEither<R, E, A>
+```
+
+Added in v0.1.18
+
+## fromPredicate
+
+**Signature**
+
+```ts
+export declare const fromPredicate: {
+  <E, A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <R>(a: A) => StateEither<R, E, B>
+  <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <R>(a: A) => StateEither<R, E, A>
+}
+```
+
+Added in v0.1.18
+
+## get
+
+**Signature**
+
+```ts
+export declare const get: <S, E = never>() => StateEither<S, E, S>
+```
+
+Added in v0.1.12
+
+## gets
+
+**Signature**
+
+```ts
+export declare const gets: <S, E = never, A = never>(f: (s: S) => A) => StateEither<S, E, A>
+```
+
+Added in v0.1.12
+
+## left
+
+**Signature**
+
+```ts
+export declare const left: <S, E, A = never>(e: E) => StateEither<S, E, A>
+```
+
+Added in v0.1.12
+
+## leftState
+
+**Signature**
+
+```ts
+export declare const leftState: <S, E = never, A = never>(me: State<S, E>) => StateEither<S, E, A>
+```
+
+Added in v0.1.12
+
+## modify
+
+**Signature**
+
+```ts
+export declare const modify: <S, E = never>(f: (s: S) => S) => StateEither<S, E, void>
+```
+
+Added in v0.1.12
+
+## put
+
+**Signature**
+
+```ts
+export declare const put: <S, E = never>(s: S) => StateEither<S, E, void>
+```
+
+Added in v0.1.12
+
+## right
+
+**Signature**
+
+```ts
+export declare const right: <S, E = never, A = never>(a: A) => StateEither<S, E, A>
+```
+
+Added in v0.1.12
+
+## rightState
+
+**Signature**
+
+```ts
+export declare const rightState: <S, E = never, A = never>(ma: State<S, A>) => StateEither<S, E, A>
+```
+
+Added in v0.1.12
+
+# instances
+
+## Applicative
+
+**Signature**
+
+```ts
+export declare const Applicative: Applicative3<'StateEither'>
+```
+
+Added in v0.1.18
+
+## Apply
+
+**Signature**
+
+```ts
+export declare const Apply: Apply3<'StateEither'>
+```
+
+Added in v0.1.18
+
+## Functor
+
+**Signature**
+
+```ts
+export declare const Functor: Functor3<'StateEither'>
+```
+
+Added in v0.1.18
+
+## Monad
+
+**Signature**
+
+```ts
+export declare const Monad: Monad3<'StateEither'>
+```
+
+Added in v0.1.18
+
+## MonadThrow
+
+**Signature**
+
+```ts
+export declare const MonadThrow: MonadThrow3<'StateEither'>
+```
+
+Added in v0.1.18
+
+## URI
+
+**Signature**
+
+```ts
+export declare const URI: 'StateEither'
+```
+
+Added in v0.1.12
+
+## URI (type alias)
+
+**Signature**
+
+```ts
+export type URI = typeof URI
+```
+
+Added in v0.1.12
+
+## stateEither
+
+**Signature**
+
+```ts
+export declare const stateEither: Monad3<'StateEither'> & MonadThrow3<'StateEither'>
+```
+
+Added in v0.1.12
+
+# model
+
+## StateEither (interface)
 
 **Signature**
 
@@ -54,266 +395,36 @@ export interface StateEither<S, E, A> {
 
 Added in v0.1.12
 
-# URI (type alias)
+# utils
+
+## chainEitherK
 
 **Signature**
 
 ```ts
-export type URI = typeof URI
-```
-
-Added in v0.1.12
-
-# URI
-
-**Signature**
-
-```ts
-export const URI: "StateEither" = ...
-```
-
-Added in v0.1.12
-
-# ap
-
-**Signature**
-
-```ts
-<R, E, A>(fa: StateEither<R, E, A>) => <B>(fab: StateEither<R, E, (a: A) => B>) => StateEither<R, E, B>
-```
-
-Added in v0.1.12
-
-# apFirst
-
-**Signature**
-
-```ts
-<R, E, B>(fb: StateEither<R, E, B>) => <A>(fa: StateEither<R, E, A>) => StateEither<R, E, A>
-```
-
-Added in v0.1.12
-
-# apSecond
-
-**Signature**
-
-```ts
-<R, E, B>(fb: StateEither<R, E, B>) => <A>(fa: StateEither<R, E, A>) => StateEither<R, E, B>
-```
-
-Added in v0.1.12
-
-# chain
-
-**Signature**
-
-```ts
-<R, E, A, B>(f: (a: A) => StateEither<R, E, B>) => (ma: StateEither<R, E, A>) => StateEither<R, E, B>
-```
-
-Added in v0.1.12
-
-# chainEitherK
-
-**Signature**
-
-```ts
-export function chainEitherK<E, A, B>(
+export declare const chainEitherK: <E, A, B>(
   f: (a: A) => E.Either<E, B>
-): <S>(ma: StateEither<S, E, A>) => StateEither<S, E, B> { ... }
+) => <S>(ma: StateEither<S, E, A>) => StateEither<S, E, B>
 ```
 
 Added in v0.1.12
 
-# chainFirst
+## evalState
 
 **Signature**
 
 ```ts
-<R, E, A, B>(f: (a: A) => StateEither<R, E, B>) => (ma: StateEither<R, E, A>) => StateEither<R, E, A>
+export declare const evalState: <S, E, A>(ma: StateEither<S, E, A>, s: S) => E.Either<E, A>
 ```
 
 Added in v0.1.12
 
-# evalState
+## execState
 
 **Signature**
 
 ```ts
-export const evalState: <S, E, A>(ma: StateEither<S, E, A>, s: S) => E.Either<E, A> = ...
-```
-
-Added in v0.1.12
-
-# execState
-
-**Signature**
-
-```ts
-export const execState: <S, E, A>(ma: StateEither<S, E, A>, s: S) => E.Either<E, S> = ...
-```
-
-Added in v0.1.12
-
-# filterOrElse
-
-**Signature**
-
-```ts
-{ <E, A, B>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <R>(ma: StateEither<R, E, A>) => StateEither<R, E, B>; <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <R>(ma: StateEither<R, E, A>) => StateEither<R, E, A>; }
-```
-
-Added in v0.1.12
-
-# flatten
-
-**Signature**
-
-```ts
-<R, E, A>(mma: StateEither<R, E, StateEither<R, E, A>>) => StateEither<R, E, A>
-```
-
-Added in v0.1.12
-
-# fromEither
-
-**Signature**
-
-```ts
-export const fromEither: <S, E, A>(ma: E.Either<E, A>) => StateEither<S, E, A> = ...
-```
-
-Added in v0.1.0
-
-# fromEitherK
-
-**Signature**
-
-```ts
-export function fromEitherK<E, A extends Array<unknown>, B>(
-  f: (...a: A) => E.Either<E, B>
-): <S>(...a: A) => StateEither<S, E, B> { ... }
-```
-
-Added in v0.1.12
-
-# fromOption
-
-**Signature**
-
-```ts
-<E>(onNone: () => E) => <R, A>(ma: Option<A>) => StateEither<R, E, A>
-```
-
-Added in v0.1.12
-
-# fromPredicate
-
-**Signature**
-
-```ts
-{ <E, A, B>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <U>(a: A) => StateEither<U, E, B>; <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <R>(a: A) => StateEither<R, E, A>; }
-```
-
-Added in v0.1.12
-
-# get
-
-**Signature**
-
-```ts
-export const get: <S, E = never>() => StateEither<S, E, S> = ...
-```
-
-Added in v0.1.12
-
-# gets
-
-**Signature**
-
-```ts
-export const gets: <S, E = never, A = never>(f: (s: S) => A) => StateEither<S, E, A> = ...
-```
-
-Added in v0.1.12
-
-# left
-
-**Signature**
-
-```ts
-export function left<S, E, A = never>(e: E): StateEither<S, E, A> { ... }
-```
-
-Added in v0.1.12
-
-# leftState
-
-**Signature**
-
-```ts
-export function leftState<S, E = never, A = never>(me: State<S, E>): StateEither<S, E, A> { ... }
-```
-
-Added in v0.1.12
-
-# map
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => B) => <R, E>(fa: StateEither<R, E, A>) => StateEither<R, E, B>
-```
-
-Added in v0.1.12
-
-# modify
-
-**Signature**
-
-```ts
-export const modify: <S, E = never>(f: (s: S) => S) => StateEither<S, E, void> = ...
-```
-
-Added in v0.1.12
-
-# put
-
-**Signature**
-
-```ts
-export const put: <S, E = never>(s: S) => StateEither<S, E, void> = ...
-```
-
-Added in v0.1.12
-
-# right
-
-**Signature**
-
-```ts
-export const right: <S, E = never, A = never>(a: A) => StateEither<S, E, A> = ...
-```
-
-Added in v0.1.12
-
-# rightState
-
-**Signature**
-
-```ts
-export const rightState: <S, E = never, A = never>(ma: State<S, A>) => StateEither<S, E, A> = ...
-```
-
-Added in v0.1.12
-
-# stateEither
-
-**Signature**
-
-```ts
-export const stateEither: Monad3<URI> & MonadThrow3<URI> = ...
+export declare const execState: <S, E, A>(ma: StateEither<S, E, A>, s: S) => E.Either<E, S>
 ```
 
 Added in v0.1.12

--- a/docs/modules/StateIO.ts.md
+++ b/docs/modules/StateIO.ts.md
@@ -4,7 +4,7 @@ nav_order: 19
 parent: Modules
 ---
 
-# StateIO overview
+## StateIO overview
 
 Added in v0.1.0
 
@@ -12,32 +12,289 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [StateIO (interface)](#stateio-interface)
-- [URI (type alias)](#uri-type-alias)
-- [URI](#uri)
-- [ap](#ap)
-- [apFirst](#apfirst)
-- [apSecond](#apsecond)
-- [chain](#chain)
-- [chainFirst](#chainfirst)
-- [chainIOK](#chainiok)
-- [evalState](#evalstate)
-- [execState](#execstate)
-- [flatten](#flatten)
-- [fromIO](#fromio)
-- [fromIOK](#fromiok)
-- [fromState](#fromstate)
-- [get](#get)
-- [gets](#gets)
-- [map](#map)
-- [modify](#modify)
-- [put](#put)
-- [run](#run)
-- [stateIO](#stateio)
+- [Applicative](#applicative)
+  - [of](#of)
+- [Apply](#apply)
+  - [ap](#ap)
+  - [apFirst](#apfirst)
+  - [apSecond](#apsecond)
+- [Functor](#functor)
+  - [map](#map)
+- [Monad](#monad)
+  - [chain](#chain)
+  - [chainFirst](#chainfirst)
+  - [chainIOK](#chainiok)
+  - [flatten](#flatten)
+- [constructors](#constructors)
+  - [fromIO](#fromio)
+  - [fromIOK](#fromiok)
+  - [fromState](#fromstate)
+  - [get](#get)
+  - [gets](#gets)
+  - [modify](#modify)
+  - [put](#put)
+- [instances](#instances)
+  - [Applicative](#applicative-1)
+  - [Apply](#apply-1)
+  - [Functor](#functor-1)
+  - [Monad](#monad-1)
+  - [URI](#uri)
+  - [URI (type alias)](#uri-type-alias)
+  - [stateIO](#stateio)
+- [model](#model)
+  - [StateIO (interface)](#stateio-interface)
+- [utils](#utils)
+  - [evalState](#evalstate)
+  - [execState](#execstate)
+  - [run](#run)
 
 ---
 
-# StateIO (interface)
+# Applicative
+
+## of
+
+**Signature**
+
+```ts
+export declare const of: <E, A>(a: A) => StateIO<E, A>
+```
+
+Added in v0.1.18
+
+# Apply
+
+## ap
+
+**Signature**
+
+```ts
+export declare const ap: <E, A>(fa: StateIO<E, A>) => <B>(fab: StateIO<E, (a: A) => B>) => StateIO<E, B>
+```
+
+Added in v0.1.18
+
+## apFirst
+
+**Signature**
+
+```ts
+export declare const apFirst: <E, B>(fb: StateIO<E, B>) => <A>(fa: StateIO<E, A>) => StateIO<E, A>
+```
+
+Added in v0.1.18
+
+## apSecond
+
+**Signature**
+
+```ts
+export declare const apSecond: <E, B>(fb: StateIO<E, B>) => <A>(fa: StateIO<E, A>) => StateIO<E, B>
+```
+
+Added in v0.1.18
+
+# Functor
+
+## map
+
+**Signature**
+
+```ts
+export declare const map: <A, B>(f: (a: A) => B) => <E>(fa: StateIO<E, A>) => StateIO<E, B>
+```
+
+Added in v0.1.18
+
+# Monad
+
+## chain
+
+**Signature**
+
+```ts
+export declare const chain: <E, A, B>(f: (a: A) => StateIO<E, B>) => (ma: StateIO<E, A>) => StateIO<E, B>
+```
+
+Added in v0.1.18
+
+## chainFirst
+
+**Signature**
+
+```ts
+export declare const chainFirst: <E, A, B>(f: (a: A) => StateIO<E, B>) => (ma: StateIO<E, A>) => StateIO<E, A>
+```
+
+Added in v0.1.18
+
+## chainIOK
+
+**Signature**
+
+```ts
+export declare const chainIOK: <A, B>(f: (a: A) => I.IO<B>) => <R>(ma: StateIO<R, A>) => StateIO<R, B>
+```
+
+Added in v0.1.10
+
+## flatten
+
+**Signature**
+
+```ts
+export declare const flatten: <E, A>(mma: StateIO<E, StateIO<E, A>>) => StateIO<E, A>
+```
+
+Added in v0.1.18
+
+# constructors
+
+## fromIO
+
+**Signature**
+
+```ts
+export declare const fromIO: <S, A>(ma: I.IO<A>) => StateIO<S, A>
+```
+
+Added in v0.1.0
+
+## fromIOK
+
+**Signature**
+
+```ts
+export declare const fromIOK: <A extends unknown[], B>(f: (...a: A) => I.IO<B>) => <R>(...a: A) => StateIO<R, B>
+```
+
+Added in v0.1.10
+
+## fromState
+
+**Signature**
+
+```ts
+export declare const fromState: <S, A>(ma: State<S, A>) => StateIO<S, A>
+```
+
+Added in v0.1.0
+
+## get
+
+**Signature**
+
+```ts
+export declare const get: <S>() => StateIO<S, S>
+```
+
+Added in v0.1.0
+
+## gets
+
+**Signature**
+
+```ts
+export declare const gets: <S, A>(f: (s: S) => A) => StateIO<S, A>
+```
+
+Added in v0.1.0
+
+## modify
+
+**Signature**
+
+```ts
+export declare const modify: <S>(f: (s: S) => S) => StateIO<S, void>
+```
+
+Added in v0.1.0
+
+## put
+
+**Signature**
+
+```ts
+export declare const put: <S>(s: S) => StateIO<S, void>
+```
+
+Added in v0.1.0
+
+# instances
+
+## Applicative
+
+**Signature**
+
+```ts
+export declare const Applicative: Applicative2<'StateIO'>
+```
+
+Added in v0.1.18
+
+## Apply
+
+**Signature**
+
+```ts
+export declare const Apply: Apply2<'StateIO'>
+```
+
+Added in v0.1.18
+
+## Functor
+
+**Signature**
+
+```ts
+export declare const Functor: Functor2<'StateIO'>
+```
+
+Added in v0.1.18
+
+## Monad
+
+**Signature**
+
+```ts
+export declare const Monad: Monad2<'StateIO'>
+```
+
+Added in v0.1.18
+
+## URI
+
+**Signature**
+
+```ts
+export declare const URI: 'StateIO'
+```
+
+Added in v0.1.0
+
+## URI (type alias)
+
+**Signature**
+
+```ts
+export type URI = typeof URI
+```
+
+Added in v0.1.0
+
+## stateIO
+
+**Signature**
+
+```ts
+export declare const stateIO: Monad2<'StateIO'>
+```
+
+Added in v0.1.0
+
+# model
+
+## StateIO (interface)
 
 **Signature**
 
@@ -49,212 +306,34 @@ export interface StateIO<S, A> {
 
 Added in v0.1.0
 
-# URI (type alias)
+# utils
+
+## evalState
 
 **Signature**
 
 ```ts
-export type URI = typeof URI
+export declare const evalState: <S, A>(ma: StateIO<S, A>, s: S) => I.IO<A>
 ```
 
 Added in v0.1.0
 
-# URI
+## execState
 
 **Signature**
 
 ```ts
-export const URI: "StateIO" = ...
+export declare const execState: <S, A>(ma: StateIO<S, A>, s: S) => I.IO<S>
 ```
 
 Added in v0.1.0
 
-# ap
+## run
 
 **Signature**
 
 ```ts
-<E, A>(fa: StateIO<E, A>) => <B>(fab: StateIO<E, (a: A) => B>) => StateIO<E, B>
-```
-
-Added in v0.1.0
-
-# apFirst
-
-**Signature**
-
-```ts
-<E, B>(fb: StateIO<E, B>) => <A>(fa: StateIO<E, A>) => StateIO<E, A>
-```
-
-Added in v0.1.0
-
-# apSecond
-
-**Signature**
-
-```ts
-<E, B>(fb: StateIO<E, B>) => <A>(fa: StateIO<E, A>) => StateIO<E, B>
-```
-
-Added in v0.1.0
-
-# chain
-
-**Signature**
-
-```ts
-<E, A, B>(f: (a: A) => StateIO<E, B>) => (ma: StateIO<E, A>) => StateIO<E, B>
-```
-
-Added in v0.1.0
-
-# chainFirst
-
-**Signature**
-
-```ts
-<E, A, B>(f: (a: A) => StateIO<E, B>) => (ma: StateIO<E, A>) => StateIO<E, A>
-```
-
-Added in v0.1.0
-
-# chainIOK
-
-**Signature**
-
-```ts
-export function chainIOK<A, B>(f: (a: A) => IO<B>): <R>(ma: StateIO<R, A>) => StateIO<R, B> { ... }
-```
-
-Added in v0.1.10
-
-# evalState
-
-**Signature**
-
-```ts
-export const evalState: <S, A>(ma: StateIO<S, A>, s: S) => IO<A> = ...
-```
-
-Added in v0.1.0
-
-# execState
-
-**Signature**
-
-```ts
-export const execState: <S, A>(ma: StateIO<S, A>, s: S) => IO<S> = ...
-```
-
-Added in v0.1.0
-
-# flatten
-
-**Signature**
-
-```ts
-<E, A>(mma: StateIO<E, StateIO<E, A>>) => StateIO<E, A>
-```
-
-Added in v0.1.0
-
-# fromIO
-
-**Signature**
-
-```ts
-export const fromIO: <S, A>(ma: IO<A>) => StateIO<S, A> = ...
-```
-
-Added in v0.1.0
-
-# fromIOK
-
-**Signature**
-
-```ts
-export function fromIOK<A extends Array<unknown>, B>(f: (...a: A) => IO<B>): <R>(...a: A) => StateIO<R, B> { ... }
-```
-
-Added in v0.1.10
-
-# fromState
-
-**Signature**
-
-```ts
-export const fromState: <S, A>(ma: State<S, A>) => StateIO<S, A> = ...
-```
-
-Added in v0.1.0
-
-# get
-
-**Signature**
-
-```ts
-export const get: <S>() => StateIO<S, S> = ...
-```
-
-Added in v0.1.0
-
-# gets
-
-**Signature**
-
-```ts
-export const gets: <S, A>(f: (s: S) => A) => StateIO<S, A> = ...
-```
-
-Added in v0.1.0
-
-# map
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => B) => <E>(fa: StateIO<E, A>) => StateIO<E, B>
-```
-
-Added in v0.1.0
-
-# modify
-
-**Signature**
-
-```ts
-export const modify: <S>(f: (s: S) => S) => StateIO<S, void> = ...
-```
-
-Added in v0.1.0
-
-# put
-
-**Signature**
-
-```ts
-export const put: <S>(s: S) => StateIO<S, void> = ...
-```
-
-Added in v0.1.0
-
-# run
-
-**Signature**
-
-```ts
-export function run<S, A>(ma: StateIO<S, A>, s: S): A { ... }
-```
-
-Added in v0.1.0
-
-# stateIO
-
-**Signature**
-
-```ts
-export const stateIO: Monad2<URI> = ...
+export declare const run: <S, A>(ma: StateIO<S, A>, s: S) => A
 ```
 
 Added in v0.1.0

--- a/docs/modules/StateTaskEither.ts.md
+++ b/docs/modules/StateTaskEither.ts.md
@@ -4,7 +4,7 @@ nav_order: 20
 parent: Modules
 ---
 
-# StateTaskEither overview
+## StateTaskEither overview
 
 Added in v0.1.0
 
@@ -12,49 +12,513 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [StateTaskEither (interface)](#statetaskeither-interface)
-- [URI (type alias)](#uri-type-alias)
-- [URI](#uri)
-- [ap](#ap)
-- [apFirst](#apfirst)
-- [apSecond](#apsecond)
-- [chain](#chain)
-- [chainEitherK](#chaineitherk)
-- [chainFirst](#chainfirst)
-- [chainIOEitherK](#chainioeitherk)
-- [chainTaskEitherK](#chaintaskeitherk)
-- [evalState](#evalstate)
-- [execState](#execstate)
-- [filterOrElse](#filterorelse)
-- [flatten](#flatten)
-- [fromEither](#fromeither)
-- [fromEitherK](#fromeitherk)
-- [fromIOEither](#fromioeither)
-- [fromIOEitherK](#fromioeitherk)
-- [fromOption](#fromoption)
-- [fromPredicate](#frompredicate)
-- [fromTaskEither](#fromtaskeither)
-- [fromTaskEitherK](#fromtaskeitherk)
-- [get](#get)
-- [gets](#gets)
-- [left](#left)
-- [leftIO](#leftio)
-- [leftState](#leftstate)
-- [leftTask](#lefttask)
-- [map](#map)
-- [modify](#modify)
-- [put](#put)
-- [right](#right)
-- [rightIO](#rightio)
-- [rightState](#rightstate)
-- [rightTask](#righttask)
-- [run](#run)
-- [stateTaskEither](#statetaskeither)
-- [stateTaskEitherSeq](#statetaskeitherseq)
+- [Applicative](#applicative)
+  - [of](#of)
+- [Apply](#apply)
+  - [ap](#ap)
+  - [apFirst](#apfirst)
+  - [apSecond](#apsecond)
+- [Functor](#functor)
+  - [map](#map)
+- [Monad](#monad)
+  - [chain](#chain)
+  - [chainEitherK](#chaineitherk)
+  - [chainFirst](#chainfirst)
+  - [chainIOEitherK](#chainioeitherk)
+  - [chainTaskEitherK](#chaintaskeitherk)
+  - [flatten](#flatten)
+- [combinators](#combinators)
+  - [filterOrElse](#filterorelse)
+- [constructors](#constructors)
+  - [fromEither](#fromeither)
+  - [fromEitherK](#fromeitherk)
+  - [fromIOEither](#fromioeither)
+  - [fromIOEitherK](#fromioeitherk)
+  - [fromOption](#fromoption)
+  - [fromPredicate](#frompredicate)
+  - [fromTaskEither](#fromtaskeither)
+  - [fromTaskEitherK](#fromtaskeitherk)
+  - [get](#get)
+  - [gets](#gets)
+  - [left](#left)
+  - [leftIO](#leftio)
+  - [leftState](#leftstate)
+  - [leftTask](#lefttask)
+  - [modify](#modify)
+  - [put](#put)
+  - [right](#right)
+  - [rightIO](#rightio)
+  - [rightState](#rightstate)
+  - [rightTask](#righttask)
+- [instances](#instances)
+  - [Applicative](#applicative-1)
+  - [Apply](#apply-1)
+  - [Functor](#functor-1)
+  - [Monad](#monad-1)
+  - [URI](#uri)
+  - [URI (type alias)](#uri-type-alias)
+  - [stateTaskEither](#statetaskeither)
+  - [stateTaskEitherSeq](#statetaskeitherseq)
+- [model](#model)
+  - [StateTaskEither (interface)](#statetaskeither-interface)
+- [utils](#utils)
+  - [evalState](#evalstate)
+  - [execState](#execstate)
+  - [run](#run)
 
 ---
 
-# StateTaskEither (interface)
+# Applicative
+
+## of
+
+**Signature**
+
+```ts
+export declare const of: <R, E, A>(a: A) => StateTaskEither<R, E, A>
+```
+
+Added in v0.1.18
+
+# Apply
+
+## ap
+
+**Signature**
+
+```ts
+export declare const ap: <R, E, A>(
+  fa: StateTaskEither<R, E, A>
+) => <B>(fab: StateTaskEither<R, E, (a: A) => B>) => StateTaskEither<R, E, B>
+```
+
+Added in v0.1.18
+
+## apFirst
+
+**Signature**
+
+```ts
+export declare const apFirst: <R, E, B>(
+  fb: StateTaskEither<R, E, B>
+) => <A>(fa: StateTaskEither<R, E, A>) => StateTaskEither<R, E, A>
+```
+
+Added in v0.1.18
+
+## apSecond
+
+**Signature**
+
+```ts
+export declare const apSecond: <R, E, B>(
+  fb: StateTaskEither<R, E, B>
+) => <A>(fa: StateTaskEither<R, E, A>) => StateTaskEither<R, E, B>
+```
+
+Added in v0.1.18
+
+# Functor
+
+## map
+
+**Signature**
+
+```ts
+export declare const map: <A, B>(f: (a: A) => B) => <R, E>(fa: StateTaskEither<R, E, A>) => StateTaskEither<R, E, B>
+```
+
+Added in v0.1.18
+
+# Monad
+
+## chain
+
+**Signature**
+
+```ts
+export declare const chain: <R, E, A, B>(
+  f: (a: A) => StateTaskEither<R, E, B>
+) => (ma: StateTaskEither<R, E, A>) => StateTaskEither<R, E, B>
+```
+
+Added in v0.1.18
+
+## chainEitherK
+
+**Signature**
+
+```ts
+export declare const chainEitherK: <E, A, B>(
+  f: (a: A) => Either<E, B>
+) => <S>(ma: StateTaskEither<S, E, A>) => StateTaskEither<S, E, B>
+```
+
+Added in v0.1.10
+
+## chainFirst
+
+**Signature**
+
+```ts
+export declare const chainFirst: <R, E, A, B>(
+  f: (a: A) => StateTaskEither<R, E, B>
+) => (ma: StateTaskEither<R, E, A>) => StateTaskEither<R, E, A>
+```
+
+Added in v0.1.18
+
+## chainIOEitherK
+
+**Signature**
+
+```ts
+export declare const chainIOEitherK: <E, A, B>(
+  f: (a: A) => IOEither<E, B>
+) => <S>(ma: StateTaskEither<S, E, A>) => StateTaskEither<S, E, B>
+```
+
+Added in v0.1.10
+
+## chainTaskEitherK
+
+**Signature**
+
+```ts
+export declare const chainTaskEitherK: <E, A, B>(
+  f: (a: A) => TE.TaskEither<E, B>
+) => <S>(ma: StateTaskEither<S, E, A>) => StateTaskEither<S, E, B>
+```
+
+Added in v0.1.10
+
+## flatten
+
+**Signature**
+
+```ts
+export declare const flatten: <R, E, A>(
+  mma: StateTaskEither<R, E, StateTaskEither<R, E, A>>
+) => StateTaskEither<R, E, A>
+```
+
+Added in v0.1.18
+
+# combinators
+
+## filterOrElse
+
+**Signature**
+
+```ts
+export declare const filterOrElse: {
+  <E, A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <R>(
+    ma: StateTaskEither<R, E, A>
+  ) => StateTaskEither<R, E, B>
+  <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <R>(ma: StateTaskEither<R, E, A>) => StateTaskEither<R, E, A>
+}
+```
+
+Added in v0.1.18
+
+# constructors
+
+## fromEither
+
+**Signature**
+
+```ts
+export declare const fromEither: <R, E, A>(ma: Either<E, A>) => StateTaskEither<R, E, A>
+```
+
+Added in v0.1.18
+
+## fromEitherK
+
+**Signature**
+
+```ts
+export declare const fromEitherK: <E, A extends unknown[], B>(
+  f: (...a: A) => Either<E, B>
+) => <S>(...a: A) => StateTaskEither<S, E, B>
+```
+
+Added in v0.1.10
+
+## fromIOEither
+
+**Signature**
+
+```ts
+export declare const fromIOEither: <S, E, A>(ma: IOEither<E, A>) => StateTaskEither<S, E, A>
+```
+
+Added in v0.1.0
+
+## fromIOEitherK
+
+**Signature**
+
+```ts
+export declare const fromIOEitherK: <E, A extends unknown[], B>(
+  f: (...a: A) => IOEither<E, B>
+) => <S>(...a: A) => StateTaskEither<S, E, B>
+```
+
+Added in v0.1.10
+
+## fromOption
+
+**Signature**
+
+```ts
+export declare const fromOption: <E>(onNone: () => E) => <R, A>(ma: Option<A>) => StateTaskEither<R, E, A>
+```
+
+Added in v0.1.18
+
+## fromPredicate
+
+**Signature**
+
+```ts
+export declare const fromPredicate: {
+  <E, A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <R>(a: A) => StateTaskEither<R, E, B>
+  <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <R>(a: A) => StateTaskEither<R, E, A>
+}
+```
+
+Added in v0.1.18
+
+## fromTaskEither
+
+**Signature**
+
+```ts
+export declare const fromTaskEither: <S, E, A>(ma: TE.TaskEither<E, A>) => StateTaskEither<S, E, A>
+```
+
+Added in v0.1.0
+
+## fromTaskEitherK
+
+**Signature**
+
+```ts
+export declare const fromTaskEitherK: <E, A extends unknown[], B>(
+  f: (...a: A) => TE.TaskEither<E, B>
+) => <S>(...a: A) => StateTaskEither<S, E, B>
+```
+
+Added in v0.1.10
+
+## get
+
+**Signature**
+
+```ts
+export declare const get: <S>() => StateTaskEither<S, never, S>
+```
+
+Added in v0.1.0
+
+## gets
+
+**Signature**
+
+```ts
+export declare const gets: <S, A>(f: (s: S) => A) => StateTaskEither<S, never, A>
+```
+
+Added in v0.1.0
+
+## left
+
+**Signature**
+
+```ts
+export declare const left: <S, E>(e: E) => StateTaskEither<S, E, never>
+```
+
+Added in v0.1.0
+
+## leftIO
+
+**Signature**
+
+```ts
+export declare const leftIO: <S, E>(me: IO<E>) => StateTaskEither<S, E, never>
+```
+
+Added in v0.1.0
+
+## leftState
+
+**Signature**
+
+```ts
+export declare const leftState: <S, E>(me: State<S, E>) => StateTaskEither<S, E, never>
+```
+
+Added in v0.1.0
+
+## leftTask
+
+**Signature**
+
+```ts
+export declare const leftTask: <S, E>(me: Task<E>) => StateTaskEither<S, E, never>
+```
+
+Added in v0.1.0
+
+## modify
+
+**Signature**
+
+```ts
+export declare const modify: <S>(f: (s: S) => S) => StateTaskEither<S, never, void>
+```
+
+Added in v0.1.0
+
+## put
+
+**Signature**
+
+```ts
+export declare const put: <S>(s: S) => StateTaskEither<S, never, void>
+```
+
+Added in v0.1.0
+
+## right
+
+**Signature**
+
+```ts
+export declare const right: <S, A>(a: A) => StateTaskEither<S, never, A>
+```
+
+Added in v0.1.0
+
+## rightIO
+
+**Signature**
+
+```ts
+export declare const rightIO: <S, A>(ma: IO<A>) => StateTaskEither<S, never, A>
+```
+
+Added in v0.1.0
+
+## rightState
+
+**Signature**
+
+```ts
+export declare const rightState: <S, A>(ma: State<S, A>) => StateTaskEither<S, never, A>
+```
+
+Added in v0.1.0
+
+## rightTask
+
+**Signature**
+
+```ts
+export declare const rightTask: <S, A>(ma: Task<A>) => StateTaskEither<S, never, A>
+```
+
+Added in v0.1.0
+
+# instances
+
+## Applicative
+
+**Signature**
+
+```ts
+export declare const Applicative: Applicative3<'StateTaskEither'>
+```
+
+Added in v0.1.18
+
+## Apply
+
+**Signature**
+
+```ts
+export declare const Apply: Apply3<'StateTaskEither'>
+```
+
+Added in v0.1.18
+
+## Functor
+
+**Signature**
+
+```ts
+export declare const Functor: Functor3<'StateTaskEither'>
+```
+
+Added in v0.1.18
+
+## Monad
+
+**Signature**
+
+```ts
+export declare const Monad: Monad3<'StateTaskEither'>
+```
+
+Added in v0.1.18
+
+## URI
+
+**Signature**
+
+```ts
+export declare const URI: 'StateTaskEither'
+```
+
+Added in v0.1.0
+
+## URI (type alias)
+
+**Signature**
+
+```ts
+export type URI = typeof URI
+```
+
+Added in v0.1.0
+
+## stateTaskEither
+
+**Signature**
+
+```ts
+export declare const stateTaskEither: Monad3<'StateTaskEither'> & MonadThrow3<'StateTaskEither'>
+```
+
+Added in v0.1.0
+
+## stateTaskEitherSeq
+
+Like `stateTaskEither` but `ap` is sequential
+
+**Signature**
+
+```ts
+export declare const stateTaskEitherSeq: Monad3<'StateTaskEither'> & MonadThrow3<'StateTaskEither'>
+```
+
+Added in v0.1.0
+
+# model
+
+## StateTaskEither (interface)
 
 **Signature**
 
@@ -66,396 +530,34 @@ export interface StateTaskEither<S, E, A> {
 
 Added in v0.1.0
 
-# URI (type alias)
+# utils
+
+## evalState
 
 **Signature**
 
 ```ts
-export type URI = typeof URI
+export declare const evalState: <S, E, A>(ma: StateTaskEither<S, E, A>, s: S) => TE.TaskEither<E, A>
 ```
 
 Added in v0.1.0
 
-# URI
+## execState
 
 **Signature**
 
 ```ts
-export const URI: "StateTaskEither" = ...
+export declare const execState: <S, E, A>(ma: StateTaskEither<S, E, A>, s: S) => TE.TaskEither<E, S>
 ```
 
 Added in v0.1.0
 
-# ap
+## run
 
 **Signature**
 
 ```ts
-<R, E, A>(fa: StateTaskEither<R, E, A>) => <B>(fab: StateTaskEither<R, E, (a: A) => B>) => StateTaskEither<R, E, B>
-```
-
-Added in v0.1.0
-
-# apFirst
-
-**Signature**
-
-```ts
-<R, E, B>(fb: StateTaskEither<R, E, B>) => <A>(fa: StateTaskEither<R, E, A>) => StateTaskEither<R, E, A>
-```
-
-Added in v0.1.0
-
-# apSecond
-
-**Signature**
-
-```ts
-<R, E, B>(fb: StateTaskEither<R, E, B>) => <A>(fa: StateTaskEither<R, E, A>) => StateTaskEither<R, E, B>
-```
-
-Added in v0.1.0
-
-# chain
-
-**Signature**
-
-```ts
-<R, E, A, B>(f: (a: A) => StateTaskEither<R, E, B>) => (ma: StateTaskEither<R, E, A>) => StateTaskEither<R, E, B>
-```
-
-Added in v0.1.0
-
-# chainEitherK
-
-**Signature**
-
-```ts
-export function chainEitherK<E, A, B>(
-  f: (a: A) => Either<E, B>
-): <S>(ma: StateTaskEither<S, E, A>) => StateTaskEither<S, E, B> { ... }
-```
-
-Added in v0.1.10
-
-# chainFirst
-
-**Signature**
-
-```ts
-<R, E, A, B>(f: (a: A) => StateTaskEither<R, E, B>) => (ma: StateTaskEither<R, E, A>) => StateTaskEither<R, E, A>
-```
-
-Added in v0.1.0
-
-# chainIOEitherK
-
-**Signature**
-
-```ts
-export function chainIOEitherK<E, A, B>(
-  f: (a: A) => IOEither<E, B>
-): <S>(ma: StateTaskEither<S, E, A>) => StateTaskEither<S, E, B> { ... }
-```
-
-Added in v0.1.10
-
-# chainTaskEitherK
-
-**Signature**
-
-```ts
-export function chainTaskEitherK<E, A, B>(
-  f: (a: A) => TaskEither<E, B>
-): <S>(ma: StateTaskEither<S, E, A>) => StateTaskEither<S, E, B> { ... }
-```
-
-Added in v0.1.10
-
-# evalState
-
-**Signature**
-
-```ts
-export const evalState: <S, E, A>(ma: StateTaskEither<S, E, A>, s: S) => TaskEither<E, A> = ...
-```
-
-Added in v0.1.0
-
-# execState
-
-**Signature**
-
-```ts
-export const execState: <S, E, A>(ma: StateTaskEither<S, E, A>, s: S) => TaskEither<E, S> = ...
-```
-
-Added in v0.1.0
-
-# filterOrElse
-
-**Signature**
-
-```ts
-{ <E, A, B>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <R>(ma: StateTaskEither<R, E, A>) => StateTaskEither<R, E, B>; <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <R>(ma: StateTaskEither<R, E, A>) => StateTaskEither<R, E, A>; }
-```
-
-Added in v0.1.0
-
-# flatten
-
-**Signature**
-
-```ts
-<R, E, A>(mma: StateTaskEither<R, E, StateTaskEither<R, E, A>>) => StateTaskEither<R, E, A>
-```
-
-Added in v0.1.0
-
-# fromEither
-
-**Signature**
-
-```ts
-<R, E, A>(ma: Either<E, A>) => StateTaskEither<R, E, A>
-```
-
-Added in v0.1.0
-
-# fromEitherK
-
-**Signature**
-
-```ts
-export function fromEitherK<E, A extends Array<unknown>, B>(
-  f: (...a: A) => Either<E, B>
-): <S>(...a: A) => StateTaskEither<S, E, B> { ... }
-```
-
-Added in v0.1.10
-
-# fromIOEither
-
-**Signature**
-
-```ts
-export function fromIOEither<S, E, A>(ma: IOEither<E, A>): StateTaskEither<S, E, A> { ... }
-```
-
-Added in v0.1.0
-
-# fromIOEitherK
-
-**Signature**
-
-```ts
-export function fromIOEitherK<E, A extends Array<unknown>, B>(
-  f: (...a: A) => IOEither<E, B>
-): <S>(...a: A) => StateTaskEither<S, E, B> { ... }
-```
-
-Added in v0.1.10
-
-# fromOption
-
-**Signature**
-
-```ts
-<E>(onNone: () => E) => <R, A>(ma: Option<A>) => StateTaskEither<R, E, A>
-```
-
-Added in v0.1.0
-
-# fromPredicate
-
-**Signature**
-
-```ts
-{ <E, A, B>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <U>(a: A) => StateTaskEither<U, E, B>; <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <R>(a: A) => StateTaskEither<R, E, A>; }
-```
-
-Added in v0.1.0
-
-# fromTaskEither
-
-**Signature**
-
-```ts
-export const fromTaskEither: <S, E, A>(ma: TaskEither<E, A>) => StateTaskEither<S, E, A> = ...
-```
-
-Added in v0.1.0
-
-# fromTaskEitherK
-
-**Signature**
-
-```ts
-export function fromTaskEitherK<E, A extends Array<unknown>, B>(
-  f: (...a: A) => TaskEither<E, B>
-): <S>(...a: A) => StateTaskEither<S, E, B> { ... }
-```
-
-Added in v0.1.10
-
-# get
-
-**Signature**
-
-```ts
-export const get: <S>() => StateTaskEither<S, never, S> = ...
-```
-
-Added in v0.1.0
-
-# gets
-
-**Signature**
-
-```ts
-export const gets: <S, A>(f: (s: S) => A) => StateTaskEither<S, never, A> = ...
-```
-
-Added in v0.1.0
-
-# left
-
-**Signature**
-
-```ts
-export function left<S, E>(e: E): StateTaskEither<S, E, never> { ... }
-```
-
-Added in v0.1.0
-
-# leftIO
-
-**Signature**
-
-```ts
-export function leftIO<S, E>(me: IO<E>): StateTaskEither<S, E, never> { ... }
-```
-
-Added in v0.1.0
-
-# leftState
-
-**Signature**
-
-```ts
-export function leftState<S, E>(me: State<S, E>): StateTaskEither<S, E, never> { ... }
-```
-
-Added in v0.1.0
-
-# leftTask
-
-**Signature**
-
-```ts
-export function leftTask<S, E>(me: Task<E>): StateTaskEither<S, E, never> { ... }
-```
-
-Added in v0.1.0
-
-# map
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => B) => <R, E>(fa: StateTaskEither<R, E, A>) => StateTaskEither<R, E, B>
-```
-
-Added in v0.1.0
-
-# modify
-
-**Signature**
-
-```ts
-export const modify: <S>(f: (s: S) => S) => StateTaskEither<S, never, void> = ...
-```
-
-Added in v0.1.0
-
-# put
-
-**Signature**
-
-```ts
-export const put: <S>(s: S) => StateTaskEither<S, never, void> = ...
-```
-
-Added in v0.1.0
-
-# right
-
-**Signature**
-
-```ts
-export const right: <S, A>(a: A) => StateTaskEither<S, never, A> = ...
-```
-
-Added in v0.1.0
-
-# rightIO
-
-**Signature**
-
-```ts
-export function rightIO<S, A>(ma: IO<A>): StateTaskEither<S, never, A> { ... }
-```
-
-Added in v0.1.0
-
-# rightState
-
-**Signature**
-
-```ts
-export const rightState: <S, A>(ma: State<S, A>) => StateTaskEither<S, never, A> = ...
-```
-
-Added in v0.1.0
-
-# rightTask
-
-**Signature**
-
-```ts
-export function rightTask<S, A>(ma: Task<A>): StateTaskEither<S, never, A> { ... }
-```
-
-Added in v0.1.0
-
-# run
-
-**Signature**
-
-```ts
-export function run<S, E, A>(ma: StateTaskEither<S, E, A>, s: S): Promise<Either<E, [A, S]>> { ... }
-```
-
-Added in v0.1.0
-
-# stateTaskEither
-
-**Signature**
-
-```ts
-export const stateTaskEither: Monad3<URI> & MonadThrow3<URI> = ...
-```
-
-Added in v0.1.0
-
-# stateTaskEitherSeq
-
-Like `stateTaskEither` but `ap` is sequential
-
-**Signature**
-
-```ts
-export const stateTaskEitherSeq: typeof stateTaskEither = ...
+export declare const run: <S, E, A>(ma: StateTaskEither<S, E, A>, s: S) => Promise<Either<E, [A, S]>>
 ```
 
 Added in v0.1.0

--- a/docs/modules/Task/getLine.ts.md
+++ b/docs/modules/Task/getLine.ts.md
@@ -4,7 +4,7 @@ nav_order: 21
 parent: Modules
 ---
 
-# getLine overview
+## getLine overview
 
 Added in v0.1.8
 
@@ -12,16 +12,19 @@ Added in v0.1.8
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [getLine](#getline)
+- [utils](#utils)
+  - [getLine](#getline)
 
 ---
 
-# getLine
+# utils
+
+## getLine
 
 **Signature**
 
 ```ts
-export function getLine(question: string): Task<string> { ... }
+export declare function getLine(question: string): Task<string>
 ```
 
 Added in v0.1.8

--- a/docs/modules/Task/getLine.ts.md
+++ b/docs/modules/Task/getLine.ts.md
@@ -24,7 +24,7 @@ Added in v0.1.8
 **Signature**
 
 ```ts
-export declare function getLine(question: string): Task<string>
+export declare const getLine: (question: string) => Task<string>
 ```
 
 Added in v0.1.8

--- a/docs/modules/Task/withTimeout.ts.md
+++ b/docs/modules/Task/withTimeout.ts.md
@@ -26,7 +26,7 @@ Returns the task result if it completes within a timeout, or a fallback value in
 **Signature**
 
 ```ts
-export declare function withTimeout<A>(onTimeout: A, millis: number): (ma: Task<A>) => Task<A>
+export declare const withTimeout: <A>(onTimeout: A, millis: number) => (ma: Task<A>) => Task<A>
 ```
 
 **Example**

--- a/docs/modules/Task/withTimeout.ts.md
+++ b/docs/modules/Task/withTimeout.ts.md
@@ -4,7 +4,7 @@ nav_order: 22
 parent: Modules
 ---
 
-# withTimeout overview
+## withTimeout overview
 
 Added in v0.1.0
 
@@ -12,18 +12,21 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [withTimeout](#withtimeout)
+- [utils](#utils)
+  - [withTimeout](#withtimeout)
 
 ---
 
-# withTimeout
+# utils
+
+## withTimeout
 
 Returns the task result if it completes within a timeout, or a fallback value instead.
 
 **Signature**
 
 ```ts
-export function withTimeout<A>(onTimeout: A, millis: number): (ma: Task<A>) => Task<A> { ... }
+export declare function withTimeout<A>(onTimeout: A, millis: number): (ma: Task<A>) => Task<A>
 ```
 
 **Example**

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -4,7 +4,7 @@ nav_order: 23
 parent: Modules
 ---
 
-# TaskOption overview
+## TaskOption overview
 
 Added in v0.1.0
 
@@ -12,54 +12,484 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [TaskOption (interface)](#taskoption-interface)
-- [URI (type alias)](#uri-type-alias)
-- [URI](#uri)
-- [alt](#alt)
-- [ap](#ap)
-- [apFirst](#apfirst)
-- [apSecond](#apsecond)
-- [chain](#chain)
-- [chainFirst](#chainfirst)
-- [chainOption](#chainoption)
-- [chainOptionK](#chainoptionk)
-- [chainTask](#chaintask)
-- [compact](#compact)
-- [filter](#filter)
-- [filterMap](#filtermap)
-- [flatten](#flatten)
-- [fold](#fold)
-- [fromNullable](#fromnullable)
-- [fromOption](#fromoption)
-- [fromOptionK](#fromoptionk)
-- [fromTask](#fromtask)
-- [fromTaskEither](#fromtaskeither)
-- [getOrElse](#getorelse)
-- [map](#map)
-- [mapNullable](#mapnullable)
-- [none](#none)
-- [partition](#partition)
-- [partitionMap](#partitionmap)
-- [separate](#separate)
-- [some](#some)
-- [taskOption](#taskoption)
-- [toNullable](#tonullable)
-- [toUndefined](#toundefined)
-- [tryCatch](#trycatch)
+- [Alternative](#alternative)
+  - [alt](#alt)
+  - [zero](#zero)
+- [Applicative](#applicative)
+  - [of](#of)
+- [Apply](#apply)
+  - [ap](#ap)
+  - [apFirst](#apfirst)
+  - [apSecond](#apsecond)
+- [Compactable](#compactable)
+  - [compact](#compact)
+  - [separate](#separate)
+- [Filterable](#filterable)
+  - [filter](#filter)
+  - [filterMap](#filtermap)
+  - [partition](#partition)
+  - [partitionMap](#partitionmap)
+- [Functor](#functor)
+  - [map](#map)
+- [Monad](#monad)
+  - [chain](#chain)
+  - [chainFirst](#chainfirst)
+  - [chainOption](#chainoption)
+  - [chainOptionK](#chainoptionk)
+  - [chainTask](#chaintask)
+  - [flatten](#flatten)
+- [combinators](#combinators)
+  - [mapNullable](#mapnullable)
+- [constructors](#constructors)
+  - [fromNullable](#fromnullable)
+  - [fromOption](#fromoption)
+  - [fromOptionK](#fromoptionk)
+  - [fromTask](#fromtask)
+  - [fromTaskEither](#fromtaskeither)
+  - [none](#none)
+  - [some](#some)
+  - [tryCatch](#trycatch)
+- [destructors](#destructors)
+  - [fold](#fold)
+  - [getOrElse](#getorelse)
+  - [toNullable](#tonullable)
+  - [toUndefined](#toundefined)
+- [instances](#instances)
+  - [Alternative](#alternative-1)
+  - [Applicative](#applicative-1)
+  - [Apply](#apply-1)
+  - [Compactable](#compactable-1)
+  - [Filterable](#filterable-1)
+  - [Functor](#functor-1)
+  - [Monad](#monad-1)
+  - [URI (type alias)](#uri-type-alias)
+  - [taskOption](#taskoption)
+- [model](#model)
+  - [TaskOption (interface)](#taskoption-interface)
 
 ---
 
-# TaskOption (interface)
+# Alternative
+
+## alt
 
 **Signature**
 
 ```ts
-export interface TaskOption<A> extends Task<Option<A>> {}
+export declare const alt: <A>(that: () => TaskOption<A>) => (fa: TaskOption<A>) => TaskOption<A>
+```
+
+Added in v0.1.18
+
+## zero
+
+**Signature**
+
+```ts
+export declare const zero: <A>() => TaskOption<A>
+```
+
+Added in v0.1.18
+
+# Applicative
+
+## of
+
+**Signature**
+
+```ts
+export declare const of: <A>(a: A) => TaskOption<A>
+```
+
+Added in v0.1.18
+
+# Apply
+
+## ap
+
+**Signature**
+
+```ts
+export declare const ap: <A>(fa: TaskOption<A>) => <B>(fab: TaskOption<(a: A) => B>) => TaskOption<B>
+```
+
+Added in v0.1.18
+
+## apFirst
+
+**Signature**
+
+```ts
+export declare const apFirst: <B>(fb: TaskOption<B>) => <A>(fa: TaskOption<A>) => TaskOption<A>
+```
+
+Added in v0.1.18
+
+## apSecond
+
+**Signature**
+
+```ts
+export declare const apSecond: <B>(fb: TaskOption<B>) => <A>(fa: TaskOption<A>) => TaskOption<B>
+```
+
+Added in v0.1.18
+
+# Compactable
+
+## compact
+
+**Signature**
+
+```ts
+export declare const compact: <A>(fa: TaskOption<O.Option<A>>) => TaskOption<A>
+```
+
+Added in v0.1.18
+
+## separate
+
+**Signature**
+
+```ts
+export declare const separate: <A, B>(ma: TaskOption<Either<A, B>>) => Separated<TaskOption<A>, TaskOption<B>>
+```
+
+Added in v0.1.18
+
+# Filterable
+
+## filter
+
+**Signature**
+
+```ts
+export declare const filter: {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: TaskOption<A>) => TaskOption<B>
+  <A>(predicate: Predicate<A>): (fa: TaskOption<A>) => TaskOption<A>
+}
+```
+
+Added in v0.1.18
+
+## filterMap
+
+**Signature**
+
+```ts
+export declare const filterMap: <A, B>(f: (a: A) => O.Option<B>) => (fa: TaskOption<A>) => TaskOption<B>
+```
+
+Added in v0.1.18
+
+## partition
+
+**Signature**
+
+```ts
+export declare const partition: {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: TaskOption<A>) => Separated<TaskOption<A>, TaskOption<B>>
+  <A>(predicate: Predicate<A>): (fa: TaskOption<A>) => Separated<TaskOption<A>, TaskOption<A>>
+}
+```
+
+Added in v0.1.18
+
+## partitionMap
+
+**Signature**
+
+```ts
+export declare const partitionMap: <A, B, C>(
+  f: (a: A) => Either<B, C>
+) => (fa: TaskOption<A>) => Separated<TaskOption<B>, TaskOption<C>>
+```
+
+Added in v0.1.18
+
+# Functor
+
+## map
+
+**Signature**
+
+```ts
+export declare const map: <A, B>(f: (a: A) => B) => (fa: TaskOption<A>) => TaskOption<B>
+```
+
+Added in v0.1.18
+
+# Monad
+
+## chain
+
+**Signature**
+
+```ts
+export declare const chain: <A, B>(f: (a: A) => TaskOption<B>) => (ma: TaskOption<A>) => TaskOption<B>
+```
+
+Added in v0.1.18
+
+## chainFirst
+
+**Signature**
+
+```ts
+export declare const chainFirst: <A, B>(f: (a: A) => TaskOption<B>) => (ma: TaskOption<A>) => TaskOption<A>
+```
+
+Added in v0.1.18
+
+## chainOption
+
+**Signature**
+
+```ts
+export declare const chainOption: <A, B>(f: (a: A) => O.Option<B>) => (ma: TaskOption<A>) => TaskOption<B>
+```
+
+Added in v0.1.4
+
+## chainOptionK
+
+**Signature**
+
+```ts
+export declare const chainOptionK: <A, B>(f: (a: A) => O.Option<B>) => (ma: TaskOption<A>) => TaskOption<B>
+```
+
+Added in v0.1.10
+
+## chainTask
+
+**Signature**
+
+```ts
+export declare const chainTask: <A, B>(f: (a: A) => Task<B>) => (ma: TaskOption<A>) => TaskOption<B>
+```
+
+Added in v0.1.4
+
+## flatten
+
+**Signature**
+
+```ts
+export declare const flatten: <A>(mma: TaskOption<TaskOption<A>>) => TaskOption<A>
+```
+
+Added in v0.1.18
+
+# combinators
+
+## mapNullable
+
+**Signature**
+
+```ts
+export declare const mapNullable: <A, B>(f: (a: A) => B) => (ma: TaskOption<A>) => TaskOption<B>
+```
+
+Added in v0.1.5
+
+# constructors
+
+## fromNullable
+
+**Signature**
+
+```ts
+export declare const fromNullable: <A>(a: A) => TaskOption<NonNullable<A>>
+```
+
+Added in v0.1.4
+
+## fromOption
+
+**Signature**
+
+```ts
+export declare const fromOption: <A>(ma: O.Option<A>) => TaskOption<A>
 ```
 
 Added in v0.1.0
 
-# URI (type alias)
+## fromOptionK
+
+**Signature**
+
+```ts
+export declare const fromOptionK: <A extends unknown[], B>(f: (...a: A) => O.Option<B>) => (...a: A) => TaskOption<B>
+```
+
+Added in v0.1.10
+
+## fromTask
+
+**Signature**
+
+```ts
+export declare const fromTask: <A>(as: Task<A>) => TaskOption<A>
+```
+
+Added in v0.1.0
+
+## fromTaskEither
+
+**Signature**
+
+```ts
+export declare const fromTaskEither: <A>(ma: TaskEither<any, A>) => TaskOption<A>
+```
+
+Added in v0.1.4
+
+## none
+
+**Signature**
+
+```ts
+export declare const none: TaskOption<never>
+```
+
+Added in v0.1.0
+
+## some
+
+**Signature**
+
+```ts
+export declare const some: <A>(a: A) => TaskOption<A>
+```
+
+Added in v0.1.0
+
+## tryCatch
+
+**Signature**
+
+```ts
+export declare const tryCatch: <A>(f: Lazy<Promise<A>>) => TaskOption<A>
+```
+
+Added in v0.1.5
+
+# destructors
+
+## fold
+
+**Signature**
+
+```ts
+export declare const fold: <A, B>(onNone: () => Task<B>, onSome: (a: A) => Task<B>) => (as: TaskOption<A>) => Task<B>
+```
+
+Added in v0.1.0
+
+## getOrElse
+
+**Signature**
+
+```ts
+export declare const getOrElse: <A>(onNone: () => Task<A>) => (as: TaskOption<A>) => Task<A>
+```
+
+Added in v0.1.0
+
+## toNullable
+
+**Signature**
+
+```ts
+export declare const toNullable: <A>(ma: TaskOption<A>) => Task<A>
+```
+
+Added in v0.1.4
+
+## toUndefined
+
+**Signature**
+
+```ts
+export declare const toUndefined: <A>(ma: TaskOption<A>) => Task<A>
+```
+
+Added in v0.1.4
+
+# instances
+
+## Alternative
+
+**Signature**
+
+```ts
+export declare const Alternative: Alternative1<'TaskOption'>
+```
+
+Added in v0.1.18
+
+## Applicative
+
+**Signature**
+
+```ts
+export declare const Applicative: Applicative1<'TaskOption'>
+```
+
+Added in v0.1.18
+
+## Apply
+
+**Signature**
+
+```ts
+export declare const Apply: Apply1<'TaskOption'>
+```
+
+Added in v0.1.18
+
+## Compactable
+
+**Signature**
+
+```ts
+export declare const Compactable: Compactable1<'TaskOption'>
+```
+
+Added in v0.1.18
+
+## Filterable
+
+**Signature**
+
+```ts
+export declare const Filterable: Filterable1<'TaskOption'>
+```
+
+Added in v0.1.18
+
+## Functor
+
+**Signature**
+
+```ts
+export declare const Functor: Functor1<'TaskOption'>
+```
+
+Added in v0.1.18
+
+## Monad
+
+**Signature**
+
+```ts
+export declare const Monad: Monad1<'TaskOption'>
+```
+
+Added in v0.1.18
+
+## URI (type alias)
 
 **Signature**
 
@@ -69,322 +499,24 @@ export type URI = typeof URI
 
 Added in v0.1.0
 
-# URI
+## taskOption
 
 **Signature**
 
 ```ts
-export const URI: "TaskOption" = ...
+export declare const taskOption: Monad1<'TaskOption'> & Alternative1<'TaskOption'> & Filterable1<'TaskOption'>
 ```
 
 Added in v0.1.0
 
-# alt
+# model
+
+## TaskOption (interface)
 
 **Signature**
 
 ```ts
-<A>(that: () => TaskOption<A>) => (fa: TaskOption<A>) => TaskOption<A>
+export interface TaskOption<A> extends Task<O.Option<A>> {}
 ```
 
 Added in v0.1.0
-
-# ap
-
-**Signature**
-
-```ts
-<A>(fa: TaskOption<A>) => <B>(fab: TaskOption<(a: A) => B>) => TaskOption<B>
-```
-
-Added in v0.1.0
-
-# apFirst
-
-**Signature**
-
-```ts
-<B>(fb: TaskOption<B>) => <A>(fa: TaskOption<A>) => TaskOption<A>
-```
-
-Added in v0.1.0
-
-# apSecond
-
-**Signature**
-
-```ts
-<B>(fb: TaskOption<B>) => <A>(fa: TaskOption<A>) => TaskOption<B>
-```
-
-Added in v0.1.0
-
-# chain
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => TaskOption<B>) => (ma: TaskOption<A>) => TaskOption<B>
-```
-
-Added in v0.1.0
-
-# chainFirst
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => TaskOption<B>) => (ma: TaskOption<A>) => TaskOption<A>
-```
-
-Added in v0.1.0
-
-# chainOption
-
-**Signature**
-
-```ts
-export function chainOption<A, B>(f: (a: A) => Option<B>): (ma: TaskOption<A>) => TaskOption<B> { ... }
-```
-
-Added in v0.1.4
-
-# chainOptionK
-
-**Signature**
-
-```ts
-export function chainOptionK<A, B>(f: (a: A) => Option<B>): (ma: TaskOption<A>) => TaskOption<B> { ... }
-```
-
-Added in v0.1.10
-
-# chainTask
-
-**Signature**
-
-```ts
-export function chainTask<A, B>(f: (a: A) => Task<B>): (ma: TaskOption<A>) => TaskOption<B> { ... }
-```
-
-Added in v0.1.4
-
-# compact
-
-**Signature**
-
-```ts
-<A>(fa: TaskOption<Option<A>>) => TaskOption<A>
-```
-
-Added in v0.1.5
-
-# filter
-
-**Signature**
-
-```ts
-{ <A, B>(refinement: Refinement<A, B>): (fa: TaskOption<A>) => TaskOption<B>; <A>(predicate: Predicate<A>): (fa: TaskOption<A>) => TaskOption<A>; }
-```
-
-Added in v0.1.5
-
-# filterMap
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => Option<B>) => (fa: TaskOption<A>) => TaskOption<B>
-```
-
-Added in v0.1.5
-
-# flatten
-
-**Signature**
-
-```ts
-<A>(mma: TaskOption<TaskOption<A>>) => TaskOption<A>
-```
-
-Added in v0.1.0
-
-# fold
-
-**Signature**
-
-```ts
-export function fold<A, B>(onNone: () => Task<B>, onSome: (a: A) => Task<B>): (as: TaskOption<A>) => Task<B> { ... }
-```
-
-Added in v0.1.0
-
-# fromNullable
-
-**Signature**
-
-```ts
-export function fromNullable<A>(a: A): TaskOption<NonNullable<A>> { ... }
-```
-
-Added in v0.1.4
-
-# fromOption
-
-**Signature**
-
-```ts
-export const fromOption: <A>(ma: Option<A>) => TaskOption<A> = ...
-```
-
-Added in v0.1.0
-
-# fromOptionK
-
-**Signature**
-
-```ts
-export function fromOptionK<A extends Array<unknown>, B>(f: (...a: A) => Option<B>): (...a: A) => TaskOption<B> { ... }
-```
-
-Added in v0.1.10
-
-# fromTask
-
-**Signature**
-
-```ts
-export const fromTask: <A>(as: Task<A>) => TaskOption<A> = ...
-```
-
-Added in v0.1.0
-
-# fromTaskEither
-
-**Signature**
-
-```ts
-export function fromTaskEither<A>(ma: TaskEither<any, A>): TaskOption<A> { ... }
-```
-
-Added in v0.1.4
-
-# getOrElse
-
-**Signature**
-
-```ts
-export function getOrElse<A>(onNone: () => Task<A>): (as: TaskOption<A>) => Task<A> { ... }
-```
-
-Added in v0.1.0
-
-# map
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => B) => (fa: TaskOption<A>) => TaskOption<B>
-```
-
-Added in v0.1.0
-
-# mapNullable
-
-**Signature**
-
-```ts
-export function mapNullable<A, B>(f: (a: A) => B | null | undefined): (ma: TaskOption<A>) => TaskOption<B> { ... }
-```
-
-Added in v0.1.5
-
-# none
-
-**Signature**
-
-```ts
-export const none: TaskOption<never> = ...
-```
-
-Added in v0.1.0
-
-# partition
-
-**Signature**
-
-```ts
-{ <A, B>(refinement: Refinement<A, B>): (fa: TaskOption<A>) => Separated<TaskOption<A>, TaskOption<B>>; <A>(predicate: Predicate<A>): (fa: TaskOption<A>) => Separated<TaskOption<A>, TaskOption<A>>; }
-```
-
-Added in v0.1.5
-
-# partitionMap
-
-**Signature**
-
-```ts
-<A, B, C>(f: (a: A) => Either<B, C>) => (fa: TaskOption<A>) => Separated<TaskOption<B>, TaskOption<C>>
-```
-
-Added in v0.1.5
-
-# separate
-
-**Signature**
-
-```ts
-<A, B>(fa: TaskOption<Either<A, B>>) => Separated<TaskOption<A>, TaskOption<B>>
-```
-
-Added in v0.1.5
-
-# some
-
-**Signature**
-
-```ts
-export const some: <A>(a: A) => TaskOption<A> = ...
-```
-
-Added in v0.1.0
-
-# taskOption
-
-**Signature**
-
-```ts
-export const taskOption: Monad1<URI> & Alternative1<URI> & Filterable1<URI> = ...
-```
-
-Added in v0.1.0
-
-# toNullable
-
-**Signature**
-
-```ts
-export function toNullable<A>(ma: TaskOption<A>): Task<A | null> { ... }
-```
-
-Added in v0.1.4
-
-# toUndefined
-
-**Signature**
-
-```ts
-export function toUndefined<A>(ma: TaskOption<A>): Task<A | undefined> { ... }
-```
-
-Added in v0.1.4
-
-# tryCatch
-
-**Signature**
-
-```ts
-export function tryCatch<A>(f: Lazy<Promise<A>>): TaskOption<A> { ... }
-```
-
-Added in v0.1.5

--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -4,7 +4,7 @@ nav_order: 25
 parent: Modules
 ---
 
-# Zipper overview
+## Zipper overview
 
 Provides a pointed array, which is a non-empty zipper-like array structure that tracks an index (focus)
 position in an array. Focus can be moved forward and backwards through the array.
@@ -23,59 +23,483 @@ Added in v0.1.6
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [Zipper (interface)](#zipper-interface)
-- [URI (type alias)](#uri-type-alias)
-- [URI](#uri)
-- [ap](#ap)
-- [apFirst](#apfirst)
-- [apSecond](#apsecond)
-- [deleteLeft](#deleteleft)
-- [deleteRight](#deleteright)
-- [down](#down)
-- [duplicate](#duplicate)
-- [end](#end)
-- [extend](#extend)
-- [foldMap](#foldmap)
-- [fromArray](#fromarray)
-- [fromNonEmptyArray](#fromnonemptyarray)
-- [getMonoid](#getmonoid)
-- [getSemigroup](#getsemigroup)
-- [getShow](#getshow)
-- [insertLeft](#insertleft)
-- [insertRight](#insertright)
-- [isOutOfBound](#isoutofbound)
-- [length](#length)
-- [make](#make)
-- [map](#map)
-- [mapWithIndex](#mapwithindex)
-- [modify](#modify)
-- [move](#move)
-- [of](#of)
-- [reduce](#reduce)
-- [reduceRight](#reduceright)
-- [start](#start)
-- [toArray](#toarray)
-- [up](#up)
-- [update](#update)
-- [zipper](#zipper)
+- [Applicative](#applicative)
+  - [of](#of)
+- [Apply](#apply)
+  - [ap](#ap)
+  - [apFirst](#apfirst)
+  - [apSecond](#apsecond)
+- [Comonad](#comonad)
+  - [extract](#extract)
+- [Extend](#extend)
+  - [duplicate](#duplicate)
+  - [extend](#extend)
+- [Foldable](#foldable)
+  - [foldMap](#foldmap)
+  - [reduce](#reduce)
+  - [reduceRight](#reduceright)
+- [Functor](#functor)
+  - [map](#map)
+- [FunctorWithIndex](#functorwithindex)
+  - [mapWithIndex](#mapwithindex)
+- [combinators](#combinators)
+  - [deleteLeft](#deleteleft)
+  - [deleteRight](#deleteright)
+  - [down](#down)
+  - [end](#end)
+  - [insertLeft](#insertleft)
+  - [insertRight](#insertright)
+  - [modify](#modify)
+  - [move](#move)
+  - [start](#start)
+  - [up](#up)
+  - [update](#update)
+- [constructors](#constructors)
+  - [fromArray](#fromarray)
+  - [fromNonEmptyArray](#fromnonemptyarray)
+  - [make](#make)
+- [destructors](#destructors)
+  - [isOutOfBound](#isoutofbound)
+  - [length](#length)
+  - [toArray](#toarray)
+- [instances](#instances)
+  - [Applicative](#applicative-1)
+  - [Apply](#apply-1)
+  - [Comonad](#comonad-1)
+  - [Foldable](#foldable-1)
+  - [Functor](#functor-1)
+  - [FunctorWithIndex](#functorwithindex-1)
+  - [Traversable](#traversable)
+  - [URI](#uri)
+  - [URI (type alias)](#uri-type-alias)
+  - [getMonoid](#getmonoid)
+  - [getSemigroup](#getsemigroup)
+  - [getShow](#getshow)
+  - [zipper](#zipper)
+- [model](#model)
+  - [Zipper (interface)](#zipper-interface)
 
 ---
 
-# Zipper (interface)
+# Applicative
+
+## of
 
 **Signature**
 
 ```ts
-export interface Zipper<A> {
-  readonly lefts: Array<A>
-  readonly focus: A
-  readonly rights: Array<A>
-}
+export declare const of: <A>(focus: A) => Zipper<A>
 ```
 
 Added in v0.1.6
 
-# URI (type alias)
+# Apply
+
+## ap
+
+**Signature**
+
+```ts
+export declare const ap: <A>(fa: Zipper<A>) => <B>(fab: Zipper<(a: A) => B>) => Zipper<B>
+```
+
+Added in v0.1.18
+
+## apFirst
+
+**Signature**
+
+```ts
+export declare const apFirst: <B>(fb: Zipper<B>) => <A>(fa: Zipper<A>) => Zipper<A>
+```
+
+Added in v0.1.18
+
+## apSecond
+
+**Signature**
+
+```ts
+export declare const apSecond: <B>(fb: Zipper<B>) => <A>(fa: Zipper<A>) => Zipper<B>
+```
+
+Added in v0.1.18
+
+# Comonad
+
+## extract
+
+**Signature**
+
+```ts
+export declare const extract: <A>(wa: Zipper<A>) => A
+```
+
+Added in v0.1.18
+
+# Extend
+
+## duplicate
+
+**Signature**
+
+```ts
+export declare const duplicate: <A>(wa: Zipper<A>) => Zipper<Zipper<A>>
+```
+
+Added in v0.1.18
+
+## extend
+
+**Signature**
+
+```ts
+export declare const extend: <A, B>(f: (fa: Zipper<A>) => B) => (wa: Zipper<A>) => Zipper<B>
+```
+
+Added in v0.1.18
+
+# Foldable
+
+## foldMap
+
+**Signature**
+
+```ts
+export declare const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: Zipper<A>) => M
+```
+
+Added in v0.1.18
+
+## reduce
+
+**Signature**
+
+```ts
+export declare const reduce: <A, B>(b: B, f: (b: B, a: A) => B) => (fa: Zipper<A>) => B
+```
+
+Added in v0.1.18
+
+## reduceRight
+
+**Signature**
+
+```ts
+export declare const reduceRight: <A, B>(b: B, f: (a: A, b: B) => B) => (fa: Zipper<A>) => B
+```
+
+Added in v0.1.18
+
+# Functor
+
+## map
+
+**Signature**
+
+```ts
+export declare const map: <A, B>(f: (a: A) => B) => (fa: Zipper<A>) => Zipper<B>
+```
+
+Added in v0.1.18
+
+# FunctorWithIndex
+
+## mapWithIndex
+
+**Signature**
+
+```ts
+export declare const mapWithIndex: <A, B>(f: (i: number, a: A) => B) => (fa: Zipper<A>) => Zipper<B>
+```
+
+Added in v0.1.18
+
+# combinators
+
+## deleteLeft
+
+Deletes the element at focus and moves the focus to the left. If there is no element on the left,
+the focus is moved to the right.
+
+**Signature**
+
+```ts
+export declare const deleteLeft: <A>(fa: Zipper<A>) => Option<Zipper<A>>
+```
+
+Added in v0.1.6
+
+## deleteRight
+
+Deletes the element at focus and moves the focus to the right. If there is no element on the right,
+the focus is moved to the left.
+
+**Signature**
+
+```ts
+export declare const deleteRight: <A>(fa: Zipper<A>) => Option<Zipper<A>>
+```
+
+Added in v0.1.6
+
+## down
+
+Moves focus of the zipper down.
+
+**Signature**
+
+```ts
+export declare const down: <A>(fa: Zipper<A>) => Option<Zipper<A>>
+```
+
+Added in v0.1.6
+
+## end
+
+Moves focus to the end of the zipper.
+
+**Signature**
+
+```ts
+export declare const end: <A>(fa: Zipper<A>) => Zipper<A>
+```
+
+Added in v0.1.6
+
+## insertLeft
+
+Inserts an element to the left of the focus and focuses on the new element.
+
+**Signature**
+
+```ts
+export declare const insertLeft: <A>(a: A) => (fa: Zipper<A>) => Zipper<A>
+```
+
+Added in v0.1.6
+
+## insertRight
+
+Inserts an element to the right of the focus and focuses on the new element.
+
+**Signature**
+
+```ts
+export declare const insertRight: <A>(a: A) => (fa: Zipper<A>) => Zipper<A>
+```
+
+Added in v0.1.6
+
+## modify
+
+Applies `f` to the focus and update with the result.
+
+**Signature**
+
+```ts
+export declare const modify: <A>(f: (a: A) => A) => (fa: Zipper<A>) => Zipper<A>
+```
+
+Added in v0.1.6
+
+## move
+
+Moves focus in the zipper, or `None` if there is no such element.
+
+**Signature**
+
+```ts
+export declare const move: <A>(f: (currentIndex: number) => number, fa: Zipper<A>) => Option<Zipper<A>>
+```
+
+Added in v0.1.6
+
+## start
+
+Moves focus to the start of the zipper.
+
+**Signature**
+
+```ts
+export declare const start: <A>(fa: Zipper<A>) => Zipper<A>
+```
+
+Added in v0.1.6
+
+## up
+
+Moves focus of the zipper up.
+
+**Signature**
+
+```ts
+export declare const up: <A>(fa: Zipper<A>) => Option<Zipper<A>>
+```
+
+Added in v0.1.6
+
+## update
+
+Updates the focus of the zipper.
+
+**Signature**
+
+```ts
+export declare const update: <A>(a: A) => (fa: Zipper<A>) => Zipper<A>
+```
+
+Added in v0.1.6
+
+# constructors
+
+## fromArray
+
+**Signature**
+
+```ts
+export declare const fromArray: <A>(as: A[], focusIndex?: number) => Option<Zipper<A>>
+```
+
+Added in v0.1.6
+
+## fromNonEmptyArray
+
+**Signature**
+
+```ts
+export declare const fromNonEmptyArray: <A>(nea: NonEmptyArray<A>) => Zipper<A>
+```
+
+Added in v0.1.6
+
+## make
+
+Creates a new zipper.
+
+**Signature**
+
+```ts
+export declare const make: <A>(lefts: A[], focus: A, rights: A[]) => Zipper<A>
+```
+
+Added in v0.1.6
+
+# destructors
+
+## isOutOfBound
+
+**Signature**
+
+```ts
+export declare const isOutOfBound: <A>(index: number, fa: Zipper<A>) => boolean
+```
+
+Added in v0.1.18
+
+## length
+
+**Signature**
+
+```ts
+export declare const length: <A>(fa: Zipper<A>) => number
+```
+
+Added in v0.1.6
+
+## toArray
+
+**Signature**
+
+```ts
+export declare const toArray: <A>(fa: Zipper<A>) => A[]
+```
+
+Added in v0.1.6
+
+# instances
+
+## Applicative
+
+**Signature**
+
+```ts
+export declare const Applicative: Applicative1<'Zipper'>
+```
+
+Added in v0.1.18
+
+## Apply
+
+**Signature**
+
+```ts
+export declare const Apply: Apply1<'Zipper'>
+```
+
+Added in v0.1.18
+
+## Comonad
+
+**Signature**
+
+```ts
+export declare const Comonad: Comonad1<'Zipper'>
+```
+
+Added in v0.1.18
+
+## Foldable
+
+**Signature**
+
+```ts
+export declare const Foldable: Foldable1<'Zipper'>
+```
+
+Added in v0.1.18
+
+## Functor
+
+**Signature**
+
+```ts
+export declare const Functor: Functor1<'Zipper'>
+```
+
+Added in v0.1.18
+
+## FunctorWithIndex
+
+**Signature**
+
+```ts
+export declare const FunctorWithIndex: FunctorWithIndex1<'Zipper', number>
+```
+
+Added in v0.1.18
+
+## Traversable
+
+**Signature**
+
+```ts
+export declare const Traversable: Traversable1<'Zipper'>
+```
+
+Added in v0.1.18
+
+## URI
+
+**Signature**
+
+```ts
+export declare const URI: 'Zipper'
+```
+
+Added in v0.1.6
+
+## URI (type alias)
 
 **Signature**
 
@@ -85,362 +509,62 @@ export type URI = typeof URI
 
 Added in v0.1.6
 
-# URI
+## getMonoid
 
 **Signature**
 
 ```ts
-export const URI: "Zipper" = ...
+export declare const getMonoid: <A>(M: Monoid<A>) => Monoid<Zipper<A>>
 ```
 
 Added in v0.1.6
 
-# ap
+## getSemigroup
 
 **Signature**
 
 ```ts
-<A>(fa: Zipper<A>) => <B>(fab: Zipper<(a: A) => B>) => Zipper<B>
+export declare const getSemigroup: <A>(S: Semigroup<A>) => Semigroup<Zipper<A>>
 ```
 
 Added in v0.1.6
 
-# apFirst
+## getShow
 
 **Signature**
 
 ```ts
-<B>(fb: Zipper<B>) => <A>(fa: Zipper<A>) => Zipper<A>
-```
-
-Added in v0.1.11
-
-# apSecond
-
-**Signature**
-
-```ts
-<B>(fb: Zipper<B>) => <A>(fa: Zipper<A>) => Zipper<B>
-```
-
-Added in v0.1.11
-
-# deleteLeft
-
-Deletes the element at focus and moves the focus to the left. If there is no element on the left,
-the focus is moved to the right.
-
-**Signature**
-
-```ts
-export function deleteLeft<A>(fa: Zipper<A>): Option<Zipper<A>> { ... }
+export declare const getShow: <A>(S: Show<A>) => Show<Zipper<A>>
 ```
 
 Added in v0.1.6
 
-# deleteRight
-
-Deletes the element at focus and moves the focus to the right. If there is no element on the right,
-the focus is moved to the left.
+## zipper
 
 **Signature**
 
 ```ts
-export function deleteRight<A>(fa: Zipper<A>): Option<Zipper<A>> { ... }
+export declare const zipper: Applicative1<'Zipper'> &
+  Foldable1<'Zipper'> &
+  Traversable1<'Zipper'> &
+  Comonad1<'Zipper'> &
+  FunctorWithIndex1<'Zipper', number>
 ```
 
 Added in v0.1.6
 
-# down
+# model
 
-Moves focus of the zipper down.
-
-**Signature**
-
-```ts
-export function down<A>(fa: Zipper<A>): Option<Zipper<A>> { ... }
-```
-
-Added in v0.1.6
-
-# duplicate
+## Zipper (interface)
 
 **Signature**
 
 ```ts
-<A>(wa: Zipper<A>) => Zipper<Zipper<A>>
-```
-
-Added in v0.1.11
-
-# end
-
-Moves focus to the end of the zipper.
-
-**Signature**
-
-```ts
-export function end<A>(fa: Zipper<A>): Zipper<A> { ... }
-```
-
-Added in v0.1.6
-
-# extend
-
-**Signature**
-
-```ts
-<A, B>(f: (wa: Zipper<A>) => B) => (wa: Zipper<A>) => Zipper<B>
-```
-
-Added in v0.1.11
-
-# foldMap
-
-**Signature**
-
-```ts
-;<M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: Zipper<A>) => M
-```
-
-Added in v0.1.11
-
-# fromArray
-
-**Signature**
-
-```ts
-export function fromArray<A>(as: Array<A>, focusIndex: number = 0): Option<Zipper<A>> { ... }
-```
-
-Added in v0.1.6
-
-# fromNonEmptyArray
-
-**Signature**
-
-```ts
-export function fromNonEmptyArray<A>(nea: NonEmptyArray<A>): Zipper<A> { ... }
-```
-
-Added in v0.1.6
-
-# getMonoid
-
-**Signature**
-
-```ts
-export function getMonoid<A>(M: Monoid<A>): Monoid<Zipper<A>> { ... }
-```
-
-Added in v0.1.6
-
-# getSemigroup
-
-**Signature**
-
-```ts
-export function getSemigroup<A>(S: Semigroup<A>): Semigroup<Zipper<A>> { ... }
-```
-
-Added in v0.1.6
-
-# getShow
-
-**Signature**
-
-```ts
-export function getShow<A>(S: Show<A>): Show<Zipper<A>> { ... }
-```
-
-Added in v0.1.6
-
-# insertLeft
-
-Inserts an element to the left of the focus and focuses on the new element.
-
-**Signature**
-
-```ts
-export function insertLeft<A>(a: A): (fa: Zipper<A>) => Zipper<A> { ... }
-```
-
-Added in v0.1.6
-
-# insertRight
-
-Inserts an element to the right of the focus and focuses on the new element.
-
-**Signature**
-
-```ts
-export function insertRight<A>(a: A): (fa: Zipper<A>) => Zipper<A> { ... }
-```
-
-Added in v0.1.6
-
-# isOutOfBound
-
-**Signature**
-
-```ts
-export function isOutOfBound<A>(index: number, fa: Zipper<A>): boolean { ... }
-```
-
-Added in v0.1.6
-
-# length
-
-**Signature**
-
-```ts
-export function length<A>(fa: Zipper<A>): number { ... }
-```
-
-Added in v0.1.6
-
-# make
-
-Creates a new zipper.
-
-**Signature**
-
-```ts
-export function make<A>(lefts: Array<A>, focus: A, rights: Array<A>): Zipper<A> { ... }
-```
-
-Added in v0.1.6
-
-# map
-
-**Signature**
-
-```ts
-<A, B>(f: (a: A) => B) => (fa: Zipper<A>) => Zipper<B>
-```
-
-Added in v0.1.6
-
-# mapWithIndex
-
-**Signature**
-
-```ts
-<A, B>(f: (i: number, a: A) => B) => (fa: Zipper<A>) => Zipper<B>
-```
-
-Added in v0.1.17
-
-# modify
-
-Applies `f` to the focus and update with the result.
-
-**Signature**
-
-```ts
-export function modify<A>(f: (a: A) => A): (fa: Zipper<A>) => Zipper<A> { ... }
-```
-
-Added in v0.1.6
-
-# move
-
-Moves focus in the zipper, or `None` if there is no such element.
-
-**Signature**
-
-```ts
-export function move<A>(f: (currentIndex: number) => number, fa: Zipper<A>): Option<Zipper<A>> { ... }
-```
-
-Added in v0.1.6
-
-# of
-
-**Signature**
-
-```ts
-export function of<A>(focus: A): Zipper<A> { ... }
-```
-
-Added in v0.1.6
-
-# reduce
-
-**Signature**
-
-```ts
-;<A, B>(b: B, f: (b: B, a: A) => B) => (fa: Zipper<A>) => B
-```
-
-Added in v0.1.6
-
-# reduceRight
-
-**Signature**
-
-```ts
-;<A, B>(b: B, f: (a: A, b: B) => B) => (fa: Zipper<A>) => B
-```
-
-Added in v0.1.6
-
-# start
-
-Moves focus to the start of the zipper.
-
-**Signature**
-
-```ts
-export function start<A>(fa: Zipper<A>): Zipper<A> { ... }
-```
-
-Added in v0.1.6
-
-# toArray
-
-**Signature**
-
-```ts
-export function toArray<A>(fa: Zipper<A>): Array<A> { ... }
-```
-
-Added in v0.1.6
-
-# up
-
-Moves focus of the zipper up.
-
-**Signature**
-
-```ts
-export function up<A>(fa: Zipper<A>): Option<Zipper<A>> { ... }
-```
-
-Added in v0.1.6
-
-# update
-
-Updates the focus of the zipper.
-
-**Signature**
-
-```ts
-export function update<A>(a: A): (fa: Zipper<A>) => Zipper<A> { ... }
-```
-
-Added in v0.1.6
-
-# zipper
-
-**Signature**
-
-```ts
-export const zipper: Applicative1<URI> &
-  Foldable1<URI> &
-  Traversable1<URI> &
-  Comonad1<URI> &
-  FunctorWithIndex1<URI, number> = ...
+export interface Zipper<A> {
+  readonly lefts: Array<A>
+  readonly focus: A
+  readonly rights: Array<A>
+}
 ```
 
 Added in v0.1.6

--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -42,6 +42,8 @@ Added in v0.1.6
   - [map](#map)
 - [FunctorWithIndex](#functorwithindex)
   - [mapWithIndex](#mapwithindex)
+- [Traversable](#traversable)
+  - [sequence](#sequence)
 - [combinators](#combinators)
   - [deleteLeft](#deleteleft)
   - [deleteRight](#deleteright)
@@ -69,7 +71,7 @@ Added in v0.1.6
   - [Foldable](#foldable-1)
   - [Functor](#functor-1)
   - [FunctorWithIndex](#functorwithindex-1)
-  - [Traversable](#traversable)
+  - [Traversable](#traversable-1)
   - [URI](#uri)
   - [URI (type alias)](#uri-type-alias)
   - [getMonoid](#getmonoid)
@@ -211,6 +213,18 @@ Added in v0.1.18
 
 ```ts
 export declare const mapWithIndex: <A, B>(f: (i: number, a: A) => B) => (fa: Zipper<A>) => Zipper<B>
+```
+
+Added in v0.1.18
+
+# Traversable
+
+## sequence
+
+**Signature**
+
+```ts
+export declare const sequence: Sequence1<'Zipper'>
 ```
 
 Added in v0.1.18

--- a/docs/modules/batchTraverse.ts.md
+++ b/docs/modules/batchTraverse.ts.md
@@ -4,7 +4,7 @@ nav_order: 6
 parent: Modules
 ---
 
-# batchTraverse overview
+## batchTraverse overview
 
 Added in v0.1.0
 
@@ -12,11 +12,14 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [batchTraverse](#batchtraverse)
+- [utils](#utils)
+  - [batchTraverse](#batchtraverse)
 
 ---
 
-# batchTraverse
+# utils
+
+## batchTraverse
 
 Like `array.traverse` but actions are batched in chunks.
 You can use `Array.chunksOf` to provide the `as` argument.
@@ -24,19 +27,21 @@ You can use `Array.chunksOf` to provide the `as` argument.
 **Signature**
 
 ```ts
-export function batchTraverse<M extends URIS3>(
+export declare function batchTraverse<M extends URIS3>(
   M: Monad3<M>
 ): <U, L, A, B>(as: Array<Array<A>>, f: (a: A) => Kind3<M, U, L, B>) => Kind3<M, U, L, Array<B>>
-export function batchTraverse<M extends URIS2>(
+export declare function batchTraverse<M extends URIS2>(
   M: Monad2<M>
 ): <L, A, B>(as: Array<Array<A>>, f: (a: A) => Kind2<M, L, B>) => Kind2<M, L, Array<B>>
-export function batchTraverse<M extends URIS2, L>(
+export declare function batchTraverse<M extends URIS2, L>(
   M: Monad2C<M, L>
 ): <A, B>(as: Array<Array<A>>, f: (a: A) => Kind2<M, L, B>) => Kind2<M, L, Array<B>>
-export function batchTraverse<M extends URIS>(
+export declare function batchTraverse<M extends URIS>(
   M: Monad1<M>
 ): <A, B>(as: Array<Array<A>>, f: (a: A) => Kind<M, B>) => Kind<M, Array<B>>
-export function batchTraverse<M>(M: Monad<M>): <A, B>(as: Array<Array<A>>, f: (a: A) => HKT<M, B>) => HKT<M, Array<B>> { ... }
+export declare function batchTraverse<M>(
+  M: Monad<M>
+): <A, B>(as: Array<Array<A>>, f: (a: A) => HKT<M, B>) => HKT<M, Array<B>>
 ```
 
 Added in v0.1.0

--- a/docs/modules/collectUntil.ts.md
+++ b/docs/modules/collectUntil.ts.md
@@ -4,7 +4,7 @@ nav_order: 7
 parent: Modules
 ---
 
-# collectUntil overview
+## collectUntil overview
 
 Added in v0.1.8
 
@@ -12,11 +12,14 @@ Added in v0.1.8
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [collectUntil](#collectuntil)
+- [utils](#utils)
+  - [collectUntil](#collectuntil)
 
 ---
 
-# collectUntil
+# utils
+
+## collectUntil
 
 Execute an action repeatedly until the `Option` condition returns a `Some`. Collects results into an arbitrary `Alt`
 value, such as a `Array` or `NonEmptyArray`.
@@ -24,22 +27,22 @@ value, such as a `Array` or `NonEmptyArray`.
 **Signature**
 
 ```ts
-export function collectUntil<M extends URIS2, F extends URIS>(
+export declare function collectUntil<M extends URIS2, F extends URIS>(
   M: Monad2<M>,
   F: Alt1<F>
 ): <I, E, A>(f: (i: I) => Kind2<M, E, [Kind<F, A>, Option<I>]>) => (i: I) => Kind2<M, E, Kind<F, A>>
-export function collectUntil<M extends URIS, F extends URIS2>(
+export declare function collectUntil<M extends URIS, F extends URIS2>(
   M: Monad1<M>,
   F: Alt2<F>
 ): <I, E, A>(f: (i: I) => Kind<M, [Kind2<F, E, A>, Option<I>]>) => (i: I) => Kind<M, Kind2<F, E, A>>
-export function collectUntil<M extends URIS, F extends URIS>(
+export declare function collectUntil<M extends URIS, F extends URIS>(
   M: Monad1<M>,
   F: Alt1<F>
 ): <I, A>(f: (i: I) => Kind<M, [Kind<F, A>, Option<I>]>) => (i: I) => Kind<M, Kind<F, A>>
-export function collectUntil<M, F>(
+export declare function collectUntil<M, F>(
   M: Monad<M>,
   F: Alt<F>
-): <I, A>(f: (i: I) => HKT<M, [HKT<F, A>, Option<I>]>) => (i: I) => HKT<M, HKT<F, A>> { ... }
+): <I, A>(f: (i: I) => HKT<M, [HKT<F, A>, Option<I>]>) => (i: I) => HKT<M, HKT<F, A>>
 ```
 
 **Example**

--- a/docs/modules/filterA.ts.md
+++ b/docs/modules/filterA.ts.md
@@ -4,7 +4,7 @@ nav_order: 9
 parent: Modules
 ---
 
-# filterA overview
+## filterA overview
 
 Added in v0.1.15
 
@@ -12,33 +12,38 @@ Added in v0.1.15
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [filterA](#filtera)
+- [utils](#utils)
+  - [filterA](#filtera)
 
 ---
 
-# filterA
+# utils
+
+## filterA
 
 This generalizes the array-based `filter` function.
 
 **Signature**
 
 ```ts
-export function filterA<F extends URIS4>(
+export declare function filterA<F extends URIS4>(
   F: Applicative4<F>
 ): <S, R, E, A>(p: (a: A) => Kind4<F, S, R, E, boolean>) => (as: Array<A>) => Kind4<F, S, R, E, Array<A>>
-export function filterA<F extends URIS3>(
+export declare function filterA<F extends URIS3>(
   F: Applicative3<F>
 ): <R, E, A>(p: (a: A) => Kind3<F, R, E, boolean>) => (as: Array<A>) => Kind3<F, R, E, Array<A>>
-export function filterA<F extends URIS2>(
+export declare function filterA<F extends URIS2>(
   F: Applicative2<F>
 ): <E, A>(p: (a: A) => Kind2<F, E, boolean>) => (as: Array<A>) => Kind2<F, E, Array<A>>
-export function filterA<F extends URIS2, E>(
+export declare function filterA<F extends URIS2, E>(
   F: Applicative2C<F, E>
 ): <A>(p: (a: A) => Kind2<F, E, boolean>) => (as: Array<A>) => Kind2<F, E, Array<A>>
-export function filterA<F extends URIS>(
+export declare function filterA<F extends URIS>(
   F: Applicative1<F>
 ): <A>(p: (a: A) => Kind<F, boolean>) => (as: Array<A>) => Kind<F, Array<A>>
-export function filterA<F>(F: Applicative<F>): <A>(p: (a: A) => HKT<F, boolean>) => (as: Array<A>) => HKT<F, Array<A>> { ... }
+export declare function filterA<F>(
+  F: Applicative<F>
+): <A>(p: (a: A) => HKT<F, boolean>) => (as: Array<A>) => HKT<F, Array<A>>
 ```
 
 **Example**

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -4,7 +4,7 @@ nav_order: 11
 parent: Modules
 ---
 
-# index overview
+## index overview
 
 Added in v0.1.0
 

--- a/docs/modules/time.ts.md
+++ b/docs/modules/time.ts.md
@@ -4,7 +4,7 @@ nav_order: 24
 parent: Modules
 ---
 
-# time overview
+## time overview
 
 Added in v0.1.0
 
@@ -12,11 +12,14 @@ Added in v0.1.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [time](#time)
+- [utils](#utils)
+  - [time](#time)
 
 ---
 
-# time
+# utils
+
+## time
 
 Mimics the analogous Unix command: given an action `HKT<M, A>`, we can derive an action `HKT<M, [A, number]>` that
 returns the elapsed time along with the computed value
@@ -24,11 +27,15 @@ returns the elapsed time along with the computed value
 **Signature**
 
 ```ts
-export function time<M extends URIS3>(M: MonadIO3<M>): <R, E, A>(ma: Kind3<M, R, E, A>) => Kind3<M, R, E, [A, number]>
-export function time<M extends URIS2>(M: MonadIO2<M>): <E, A>(ma: Kind2<M, E, A>) => Kind2<M, E, [A, number]>
-export function time<M extends URIS2, E>(M: MonadIO2C<M, E>): <A>(ma: Kind2<M, E, A>) => Kind2<M, E, [A, number]>
-export function time<M extends URIS>(M: MonadIO1<M>): <A>(ma: Kind<M, A>) => Kind<M, [A, number]>
-export function time<M>(M: MonadIO<M>): <A>(ma: HKT<M, A>) => HKT<M, [A, number]> { ... }
+export declare function time<M extends URIS3>(
+  M: MonadIO3<M>
+): <R, E, A>(ma: Kind3<M, R, E, A>) => Kind3<M, R, E, [A, number]>
+export declare function time<M extends URIS2>(M: MonadIO2<M>): <E, A>(ma: Kind2<M, E, A>) => Kind2<M, E, [A, number]>
+export declare function time<M extends URIS2, E>(
+  M: MonadIO2C<M, E>
+): <A>(ma: Kind2<M, E, A>) => Kind2<M, E, [A, number]>
+export declare function time<M extends URIS>(M: MonadIO1<M>): <A>(ma: Kind<M, A>) => Kind<M, [A, number]>
+export declare function time<M>(M: MonadIO<M>): <A>(ma: HKT<M, A>) => HKT<M, [A, number]>
 ```
 
 **Example**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts-contrib",
-  "version": "0.1.14",
+  "version": "0.1.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -520,9 +520,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
         }
       }
@@ -580,19 +580,12 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-      "dev": true
-    },
     "@types/glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
         "@types/minimatch": "*",
         "@types/node": "*"
       }
@@ -726,7 +719,7 @@
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
@@ -1211,7 +1204,7 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
@@ -1399,7 +1392,7 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
@@ -1463,7 +1456,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
@@ -1589,7 +1582,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
@@ -1687,7 +1680,7 @@
     },
     "diff": {
       "version": "3.2.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
@@ -1715,14 +1708,14 @@
       }
     },
     "docs-ts": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/docs-ts/-/docs-ts-0.3.4.tgz",
-      "integrity": "sha512-FYtLfQ5eUSLoTzBa/ACUoxVGzEQaw71T+XhWu0TwRM03S3AR5tygWe8jnsSiAg4FUNsrdkjv/PTmkPmyaPr0eA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/docs-ts/-/docs-ts-0.5.1.tgz",
+      "integrity": "sha512-zdBt4P6X7h577/Vku0YHAw/RR1+zpKklK+DOzed1HJltwAAciQG14qy18TzcMbVUFxrnT9OO4Y1K/lQLdX1i/Q==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "doctrine": "^3.0.0",
-        "fp-ts": "^2.0.2",
+        "fp-ts": "^2.6.2",
         "fs-extra": "^7.0.1",
         "glob": "^7.1.3",
         "markdown-toc": "^1.2.0",
@@ -1759,6 +1752,12 @@
           "requires": {
             "esutils": "^2.0.2"
           }
+        },
+        "fp-ts": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.7.1.tgz",
+          "integrity": "sha512-rYy41jF1gVhBNYbPwup50dtyT686OKOoa86PXwh8aKpBRfmvPhnBh2zUkOYj84GIMSCsgY+oJ/RVhVKRvWNPTA==",
+          "dev": true
         },
         "fs-extra": {
           "version": "7.0.1",
@@ -1945,7 +1944,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -2213,16 +2212,17 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
-      "integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.0",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
       },
       "dependencies": {
         "braces": {
@@ -2283,12 +2283,12 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
-      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
       "dev": true,
       "requires": {
-        "reusify": "^1.0.0"
+        "reusify": "^1.0.4"
       }
     },
     "fault": {
@@ -2388,7 +2388,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -2991,9 +2991,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -3031,7 +3031,7 @@
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
@@ -3256,9 +3256,9 @@
       }
     },
     "ignore": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
     },
     "import-local": {
@@ -3354,7 +3354,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -3364,7 +3364,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
@@ -3420,7 +3420,7 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
@@ -4636,9 +4636,9 @@
       }
     },
     "merge2": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "micromatch": {
@@ -4702,7 +4702,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -4729,7 +4729,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4738,7 +4738,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -4977,7 +4977,7 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
@@ -5067,7 +5067,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -5232,7 +5232,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -5264,9 +5264,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "pify": {
@@ -5631,7 +5631,7 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
@@ -5775,13 +5775,13 @@
     },
     "semver": {
       "version": "5.3.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
       "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
@@ -6173,7 +6173,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -6200,7 +6200,7 @@
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
@@ -6900,7 +6900,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -6932,7 +6932,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1754,9 +1754,9 @@
           }
         },
         "fp-ts": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.7.1.tgz",
-          "integrity": "sha512-rYy41jF1gVhBNYbPwup50dtyT686OKOoa86PXwh8aKpBRfmvPhnBh2zUkOYj84GIMSCsgY+oJ/RVhVKRvWNPTA==",
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.8.1.tgz",
+          "integrity": "sha512-HuA/6roEliHoBgEOLCKmGRcM90e2trW/ITZZ9d9P/ra7PreqQagC3Jg6OzqWkai13KUbG90b8QO9rHPBGK/ckw==",
           "dev": true
         },
         "fs-extra": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/jest": "^23.3.13",
     "@types/node": "^12.7.12",
     "benchmark": "^2.1.4",
-    "docs-ts": "^0.3.4",
+    "docs-ts": "^0.5.1",
     "doctoc": "^1.4.0",
     "dtslint": "github:gcanti/dtslint",
     "fast-check": "^1.20.0",

--- a/src/Align/Array.ts
+++ b/src/Align/Array.ts
@@ -72,7 +72,7 @@ export const alignArray: Align1<URI> = {
    */
   align: <A, B>(fa: Array<A>, fb: Array<B>): Array<These<A, B>> => {
     return alignArray.alignWith<A, B, These<A, B>>(fa, fb, identity)
-  }
+  },
 }
 
 /**
@@ -96,9 +96,11 @@ export const alignArray: Align1<URI> = {
  *
  * @since 0.1.0
  */
-export function lpadZipWith<A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: Option<A>, b: B) => C): Array<C> {
-  return array.compact(padZipWith(alignArray)(xs, ys, (ma, mb) => option.map(mb, b => f(ma, b))))
-}
+export const lpadZipWith: <A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: Option<A>, b: B) => C) => Array<C> = (
+  xs,
+  ys,
+  f
+) => array.compact(padZipWith(alignArray)(xs, ys, (ma, mb) => option.map(mb, (b) => f(ma, b))))
 
 /**
  * Takes two arrays and returns an array of corresponding pairs. If the left input array is short, it will be
@@ -115,9 +117,8 @@ export function lpadZipWith<A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: Option<A
  *
  * @since 0.1.0
  */
-export function lpadZip<A, B>(xs: Array<A>, ys: Array<B>): Array<[Option<A>, B]> {
-  return lpadZipWith(xs, ys, (a, b) => tuple(a, b))
-}
+export const lpadZip: <A, B>(xs: Array<A>, ys: Array<B>) => Array<[Option<A>, B]> = (xs, ys) =>
+  lpadZipWith(xs, ys, (a, b) => tuple(a, b))
 
 /**
  * Apply a function to pairs of elements at the same index in two arrays, collecting the results in a new array. If the
@@ -135,9 +136,11 @@ export function lpadZip<A, B>(xs: Array<A>, ys: Array<B>): Array<[Option<A>, B]>
  *
  * @since 0.1.0
  */
-export function rpadZipWith<A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: A, b: Option<B>) => C): Array<C> {
-  return lpadZipWith(ys, xs, (a, b) => f(b, a))
-}
+export const rpadZipWith: <A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: A, b: Option<B>) => C) => Array<C> = (
+  xs,
+  ys,
+  f
+) => lpadZipWith(ys, xs, (a, b) => f(b, a))
 
 /**
  * Takes two arrays and returns an array of corresponding pairs. If the right input array is short, it will be
@@ -154,6 +157,5 @@ export function rpadZipWith<A, B, C>(xs: Array<A>, ys: Array<B>, f: (a: A, b: Op
  *
  * @since 0.1.0
  */
-export function rpadZip<A, B>(xs: Array<A>, ys: Array<B>): Array<[A, Option<B>]> {
-  return rpadZipWith(xs, ys, (a, b) => tuple(a, b))
-}
+export const rpadZip: <A, B>(xs: Array<A>, ys: Array<B>) => Array<[A, Option<B>]> = (xs, ys) =>
+  rpadZipWith(xs, ys, (a, b) => tuple(a, b))

--- a/src/Align/Record.ts
+++ b/src/Align/Record.ts
@@ -54,6 +54,4 @@ export function align<A, B>(fa: Record<string, A>, fb: Record<string, B>): Recor
 /**
  * @since 0.1.0
  */
-export function nil<A>(): Record<string, A> {
-  return R.empty
-}
+export const nil: <A>() => Record<string, A> = () => R.empty

--- a/src/ArrayOption.ts
+++ b/src/ArrayOption.ts
@@ -45,9 +45,9 @@ export const fromOption: <A>(ma: Option<A>) => ArrayOption<A> = arrayOf
  * @category constructors
  * @since 0.1.10
  */
-export const fromOptionK: <A extends Array<unknown>, B>(
-  f: (...a: A) => Option<B>
-) => (...a: A) => ArrayOption<B> = f => (...a) => fromOption(f(...a))
+export const fromOptionK: <A extends Array<unknown>, B>(f: (...a: A) => Option<B>) => (...a: A) => ArrayOption<B> = (
+  f
+) => (...a) => fromOption(f(...a))
 
 /**
  * @category constructors
@@ -72,13 +72,13 @@ export const some: <A>(a: A) => ArrayOption<A> = T.of
 export const fold: <A, B>(onNone: () => Array<B>, onSome: (a: A) => Array<B>) => (as: ArrayOption<A>) => Array<B> = (
   onNone,
   onSome
-) => as => T.fold(as, onNone, onSome)
+) => (as) => T.fold(as, onNone, onSome)
 
 /**
  * @category destructors
  * @since 0.1.0
  */
-export const getOrElse: <A>(onNone: () => Array<A>) => (as: ArrayOption<A>) => Array<A> = onNone => as =>
+export const getOrElse: <A>(onNone: () => Array<A>) => (as: ArrayOption<A>) => Array<A> = (onNone) => (as) =>
   T.getOrElse(as, onNone)
 
 // -------------------------------------------------------------------------------------
@@ -89,13 +89,13 @@ export const getOrElse: <A>(onNone: () => Array<A>) => (as: ArrayOption<A>) => A
  * @category Functor
  * @since 0.1.18
  */
-export const map: <A, B>(f: (a: A) => B) => (fa: ArrayOption<A>) => ArrayOption<B> = f => fa => T.map(fa, f)
+export const map: <A, B>(f: (a: A) => B) => (fa: ArrayOption<A>) => ArrayOption<B> = (f) => (fa) => T.map(fa, f)
 
 /**
  * @category Apply
  * @since 0.1.18
  */
-export const ap: <A>(fa: ArrayOption<A>) => <B>(fab: ArrayOption<(a: A) => B>) => ArrayOption<B> = fa => fab =>
+export const ap: <A>(fa: ArrayOption<A>) => <B>(fab: ArrayOption<(a: A) => B>) => ArrayOption<B> = (fa) => (fab) =>
   T.ap(fab, fa)
 
 /**
@@ -105,7 +105,7 @@ export const ap: <A>(fa: ArrayOption<A>) => <B>(fab: ArrayOption<(a: A) => B>) =
 export const apFirst = <B>(fb: ArrayOption<B>) => <A>(fa: ArrayOption<A>): ArrayOption<A> =>
   pipe(
     fa,
-    map(a => (_: B) => a),
+    map((a) => (_: B) => a),
     ap(fb)
   )
 
@@ -130,34 +130,34 @@ export const of: <A>(a: A) => ArrayOption<A> = T.of
  * @category Monad
  * @since 0.1.10
  */
-export const chainOptionK: <A, B>(f: (a: A) => Option<B>) => (ma: ArrayOption<A>) => ArrayOption<B> = f =>
+export const chainOptionK: <A, B>(f: (a: A) => Option<B>) => (ma: ArrayOption<A>) => ArrayOption<B> = (f) =>
   chain(fromOptionK(f))
 
 /**
  * @category Monad
  * @since 0.1.18
  */
-export const chain: <A, B>(f: (a: A) => ArrayOption<B>) => (fa: ArrayOption<A>) => ArrayOption<B> = f => fa =>
+export const chain: <A, B>(f: (a: A) => ArrayOption<B>) => (fa: ArrayOption<A>) => ArrayOption<B> = (f) => (fa) =>
   T.chain(fa, f)
 
 /**
  * @category Monad
  * @since 0.1.18
  */
-export const chainFirst: <A, B>(f: (a: A) => ArrayOption<B>) => (ma: ArrayOption<A>) => ArrayOption<A> = f => ma =>
-  T.chain(ma, a => T.map(f(a), () => a))
+export const chainFirst: <A, B>(f: (a: A) => ArrayOption<B>) => (ma: ArrayOption<A>) => ArrayOption<A> = (f) => (ma) =>
+  T.chain(ma, (a) => T.map(f(a), () => a))
 
 /**
  * @category Monad
  * @since 0.1.18
  */
-export const flatten: <A>(mma: ArrayOption<ArrayOption<A>>) => ArrayOption<A> = mma => T.chain(mma, identity)
+export const flatten: <A>(mma: ArrayOption<ArrayOption<A>>) => ArrayOption<A> = (mma) => T.chain(mma, identity)
 
 /**
  * @category Alternative
  * @since 0.1.18
  */
-export const alt: <A>(that: () => ArrayOption<A>) => (fa: ArrayOption<A>) => ArrayOption<A> = that => fa =>
+export const alt: <A>(that: () => ArrayOption<A>) => (fa: ArrayOption<A>) => ArrayOption<A> = (that) => (fa) =>
   T.alt(fa, that)
 
 /**
@@ -194,7 +194,7 @@ declare module 'fp-ts/lib/HKT' {
  */
 export const Functor: Functor1<URI> = {
   URI,
-  map: T.map
+  map: T.map,
 }
 
 /**
@@ -205,7 +205,7 @@ export const Applicative: Applicative1<URI> = {
   URI,
   map: T.map,
   ap: T.ap,
-  of
+  of,
 }
 
 /**
@@ -215,7 +215,7 @@ export const Applicative: Applicative1<URI> = {
 export const Apply: Apply1<URI> = {
   URI,
   ap: T.ap,
-  map: T.map
+  map: T.map,
 }
 
 /**
@@ -227,7 +227,7 @@ export const Monad: Monad1<URI> = {
   ap: T.ap,
   chain: T.chain,
   map: T.map,
-  of: T.of
+  of: T.of,
 }
 
 /**
@@ -237,7 +237,7 @@ export const Monad: Monad1<URI> = {
 export const Alt: Alt1<URI> = {
   URI,
   alt: T.alt,
-  map: T.map
+  map: T.map,
 }
 
 /**
@@ -250,11 +250,11 @@ export const Alternative: Alternative1<URI> = {
   ap: T.ap,
   map: T.map,
   of: T.of,
-  zero
+  zero,
 }
 
 /**
- * @category
+ * @category instances
  * @since 0.1.0
  */
 export const arrayOption: Monad1<URI> & Alt1<URI> = {
@@ -263,5 +263,5 @@ export const arrayOption: Monad1<URI> & Alt1<URI> = {
   of: some,
   ap: T.ap,
   chain: T.chain,
-  alt: T.alt
+  alt: T.alt,
 }

--- a/src/ArrayOption.ts
+++ b/src/ArrayOption.ts
@@ -199,7 +199,7 @@ export const Functor: Functor1<URI> = {
 
 /**
  * @category instances
- * @since 2.7.0
+ * @since 0.1.18
  */
 export const Applicative: Applicative1<URI> = {
   URI,

--- a/src/Free.ts
+++ b/src/Free.ts
@@ -1,30 +1,22 @@
 /**
  * @since 0.1.3
  */
+import { Applicative2 } from 'fp-ts/lib/Applicative'
+import { Apply2 } from 'fp-ts/lib/Apply'
+import { identity } from 'fp-ts/lib/function'
+import { Functor2 } from 'fp-ts/lib/Functor'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from 'fp-ts/lib/HKT'
 import { Monad, Monad1, Monad2, Monad2C, Monad3 } from 'fp-ts/lib/Monad'
-import { pipeable } from 'fp-ts/lib/pipeable'
 
-/**
- * @since 0.1.3
- */
-export const URI = 'Free'
-
-/**
- * @since 0.1.3
- */
-export type URI = typeof URI
-
-declare module 'fp-ts/lib/HKT' {
-  interface URItoKind2<E, A> {
-    Free: Free<E, A>
-  }
-}
+// -------------------------------------------------------------------------------------
+// model
+// -------------------------------------------------------------------------------------
 
 /**
  * @data
  * @constructor Pure
  * @constructor Impure
+ * @category model
  * @since 0.1.3
  */
 export type Free<F, A> = Pure<F, A> | Impure<F, A, any>
@@ -40,61 +32,26 @@ interface Impure<F, A, X> {
   readonly f: (x: X) => Free<F, A>
 }
 
+// -------------------------------------------------------------------------------------
+// constructors
+// -------------------------------------------------------------------------------------
+
 const impure = <F, A, X>(fx: HKT<F, X>, f: (x: X) => Free<F, A>): Free<F, A> => ({ _tag: 'Impure', fx, f })
-
-/**
- * Check if given Free instance is Pure
- *
- * @since 0.1.3
- */
-export const isPure = <F, A>(fa: Free<F, A>): fa is Pure<F, A> => fa._tag === 'Pure'
-
-/**
- * Check if given Free instance is Impure
- *
- * @since 0.1.3
- */
-export const isImpure = <F, A>(fa: Free<F, A>): fa is Impure<F, A, any> => fa._tag === 'Impure'
 
 /**
  * Lift an impure value described by the generating type constructor `F` into the free monad
  *
+ * @category constructors
  * @since 0.1.3
  */
 export const liftF = <F, A>(fa: HKT<F, A>): Free<F, A> => impure(fa, a => free.of(a))
 
-const substFree = <F, G>(f: <A>(fa: HKT<F, A>) => Free<G, A>): (<A>(fa: Free<F, A>) => Free<G, A>) => {
-  function go<A>(fa: Free<F, A>): Free<G, A> {
-    switch (fa._tag) {
-      case 'Pure':
-        return free.of(fa.value)
-      case 'Impure':
-        return free.chain(f(fa.fx), x => go(fa.f(x)))
-    }
-  }
-  return go
-}
+// -------------------------------------------------------------------------------------
+// destructors
+// -------------------------------------------------------------------------------------
 
 /**
- * Use a natural transformation to change the generating type constructor of a free monad
- *
- * @since 0.1.3
- */
-export function hoistFree<F extends URIS3 = never, G extends URIS3 = never>(
-  nt: <U, L, A>(fa: Kind3<F, U, L, A>) => Kind3<G, U, L, A>
-): <A>(fa: Free<F, A>) => Free<G, A>
-export function hoistFree<F extends URIS2 = never, G extends URIS2 = never>(
-  nt: <L, A>(fa: Kind2<F, L, A>) => Kind2<G, L, A>
-): <A>(fa: Free<F, A>) => Free<G, A>
-export function hoistFree<F extends URIS = never, G extends URIS = never>(
-  nt: <A>(fa: Kind<F, A>) => Kind<G, A>
-): <A>(fa: Free<F, A>) => Free<G, A>
-export function hoistFree<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(fa: Free<F, A>) => Free<G, A>
-export function hoistFree<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(fa: Free<F, A>) => Free<G, A> {
-  return substFree(fa => liftF(nt(fa)))
-}
-
-/**
+ * @category destructors
  * @since 0.1.3
  */
 export interface FoldFree3<M extends URIS3> {
@@ -104,6 +61,7 @@ export interface FoldFree3<M extends URIS3> {
 }
 
 /**
+ * @category destructors
  * @since 0.1.3
  */
 export interface FoldFree2<M extends URIS2> {
@@ -112,6 +70,7 @@ export interface FoldFree2<M extends URIS2> {
 }
 
 /**
+ * @category destructors
  * @since 0.1.3
  */
 export interface FoldFree2C<M extends URIS2, L> {
@@ -122,6 +81,7 @@ export interface FoldFree2C<M extends URIS2, L> {
 /**
  * Perform folding of a free monad using given natural transformation as an interpreter
  *
+ * @category destructors
  * @since 0.1.3
  */
 export function foldFree<M extends URIS3>(M: Monad3<M>): FoldFree3<M>
@@ -141,49 +101,167 @@ export function foldFree<M>(M: Monad<M>): <F, A>(nt: any, fa: Free<F, A>) => HKT
   }
 }
 
+// -------------------------------------------------------------------------------------
+// combinators
+// -------------------------------------------------------------------------------------
+
+const substFree = <F, G>(f: <A>(fa: HKT<F, A>) => Free<G, A>): (<A>(fa: Free<F, A>) => Free<G, A>) => {
+  function go<A>(fa: Free<F, A>): Free<G, A> {
+    switch (fa._tag) {
+      case 'Pure':
+        return free.of(fa.value)
+      case 'Impure':
+        return free.chain(f(fa.fx), x => go(fa.f(x)))
+    }
+  }
+  return go
+}
+
+/**
+ * Use a natural transformation to change the generating type constructor of a free monad
+ *
+ * @category combinators
+ * @since 0.1.3
+ */
+export function hoistFree<F extends URIS3 = never, G extends URIS3 = never>(
+  nt: <U, L, A>(fa: Kind3<F, U, L, A>) => Kind3<G, U, L, A>
+): <A>(fa: Free<F, A>) => Free<G, A>
+export function hoistFree<F extends URIS2 = never, G extends URIS2 = never>(
+  nt: <L, A>(fa: Kind2<F, L, A>) => Kind2<G, L, A>
+): <A>(fa: Free<F, A>) => Free<G, A>
+export function hoistFree<F extends URIS = never, G extends URIS = never>(
+  nt: <A>(fa: Kind<F, A>) => Kind<G, A>
+): <A>(fa: Free<F, A>) => Free<G, A>
+export function hoistFree<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(fa: Free<F, A>) => Free<G, A>
+export function hoistFree<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(fa: Free<F, A>) => Free<G, A> {
+  return substFree(fa => liftF(nt(fa)))
+}
+
+// -------------------------------------------------------------------------------------
+// non-pipeables
+// -------------------------------------------------------------------------------------
+
+const map_: <F, A, B>(fa: Free<F, A>, f: (a: A) => B) => Free<F, B> = (fa, f) =>
+  isPure(fa) ? free.of(f(fa.value)) : impure(fa.fx, x => free.map(fa.f(x), f))
+const ap_: <F, A, B>(fab: Free<F, (a: A) => B>, fa: Free<F, A>) => Free<F, B> = (fab, fa) =>
+  free.chain(fab, f => free.map(fa, f))
+const chain_: <F, A, B>(ma: Free<F, A>, f: (a: A) => Free<F, B>) => Free<F, B> = (ma, f) =>
+  isPure(ma) ? f(ma.value) : impure(ma.fx, x => free.chain(ma.f(x), f))
+
+// -------------------------------------------------------------------------------------
+// pipeables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category Functor
+ * @since 0.1.18
+ */
+export const map: <A, B>(f: (a: A) => B) => <F>(fa: Free<F, A>) => Free<F, B> = f => fa => map_(fa, f)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const ap: <F, A, B>(fa: Free<F, A>) => (fab: Free<F, (a: A) => B>) => Free<F, B> = fa => fab => ap_(fab, fa)
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const chain: <F, A, B>(f: (a: A) => Free<F, B>) => (ma: Free<F, A>) => Free<F, B> = f => ma => chain_(ma, f)
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const flatten: <E, A>(mma: Free<E, Free<E, A>>) => Free<E, A> = mma => chain_(mma, identity)
+
+/**
+ * @category Applicative
+ * @since 0.1.18
+ */
+export const of: <F, A>(a: A) => Free<F, A> = a => ({ _tag: 'Pure', value: a })
+
+// -------------------------------------------------------------------------------------
+// instances
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category instances
+ * @since 0.1.3
+ */
+export const URI = 'Free'
+
+/**
+ * @category instances
+ * @since 0.1.3
+ */
+export type URI = typeof URI
+
+declare module 'fp-ts/lib/HKT' {
+  interface URItoKind2<E, A> {
+    Free: Free<E, A>
+  }
+}
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Functor: Functor2<URI> = {
+  URI,
+  map: map_
+}
+
+/**
+ * @category instances
+ * @since 2.7.0
+ */
+export const Applicative: Applicative2<URI> = {
+  URI,
+  map: map_,
+  ap: ap_,
+  of
+}
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Apply: Apply2<URI> = {
+  URI,
+  ap: ap_,
+  map: map_
+}
+
 /**
  * Monad instance for Free
  *
+ * @category instances
  * @since 0.1.3
  */
 export const free: Monad2<URI> = {
   URI,
-  /**
-   * @since 0.1.3
-   */
-  of: <F, A>(value: A): Free<F, A> => ({ _tag: 'Pure', value }),
-  /**
-   * @since 0.1.3
-   */
-  chain: <F, A, B>(ma: Free<F, A>, f: (a: A) => Free<F, B>): Free<F, B> =>
-    isPure(ma) ? f(ma.value) : impure(ma.fx, x => free.chain(ma.f(x), f)),
-  /**
-   * @since 0.1.3
-   */
-  map: (fa, f) => (isPure(fa) ? free.of(f(fa.value)) : impure(fa.fx, x => free.map(fa.f(x), f))),
-  /**
-   * @since 0.1.3
-   */
-  ap: (fab, fa) => free.chain(fab, f => free.map(fa, f))
+  ap: ap_,
+  chain: chain_,
+  map: map_,
+  of
 }
 
-const { ap, chain, map, flatten } = pipeable(free)
+// -------------------------------------------------------------------------------------
+// utils
+// -------------------------------------------------------------------------------------
 
-export {
-  /**
-   * @since 0.1.3
-   */
-  ap,
-  /**
-   * @since 0.1.3
-   */
-  chain,
-  /**
-   * @since 0.1.3
-   */
-  map,
-  /**
-   * @since 0.1.3
-   */
-  flatten
-}
+/**
+ * Check if given Free instance is Pure
+ *
+ * @since 0.1.3
+ */
+export const isPure = <F, A>(fa: Free<F, A>): fa is Pure<F, A> => fa._tag === 'Pure'
+
+/**
+ * Check if given Free instance is Impure
+ *
+ * @since 0.1.3
+ */
+export const isImpure = <F, A>(fa: Free<F, A>): fa is Impure<F, A, any> => fa._tag === 'Impure'

--- a/src/Free.ts
+++ b/src/Free.ts
@@ -215,7 +215,7 @@ export const Functor: Functor2<URI> = {
 
 /**
  * @category instances
- * @since 2.7.0
+ * @since 0.1.18
  */
 export const Applicative: Applicative2<URI> = {
   URI,

--- a/src/IOOption.ts
+++ b/src/IOOption.ts
@@ -2,20 +2,271 @@
  * @since 0.1.14
  */
 import { Alt1 } from 'fp-ts/lib/Alt'
+import { Applicative1 } from 'fp-ts/lib/Applicative'
+import { Apply1 } from 'fp-ts/lib/Apply'
+import { Alternative1 } from 'fp-ts/lib/Alternative'
+import { Separated, Compactable1 } from 'fp-ts/lib/Compactable'
+import { Either } from 'fp-ts/lib/Either'
+import { Functor1 } from 'fp-ts/lib/Functor'
 import * as O from 'fp-ts/lib/Option'
 import { getOptionM } from 'fp-ts/lib/OptionT'
 import { getFilterableComposition, Filterable1 } from 'fp-ts/lib/Filterable'
-import { getSemigroup as getIOSemigroup, IO, io, of, map as ioMap } from 'fp-ts/lib/IO'
+import { identity, Predicate, Refinement } from 'fp-ts/lib/function'
+import { getSemigroup as getIOSemigroup, io, of as ioOf, map as ioMap, IO } from 'fp-ts/lib/IO'
+import { IOEither } from 'fp-ts/lib/IOEither'
 import { Monad1 } from 'fp-ts/lib/Monad'
 import { MonadIO1 } from 'fp-ts/lib/MonadIO'
 import { Monoid } from 'fp-ts/lib/Monoid'
-import { pipeable } from 'fp-ts/lib/pipeable'
+import { pipe } from 'fp-ts/lib/pipeable'
 import { Semigroup } from 'fp-ts/lib/Semigroup'
 
 import Option = O.Option
-import { IOEither } from 'fp-ts/lib/IOEither'
 
 const T = getOptionM(io)
+const F = getFilterableComposition(io, O.option)
+
+// -------------------------------------------------------------------------------------
+// model
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category model
+ * @since 0.1.14
+ */
+export interface IOOption<A> extends IO<Option<A>> {}
+
+// -------------------------------------------------------------------------------------
+// constructors
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category constructors
+ * @since 0.1.14
+ */
+export const none: IOOption<never> = T.none()
+
+/**
+ * @category constructors
+ * @since 0.1.14
+ */
+export const some: <A = never>(a: A) => IOOption<A> = T.of
+
+/**
+ * @category constructors
+ * @since 0.1.14
+ */
+export const fromIO: <A = never>(ma: IO<A>) => IOOption<A> = T.fromM
+
+/**
+ * @category constructors
+ * @since 0.1.14
+ */
+export const fromOption: <A = never>(ma: Option<A>) => IOOption<A> = ioOf
+
+/**
+ * @category constructors
+ * @since 0.1.14
+ */
+export const fromOptionK: <A extends Array<unknown>, B>(f: (...a: A) => Option<B>) => (...a: A) => IOOption<B> = f => (
+  ...a
+) => fromOption(f(...a))
+
+/**
+ * @category constructors
+ * @since 0.1.14
+ */
+export const fromNullable: <A>(a: A) => IOOption<NonNullable<A>> = a => fromOption(O.fromNullable(a))
+
+/**
+ * @category constructors
+ * @since 0.1.14
+ */
+export const fromIOEither: <A>(ma: IOEither<any, A>) => IOOption<A> = ma => io.map(ma, O.fromEither)
+
+// -------------------------------------------------------------------------------------
+// destructors
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category destructors
+ * @since 0.1.14
+ */
+export const fold: <A, B>(onNone: () => IO<B>, onSome: (a: A) => IO<B>) => (ma: IOOption<A>) => IO<B> = (
+  onNone,
+  onSome
+) => ma => T.fold(ma, onNone, onSome)
+
+/**
+ * @category destructors
+ * @since 0.1.14
+ */
+export const getOrElse: <A>(onNone: () => IO<A>) => (ma: IOOption<A>) => IO<A> = onNone => ma => T.getOrElse(ma, onNone)
+
+/**
+ * @category destructors
+ * @since 0.1.14
+ */
+export const toUndefined: <A>(ma: IOOption<A>) => IO<A | undefined> = ma => io.map(ma, O.toUndefined)
+
+/**
+ * @category destructors
+ * @since 0.1.14
+ */
+export const toNullable: <A>(ma: IOOption<A>) => IO<A | null> = ma => io.map(ma, O.toNullable)
+
+// -------------------------------------------------------------------------------------
+// combinators
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 0.1.14
+ */
+export const mapNullable: <A, B>(f: (a: A) => B | null | undefined) => (ma: IOOption<A>) => IOOption<B> = f =>
+  ioMap(O.mapNullable(f))
+
+// -------------------------------------------------------------------------------------
+// pipeables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category Functor
+ * @since 0.1.18
+ */
+export const map: <A, B>(f: (a: A) => B) => (fa: IOOption<A>) => IOOption<B> = f => fa => T.map(fa, f)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const ap: <A>(fa: IOOption<A>) => <B>(fab: IOOption<(a: A) => B>) => IOOption<B> = fa => fab => T.ap(fab, fa)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const apFirst = <B>(fb: IOOption<B>) => <A>(fa: IOOption<A>): IOOption<A> =>
+  pipe(
+    fa,
+    map(a => (_: B) => a),
+    ap(fb)
+  )
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const apSecond = <B>(fb: IOOption<B>) => <A>(fa: IOOption<A>): IOOption<B> =>
+  pipe(
+    fa,
+    map(() => (b: B) => b),
+    ap(fb)
+  )
+
+/**
+ * @category Applicative
+ * @since 0.1.18
+ */
+export const of: <A>(a: A) => IOOption<A> = some
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const chain: <A, B>(f: (a: A) => IOOption<B>) => (ma: IOOption<A>) => IOOption<B> = f => ma => T.chain(ma, f)
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const chainFirst: <A, B>(f: (a: A) => IOOption<B>) => (ma: IOOption<A>) => IOOption<A> = f => ma =>
+  T.chain(ma, a => T.map(f(a), () => a))
+
+/**
+ * @category Monad
+ * @since 0.1.14
+ */
+export const chainOptionK: <A, B>(f: (a: A) => Option<B>) => (ma: IOOption<A>) => IOOption<B> = f =>
+  chain(fromOptionK(f))
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const flatten: <A>(mma: IOOption<IOOption<A>>) => IOOption<A> = mma => T.chain(mma, identity)
+
+/**
+ * @category Alt
+ * @since 0.1.18
+ */
+export const alt: <A>(that: () => IOOption<A>) => (fa: IOOption<A>) => IOOption<A> = that => fa => T.alt(fa, that)
+
+/**
+ * @category Alternative
+ * @since 0.1.18
+ */
+export const zero: Alternative1<URI>['zero'] = () => () => O.none
+
+/**
+ * @category Compactable
+ * @since 0.1.18
+ */
+export const compact: <A>(fa: IOOption<O.Option<A>>) => IOOption<A> = F.compact
+
+/**
+ * @category Compactable
+ * @since 0.1.18
+ */
+export const separate: <A, B>(fa: IOOption<Either<A, B>>) => Separated<IOOption<A>, IOOption<B>> = F.separate
+
+/**
+ * @category Filterable
+ * @since 0.1.18
+ */
+export const filter: {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: IOOption<A>) => IOOption<B>
+  <A>(predicate: Predicate<A>): (fa: IOOption<A>) => IOOption<A>
+} = <A>(predicate: Predicate<A>) => (fa: IOOption<A>) => F.filter(fa, predicate)
+
+/**
+ * @category Filterable
+ * @since 0.1.18
+ */
+export const filterMap: <A, B>(f: (a: A) => O.Option<B>) => (fa: IOOption<A>) => IOOption<B> = f => fa =>
+  F.filterMap(fa, f)
+
+/**
+ * @category Filterable
+ * @since 0.1.18
+ */
+export const partition: {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: IOOption<A>) => Separated<IOOption<A>, IOOption<B>>
+  <A>(predicate: Predicate<A>): (fa: IOOption<A>) => Separated<IOOption<A>, IOOption<A>>
+} = <A>(predicate: Predicate<A>) => (fa: IOOption<A>) => F.partition(fa, predicate)
+
+/**
+ * @category Filterable
+ * @since 0.1.18
+ */
+export const partitionMap: <A, B, C>(
+  f: (a: A) => Either<B, C>
+) => (fa: IOOption<A>) => Separated<IOOption<B>, IOOption<C>> = f => fa => F.partitionMap(fa, f)
+
+// -------------------------------------------------------------------------------------
+// instances
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category instances
+ * @since 0.1.14
+ */
+export const URI = 'IOOption'
+
+/**
+ * @category instances
+ * @since 0.1.14
+ */
+export type URI = typeof URI
 
 declare module 'fp-ts/lib/HKT' {
   interface URItoKind<A> {
@@ -24,118 +275,109 @@ declare module 'fp-ts/lib/HKT' {
 }
 
 /**
+ * @category instances
  * @since 0.1.14
  */
-export const URI = 'IOOption'
+export const getApplySemigroup = <A>(S: Semigroup<A>): Semigroup<IOOption<A>> =>
+  getIOSemigroup(O.getApplySemigroup<A>(S))
 
 /**
+ * @category instances
  * @since 0.1.14
  */
-export type URI = typeof URI
+export const getApplyMonoid = <A>(M: Monoid<A>): Monoid<IOOption<A>> => ({
+  concat: getApplySemigroup<A>(M).concat,
+  empty: some(M.empty)
+})
 
 /**
- * @since 0.1.14
+ * @category instances
+ * @since 0.1.18
  */
-export interface IOOption<A> extends IO<Option<A>> {}
-
-/**
- * @since 0.1.14
- */
-export const none: IOOption<never> = T.none()
-
-/**
- * @since 0.1.14
- */
-export const some: <A = never>(a: A) => IOOption<A> = T.of
-
-/**
- * @since 0.1.14
- */
-export const fromIO: <A = never>(ma: IO<A>) => IOOption<A> = T.fromM
-
-/**
- * @since 0.1.14
- */
-export const fromOption: <A = never>(ma: Option<A>) => IOOption<A> = of
-
-/**
- * @since 0.1.14
- */
-export function fold<A, B>(onNone: () => IO<B>, onSome: (a: A) => IO<B>): (ma: IOOption<A>) => IO<B> {
-  return ma => T.fold(ma, onNone, onSome)
+export const Functor: Functor1<URI> = {
+  URI,
+  map: T.map
 }
 
 /**
- * @since 0.1.14
+ * @category instances
+ * @since 0.1.18
  */
-export function fromNullable<A>(a: A): IOOption<NonNullable<A>> {
-  return fromOption(O.fromNullable(a))
+export const Applicative: Applicative1<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  of
 }
 
 /**
- * @since 0.1.14
+ * @category instances
+ * @since 0.1.18
  */
-export function getOrElse<A>(onNone: () => IO<A>): (ma: IOOption<A>) => IO<A> {
-  return ma => T.getOrElse(ma, onNone)
+export const Apply: Apply1<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap
 }
 
 /**
- * @since 0.1.14
+ * @category instances
+ * @since 0.1.18
  */
-export function fromIOEither<A>(ma: IOEither<any, A>): IOOption<A> {
-  return io.map(ma, O.fromEither)
+export const Monad: Monad1<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  of,
+  chain: T.chain
 }
 
 /**
- * @since 0.1.14
+ * @category instances
+ * @since 0.1.18
  */
-export function toUndefined<A>(ma: IOOption<A>): IO<A | undefined> {
-  return io.map(ma, O.toUndefined)
+export const Alt: Alt1<URI> = {
+  URI,
+  map: T.map,
+  alt: T.alt
 }
 
 /**
- * @since 0.1.14
+ * @category instances
+ * @since 0.1.18
  */
-export function toNullable<A>(ma: IOOption<A>): IO<A | null> {
-  return io.map(ma, O.toNullable)
+export const Alternative: Alternative1<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  of,
+  alt: T.alt,
+  zero
 }
 
 /**
- * @since 0.1.14
+ * @category instances
+ * @since 0.1.18
  */
-export function mapNullable<A, B>(f: (a: A) => B | null | undefined): (ma: IOOption<A>) => IOOption<B> {
-  return ioMap(O.mapNullable(f))
+export const Compactable: Compactable1<URI> = {
+  URI,
+  compact,
+  separate
 }
 
 /**
- * @since 0.1.14
+ * @category instances
+ * @since 0.1.18
  */
-export function getApplySemigroup<A>(S: Semigroup<A>): Semigroup<IOOption<A>> {
-  return getIOSemigroup(O.getApplySemigroup<A>(S))
-}
-
-/**
- * @since 0.1.14
- */
-export function getApplyMonoid<A>(M: Monoid<A>): Monoid<IOOption<A>> {
-  return {
-    concat: getApplySemigroup<A>(M).concat,
-    empty: some(M.empty)
-  }
-}
-
-/**
- * @since 0.1.14
- */
-export function fromOptionK<A extends Array<unknown>, B>(f: (...a: A) => Option<B>): (...a: A) => IOOption<B> {
-  return (...a) => fromOption(f(...a))
-}
-
-/**
- * @since 0.1.14
- */
-export function chainOptionK<A, B>(f: (a: A) => Option<B>): (ma: IOOption<A>) => IOOption<B> {
-  return chain(fromOptionK(f))
+export const Filterable: Filterable1<URI> = {
+  URI,
+  map: T.map,
+  compact,
+  separate,
+  filter: F.filter,
+  filterMap: F.filterMap,
+  partition: F.partition,
+  partitionMap: F.partitionMap
 }
 
 /**
@@ -149,81 +391,5 @@ export const ioOption: Monad1<URI> & Alt1<URI> & MonadIO1<URI> & Filterable1<URI
   chain: T.chain,
   alt: T.alt,
   fromIO,
-  ...getFilterableComposition(io, O.option)
-}
-
-const {
-  alt,
-  ap,
-  apFirst,
-  apSecond,
-  chain,
-  chainFirst,
-  flatten,
-  map,
-  partition,
-  partitionMap,
-  filter,
-  filterMap,
-  compact,
-  separate
-} = pipeable(ioOption)
-
-export {
-  /**
-   * @since 0.1.14
-   */
-  alt,
-  /**
-   * @since 0.1.14
-   */
-  ap,
-  /**
-   * @since 0.1.14
-   */
-  apFirst,
-  /**
-   * @since 0.1.14
-   */
-  apSecond,
-  /**
-   * @since 0.1.14
-   */
-  chain,
-  /**
-   * @since 0.1.14
-   */
-  chainFirst,
-  /**
-   * @since 0.1.14
-   */
-  flatten,
-  /**
-   * @since 0.1.14
-   */
-  map,
-  /**
-   * @since 0.1.14
-   */
-  partition,
-  /**
-   * @since 0.1.14
-   */
-  partitionMap,
-  /**
-   * @since 0.1.14
-   */
-  filter,
-  /**
-   * @since 0.1.14
-   */
-  filterMap,
-  /**
-   * @since 0.1.14
-   */
-  compact,
-  /**
-   * @since 0.1.14
-   */
-  separate
+  ...F
 }

--- a/src/List.ts
+++ b/src/List.ts
@@ -69,7 +69,7 @@ export const cons: <A>(head: A, tail: List<A>) => List<A> = (head, tail) => ({
   type: 'Cons',
   head,
   tail,
-  length: 1 + tail.length
+  length: 1 + tail.length,
 })
 
 /**
@@ -103,7 +103,7 @@ export const fromArray = <A>(as: Array<A>): List<A> => A.array.reduceRight<A, Li
  * @category destructors
  * @since 0.1.8
  */
-export const head: <A>(fa: List<A>) => O.Option<A> = fa => (isCons(fa) ? O.some(fa.head) : O.none)
+export const head: <A>(fa: List<A>) => O.Option<A> = (fa) => (isCons(fa) ? O.some(fa.head) : O.none)
 
 /**
  * Gets all but the first element of a list, or `None` if the list is empty.
@@ -119,7 +119,7 @@ export const head: <A>(fa: List<A>) => O.Option<A> = fa => (isCons(fa) ? O.some(
  * @category destructors
  * @since 0.1.8
  */
-export const tail: <A>(fa: List<A>) => O.Option<List<A>> = fa => (isCons(fa) ? O.some(fa.tail) : O.none)
+export const tail: <A>(fa: List<A>) => O.Option<List<A>> = (fa) => (isCons(fa) ? O.some(fa.tail) : O.none)
 
 /**
  * Breaks a list into its first element and the remaining elements.
@@ -139,7 +139,7 @@ export const tail: <A>(fa: List<A>) => O.Option<List<A>> = fa => (isCons(fa) ? O
 export const foldLeft: <A, B>(onNil: () => B, onCons: (head: A, tail: List<A>) => B) => (fa: List<A>) => B = (
   onNil,
   onCons
-) => fa => (isNil(fa) ? onNil() : onCons(fa.head, fa.tail))
+) => (fa) => (isNil(fa) ? onNil() : onCons(fa.head, fa.tail))
 
 /**
  * Gets an array from a list.
@@ -250,7 +250,7 @@ export const dropLeft = (n: number) => <A>(fa: List<A>): List<A> => {
 export function dropLeftWhile<A, B extends A>(refinement: Refinement<A, B>): (fa: List<A>) => List<B>
 export function dropLeftWhile<A>(predicate: Predicate<A>): (fa: List<A>) => List<A>
 export function dropLeftWhile<A>(predicate: Predicate<A>): (fa: List<A>) => List<A> {
-  return fa => {
+  return (fa) => {
     if (isNil(fa)) return nil
 
     let l: List<A> = fa
@@ -277,7 +277,7 @@ const reduce_: Foldable1<URI>['reduce'] = (fa, b, f) => {
   return out
 }
 const reduceRight_: Foldable1<URI>['reduceRight'] = (fa, b, f) => A.array.reduceRight(toArray(fa), b, f)
-const foldMap_: Foldable1<URI>['foldMap'] = M => (fa, f) => {
+const foldMap_: Foldable1<URI>['foldMap'] = (M) => (fa, f) => {
   let out = M.empty
   let l = fa
   while (isCons(l)) {
@@ -290,7 +290,7 @@ const traverse_ = <F>(F: Applicative<F>): (<A, B>(ta: List<A>, f: (a: A) => HKT<
   return <A, B>(ta: List<A>, f: (a: A) => HKT<F, B>) =>
     list.reduceRight(ta, F.of<List<B>>(nil), (a, fbs) =>
       F.ap(
-        F.map(fbs, bs => (b: B) => cons(b, bs)),
+        F.map(fbs, (bs) => (b: B) => cons(b, bs)),
         f(a)
       )
     )
@@ -298,7 +298,7 @@ const traverse_ = <F>(F: Applicative<F>): (<A, B>(ta: List<A>, f: (a: A) => HKT<
 const sequence_ = <F>(F: Applicative<F>) => <A>(ta: List<HKT<F, A>>): HKT<F, List<A>> => {
   return list.reduceRight(ta, F.of<List<A>>(nil), (a, fas) =>
     F.ap(
-      F.map(fas, as => (a: A) => cons(a, as)),
+      F.map(fas, (as) => (a: A) => cons(a, as)),
       a
     )
   )
@@ -312,29 +312,29 @@ const sequence_ = <F>(F: Applicative<F>) => <A>(ta: List<HKT<F, A>>): HKT<F, Lis
  * @category Functor
  * @since 0.1.18
  */
-export const map: <A, B>(f: (a: A) => B) => (fa: List<A>) => List<B> = f => fa => map_(fa, f)
+export const map: <A, B>(f: (a: A) => B) => (fa: List<A>) => List<B> = (f) => (fa) => map_(fa, f)
 
 /**
  * @category Foldable
  * @since 0.1.18
  */
-export const reduce: <A, B>(b: B, f: (b: B, a: A) => B) => (fa: List<A>) => B = (b, f) => fa => reduce_(fa, b, f)
+export const reduce: <A, B>(b: B, f: (b: B, a: A) => B) => (fa: List<A>) => B = (b, f) => (fa) => reduce_(fa, b, f)
 
 /**
  * @category Foldable
  * @since 0.1.18
  */
-export const reduceRight: <A, B>(b: B, f: (a: A, b: B) => B) => (fa: List<A>) => B = (b, f) => fa =>
+export const reduceRight: <A, B>(b: B, f: (a: A, b: B) => B) => (fa: List<A>) => B = (b, f) => (fa) =>
   reduceRight_(fa, b, f)
 
 /**
  * @category Foldable
  * @since 0.1.18
  */
-export const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: List<A>) => M = M => f => fa =>
+export const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: List<A>) => M = (M) => (f) => (fa) =>
   foldMap_(M)(fa, f)
 
-// TODO: add when fp-ts version >= 2.6.3
+// TODO: add pipeable traverse when fp-ts version >= 2.6.3
 // /**
 //  * @category Traversable
 //  * @since 0.1.18
@@ -346,7 +346,7 @@ export const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: List<A>) 
 //   return f => ta => traverseF(ta, f)
 // }
 
-// TODO: add when fp-ts version >= 2.6.3
+// TODO: add pipeable sequence when fp-ts version >= 2.6.3
 // /**
 //  * @category Traversable
 //  * @since 0.1.18
@@ -364,7 +364,7 @@ export const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: List<A>) 
  * @category Applicative
  * @since 0.1.8
  */
-export const of: <A>(head: A) => List<A> = head => cons(head, nil)
+export const of: <A>(head: A) => List<A> = (head) => cons(head, nil)
 
 // -------------------------------------------------------------------------------------
 // utils
@@ -446,7 +446,7 @@ export const getEq = <A>(E: Eq.Eq<A>): Eq.Eq<List<A>> => ({
       ly = ly.tail
     }
     return true
-  }
+  },
 })
 
 /**
@@ -455,7 +455,7 @@ export const getEq = <A>(E: Eq.Eq<A>): Eq.Eq<List<A>> => ({
  */
 export const Functor: Functor1<URI> = {
   URI,
-  map: map_
+  map: map_,
 }
 
 /**
@@ -466,7 +466,7 @@ export const Foldable: Foldable1<URI> = {
   URI,
   foldMap: foldMap_,
   reduce: reduce_,
-  reduceRight: reduceRight_
+  reduceRight: reduceRight_,
 }
 
 /**
@@ -480,7 +480,7 @@ export const Traversable: Traversable1<URI> = {
   reduce: reduce_,
   reduceRight: reduceRight_,
   traverse: traverse_,
-  sequence: sequence_
+  sequence: sequence_,
 }
 
 /**
@@ -494,7 +494,7 @@ export const list: Functor1<URI> & Foldable1<URI> & Traversable1<URI> = {
   foldMap: foldMap_,
   reduceRight: reduceRight_,
   traverse: traverse_,
-  sequence: sequence_
+  sequence: sequence_,
 }
 
 // -------------------------------------------------------------------------------------

--- a/src/List.ts
+++ b/src/List.ts
@@ -346,12 +346,13 @@ export const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: List<A>) 
 //   return f => ta => traverseF(ta, f)
 // }
 
-// TODO: add pipeable sequence when fp-ts version >= 2.6.3
-// /**
-//  * @category Traversable
-//  * @since 0.1.18
-//  */
-// export const sequence = <F>(F: Applicative<F>): (<A>(ta: List<HKT<F, A>>) => HKT<F, List<A>>) => sequence(F)
+/**
+ * @category Traversable
+ * @since 0.1.18
+ */
+export const sequence: Traversable1<URI>['sequence'] = <F>(
+  F: Applicative<F>
+): (<A>(ta: List<HKT<F, A>>) => HKT<F, List<A>>) => sequence_(F)
 
 /**
  * Creates a list with a single element.

--- a/src/RegExp.ts
+++ b/src/RegExp.ts
@@ -6,9 +6,9 @@
  * @since 0.1.8
  */
 
-import * as O from 'fp-ts/lib/Option'
 import { Predicate } from 'fp-ts/lib/function'
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
+import * as O from 'fp-ts/lib/Option'
 
 /**
  * Returns the list of subexpression matches, or `None` if the match fails.
@@ -24,9 +24,7 @@ import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
  *
  * @since 0.1.8
  */
-export function match(r: RegExp): (s: string) => O.Option<RegExpMatchArray> {
-  return s => O.fromNullable(s.match(r))
-}
+export const match: (r: RegExp) => (s: string) => O.Option<RegExpMatchArray> = r => s => O.fromNullable(s.match(r))
 
 /**
  * Returns `true` if the string matches the regular expression,
@@ -41,9 +39,7 @@ export function match(r: RegExp): (s: string) => O.Option<RegExpMatchArray> {
  *
  * @since 0.1.8
  */
-export function test(r: RegExp): Predicate<string> {
-  return s => r.test(s)
-}
+export const test: (r: RegExp) => Predicate<string> = r => s => r.test(s)
 
 /**
  * Replaces every occurance of the given regular expression
@@ -57,9 +53,8 @@ export function test(r: RegExp): Predicate<string> {
  *
  * @since 0.1.8
  */
-export function sub(r: RegExp, replacement: string): (s: string) => string {
-  return s => s.replace(r, replacement)
-}
+export const sub: (r: RegExp, replacement: string) => (s: string) => string = (r, replacement) => s =>
+  s.replace(r, replacement)
 
 /**
  * Splits a string based on a regular expression. The regular expression
@@ -74,6 +69,4 @@ export function sub(r: RegExp, replacement: string): (s: string) => string {
  *
  * @since 0.1.8
  */
-export function split(r: RegExp): (s: string) => NonEmptyArray<string> {
-  return s => s.split(r) as any
-}
+export const split: (r: RegExp) => (s: string) => NonEmptyArray<string> = r => s => s.split(r) as any

--- a/src/StateEither.ts
+++ b/src/StateEither.ts
@@ -1,14 +1,215 @@
 /**
  * @since 0.1.12
  */
+import { Applicative3 } from 'fp-ts/lib/Applicative'
+import { Apply3 } from 'fp-ts/lib/Apply'
 import * as E from 'fp-ts/lib/Either'
+import { identity, Predicate, Refinement } from 'fp-ts/lib/function'
+import { Functor3 } from 'fp-ts/lib/Functor'
 import { Monad3 } from 'fp-ts/lib/Monad'
 import { MonadThrow3 } from 'fp-ts/lib/MonadThrow'
+import { Option } from 'fp-ts/lib/Option'
+import { pipe } from 'fp-ts/lib/pipeable'
 import { State } from 'fp-ts/lib/State'
 import { getStateM } from 'fp-ts/lib/StateT'
-import { pipeable } from 'fp-ts/lib/pipeable'
 
 const T = getStateM(E.either)
+
+// -------------------------------------------------------------------------------------
+// model
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category model
+ * @since 0.1.12
+ */
+export interface StateEither<S, E, A> {
+  (s: S): E.Either<E, [A, S]>
+}
+
+// -------------------------------------------------------------------------------------
+// constructors
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category constructors
+ * @since 0.1.12
+ */
+export const get: <S, E = never>() => StateEither<S, E, S> = T.get
+
+/**
+ * @category constructors
+ * @since 0.1.12
+ */
+export const put: <S, E = never>(s: S) => StateEither<S, E, void> = T.put
+
+/**
+ * @category constructors
+ * @since 0.1.12
+ */
+export const modify: <S, E = never>(f: (s: S) => S) => StateEither<S, E, void> = T.modify
+
+/**
+ * @category constructors
+ * @since 0.1.12
+ */
+export const gets: <S, E = never, A = never>(f: (s: S) => A) => StateEither<S, E, A> = T.gets
+
+/**
+ * @category constructors
+ * @since 0.1.12
+ */
+export const left: <S, E, A = never>(e: E) => StateEither<S, E, A> = e => fromEither(E.left(e))
+
+/**
+ * @category constructors
+ * @since 0.1.12
+ */
+export const right: <S, E = never, A = never>(a: A) => StateEither<S, E, A> = T.of
+
+/**
+ * @category constructors
+ * @since 0.1.12
+ */
+export const leftState: <S, E = never, A = never>(me: State<S, E>) => StateEither<S, E, A> = me => s => E.left(me(s)[0])
+
+/**
+ * @category constructors
+ * @since 0.1.12
+ */
+export const rightState: <S, E = never, A = never>(ma: State<S, A>) => StateEither<S, E, A> = T.fromState
+
+/**
+ * @category constructors
+ * @since 0.1.18
+ */
+export const fromOption: <E>(onNone: () => E) => <R, A>(ma: Option<A>) => StateEither<R, E, A> = onNone => ma =>
+  ma._tag === 'None' ? left(onNone()) : right(ma.value)
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const fromEither: <S, E, A>(ma: E.Either<E, A>) => StateEither<S, E, A> = T.fromM
+
+/**
+ * @category constructors
+ * @since 0.1.12
+ */
+export const fromEitherK: <E, A extends Array<unknown>, B>(
+  f: (...a: A) => E.Either<E, B>
+) => <S>(...a: A) => StateEither<S, E, B> = f => (...a) => fromEither(f(...a))
+
+/**
+ * @category constructors
+ * @since 0.1.18
+ */
+export const fromPredicate: {
+  <E, A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <R>(a: A) => StateEither<R, E, B>
+  <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <R>(a: A) => StateEither<R, E, A>
+} = <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E) => <R>(a: A): StateEither<R, E, A> =>
+  predicate(a) ? right(a) : left(onFalse(a))
+
+// -------------------------------------------------------------------------------------
+// pipeables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category Functor
+ * @since 0.1.18
+ */
+export const map: <A, B>(f: (a: A) => B) => <R, E>(fa: StateEither<R, E, A>) => StateEither<R, E, B> = f => fa =>
+  T.map(fa, f)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const ap: <R, E, A>(
+  fa: StateEither<R, E, A>
+) => <B>(fab: StateEither<R, E, (a: A) => B>) => StateEither<R, E, B> = fa => fab => T.ap(fab, fa)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const apFirst = <R, E, B>(fb: StateEither<R, E, B>) => <A>(fa: StateEither<R, E, A>): StateEither<R, E, A> =>
+  pipe(
+    fa,
+    map(a => (_: B) => a),
+    ap(fb)
+  )
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const apSecond = <R, E, B>(fb: StateEither<R, E, B>) => <A>(fa: StateEither<R, E, A>): StateEither<R, E, B> =>
+  pipe(
+    fa,
+    map(() => (b: B) => b),
+    ap(fb)
+  )
+
+/**
+ * @category Applicative
+ * @since 0.1.18
+ */
+export const of: <R, E, A>(a: A) => StateEither<R, E, A> = right
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const chain: <R, E, A, B>(
+  f: (a: A) => StateEither<R, E, B>
+) => (ma: StateEither<R, E, A>) => StateEither<R, E, B> = f => ma => T.chain(ma, f)
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const chainFirst: <R, E, A, B>(
+  f: (a: A) => StateEither<R, E, B>
+) => (ma: StateEither<R, E, A>) => StateEither<R, E, A> = f => ma => T.chain(ma, a => T.map(f(a), () => a))
+
+/**
+ * @since 0.1.12
+ */
+export const chainEitherK = <E, A, B>(
+  f: (a: A) => E.Either<E, B>
+): (<S>(ma: StateEither<S, E, A>) => StateEither<S, E, B>) => chain<any, E, A, B>(fromEitherK(f))
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const flatten: <R, E, A>(mma: StateEither<R, E, StateEither<R, E, A>>) => StateEither<R, E, A> = mma =>
+  T.chain(mma, identity)
+
+export const filterOrElse: {
+  <E, A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <R>(
+    ma: StateEither<R, E, A>
+  ) => StateEither<R, E, B>
+  <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <R>(ma: StateEither<R, E, A>) => StateEither<R, E, A>
+} = <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E) => <R>(ma: StateEither<R, E, A>) =>
+  T.chain(ma, a => (predicate(a) ? right(a) : left(onFalse(a))))
+
+// -------------------------------------------------------------------------------------
+// instances
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category instances
+ * @since 0.1.12
+ */
+export const URI = 'StateEither'
+
+/**
+ * @category instances
+ * @since 0.1.12
+ */
+export type URI = typeof URI
 
 declare module 'fp-ts/lib/HKT' {
   interface URItoKind3<R, E, A> {
@@ -17,100 +218,62 @@ declare module 'fp-ts/lib/HKT' {
 }
 
 /**
- * @since 0.1.12
+ * @category instances
+ * @since 0.1.18
  */
-export const URI = 'StateEither'
-
-/**
- * @since 0.1.12
- */
-export type URI = typeof URI
-
-/**
- * @since 0.1.12
- */
-export interface StateEither<S, E, A> {
-  (s: S): E.Either<E, [A, S]>
+export const Functor: Functor3<URI> = {
+  URI,
+  map: T.map
 }
 
 /**
- * @since 0.1.12
+ * @category instances
+ * @since 0.1.18
  */
-export const evalState: <S, E, A>(ma: StateEither<S, E, A>, s: S) => E.Either<E, A> = T.evalState
-
-/**
- * @since 0.1.12
- */
-export const execState: <S, E, A>(ma: StateEither<S, E, A>, s: S) => E.Either<E, S> = T.execState
-
-/**
- * @since 0.1.12
- */
-export function left<S, E, A = never>(e: E): StateEither<S, E, A> {
-  return fromEither(E.left(e))
+export const Applicative: Applicative3<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  of
 }
 
 /**
- * @since 0.1.12
+ * @category instances
+ * @since 0.1.18
  */
-export const right: <S, E = never, A = never>(a: A) => StateEither<S, E, A> = T.of
-
-/**
- * @since 0.1.12
- */
-export const rightState: <S, E = never, A = never>(ma: State<S, A>) => StateEither<S, E, A> = T.fromState
-
-/**
- * @since 0.1.12
- */
-export function leftState<S, E = never, A = never>(me: State<S, E>): StateEither<S, E, A> {
-  return s => E.left(me(s)[0])
+export const Apply: Apply3<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap
 }
 
 /**
- * @since 0.1.12
+ * @category instances
+ * @since 0.1.18
  */
-export const get: <S, E = never>() => StateEither<S, E, S> = T.get
-
-/**
- * @since 0.1.12
- */
-export const put: <S, E = never>(s: S) => StateEither<S, E, void> = T.put
-
-/**
- * @since 0.1.12
- */
-export const modify: <S, E = never>(f: (s: S) => S) => StateEither<S, E, void> = T.modify
-
-/**
- * @since 0.1.12
- */
-export const gets: <S, E = never, A = never>(f: (s: S) => A) => StateEither<S, E, A> = T.gets
-
-/**
- * @since 0.1.0
- */
-export const fromEither: <S, E, A>(ma: E.Either<E, A>) => StateEither<S, E, A> = T.fromM
-
-/**
- * @since 0.1.12
- */
-export function fromEitherK<E, A extends Array<unknown>, B>(
-  f: (...a: A) => E.Either<E, B>
-): <S>(...a: A) => StateEither<S, E, B> {
-  return (...a) => fromEither(f(...a))
+export const Monad: Monad3<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  chain: T.chain,
+  of
 }
 
 /**
- * @since 0.1.12
+ * @category instances
+ * @since 0.1.18
  */
-export function chainEitherK<E, A, B>(
-  f: (a: A) => E.Either<E, B>
-): <S>(ma: StateEither<S, E, A>) => StateEither<S, E, B> {
-  return chain<any, E, A, B>(fromEitherK(f))
+export const MonadThrow: MonadThrow3<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  chain: T.chain,
+  of,
+  throwError: left
 }
 
 /**
+ * @category instances
  * @since 0.1.12
  */
 export const stateEither: Monad3<URI> & MonadThrow3<URI> = {
@@ -122,49 +285,16 @@ export const stateEither: Monad3<URI> & MonadThrow3<URI> = {
   throwError: left
 }
 
-const { ap, apFirst, apSecond, chain, chainFirst, flatten, map, filterOrElse, fromOption, fromPredicate } = pipeable(
-  stateEither
-)
+// -------------------------------------------------------------------------------------
+// utils
+// -------------------------------------------------------------------------------------
 
-export {
-  /**
-   * @since 0.1.12
-   */
-  ap,
-  /**
-   * @since 0.1.12
-   */
-  apFirst,
-  /**
-   * @since 0.1.12
-   */
-  apSecond,
-  /**
-   * @since 0.1.12
-   */
-  chain,
-  /**
-   * @since 0.1.12
-   */
-  chainFirst,
-  /**
-   * @since 0.1.12
-   */
-  flatten,
-  /**
-   * @since 0.1.12
-   */
-  map,
-  /**
-   * @since 0.1.12
-   */
-  filterOrElse,
-  /**
-   * @since 0.1.12
-   */
-  fromOption,
-  /**
-   * @since 0.1.12
-   */
-  fromPredicate
-}
+/**
+ * @since 0.1.12
+ */
+export const evalState: <S, E, A>(ma: StateEither<S, E, A>, s: S) => E.Either<E, A> = T.evalState
+
+/**
+ * @since 0.1.12
+ */
+export const execState: <S, E, A>(ma: StateEither<S, E, A>, s: S) => E.Either<E, S> = T.execState

--- a/src/StateIO.ts
+++ b/src/StateIO.ts
@@ -1,14 +1,167 @@
 /**
  * @since 0.1.0
  */
+import { Applicative2 } from 'fp-ts/lib/Applicative'
+import { Apply2 } from 'fp-ts/lib/Apply'
+import { identity } from 'fp-ts/lib/function'
+import { Functor2 } from 'fp-ts/lib/Functor'
 import * as I from 'fp-ts/lib/IO'
 import { Monad2 } from 'fp-ts/lib/Monad'
+import { pipe } from 'fp-ts/lib/pipeable'
 import { State } from 'fp-ts/lib/State'
 import { getStateM } from 'fp-ts/lib/StateT'
+
 import IO = I.IO
-import { pipeable } from 'fp-ts/lib/pipeable'
 
 const T = getStateM(I.io)
+
+// -------------------------------------------------------------------------------------
+// model
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category model
+ * @since 0.1.0
+ */
+export interface StateIO<S, A> {
+  (s: S): IO<[A, S]>
+}
+
+// -------------------------------------------------------------------------------------
+// constructors
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const get: <S>() => StateIO<S, S> = T.get
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const put: <S>(s: S) => StateIO<S, void> = T.put
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const modify: <S>(f: (s: S) => S) => StateIO<S, void> = T.modify
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const gets: <S, A>(f: (s: S) => A) => StateIO<S, A> = T.gets
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const fromIO: <S, A>(ma: IO<A>) => StateIO<S, A> = T.fromM
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const fromState: <S, A>(ma: State<S, A>) => StateIO<S, A> = T.fromState
+
+/**
+ * @category constructors
+ * @since 0.1.10
+ */
+export const fromIOK: <A extends Array<unknown>, B>(f: (...a: A) => IO<B>) => <R>(...a: A) => StateIO<R, B> = f => (
+  ...a
+) => fromIO(f(...a))
+
+// -------------------------------------------------------------------------------------
+// pipeables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category Functor
+ * @since 0.1.18
+ */
+export const map: <A, B>(f: (a: A) => B) => <E>(fa: StateIO<E, A>) => StateIO<E, B> = f => fa => T.map(fa, f)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const ap: <E, A>(fa: StateIO<E, A>) => <B>(fab: StateIO<E, (a: A) => B>) => StateIO<E, B> = fa => fab =>
+  T.ap(fab, fa)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const apFirst = <E, B>(fb: StateIO<E, B>) => <A>(fa: StateIO<E, A>): StateIO<E, A> =>
+  pipe(
+    fa,
+    map(a => (_: B) => a),
+    ap(fb)
+  )
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const apSecond = <E, B>(fb: StateIO<E, B>) => <A>(fa: StateIO<E, A>): StateIO<E, B> =>
+  pipe(
+    fa,
+    map(() => (b: B) => b),
+    ap(fb)
+  )
+
+/**
+ * @category Applicative
+ * @since 0.1.18
+ */
+export const of: <E, A>(a: A) => StateIO<E, A> = T.of
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const chain: <E, A, B>(f: (a: A) => StateIO<E, B>) => (ma: StateIO<E, A>) => StateIO<E, B> = f => ma =>
+  T.chain(ma, f)
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const chainFirst: <E, A, B>(f: (a: A) => StateIO<E, B>) => (ma: StateIO<E, A>) => StateIO<E, A> = f => ma =>
+  T.chain(ma, a => T.map(f(a), () => a))
+
+/**
+ * @category Monad
+ * @since 0.1.10
+ */
+export const chainIOK = <A, B>(f: (a: A) => IO<B>): (<R>(ma: StateIO<R, A>) => StateIO<R, B>) =>
+  chain<any, A, B>(fromIOK(f))
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const flatten: <E, A>(mma: StateIO<E, StateIO<E, A>>) => StateIO<E, A> = mma => T.chain(mma, identity)
+
+// -------------------------------------------------------------------------------------
+// instances
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category instances
+ * @since 0.1.0
+ */
+export const URI = 'StateIO'
+
+/**
+ * @category instances
+ * @since 0.1.0
+ */
+export type URI = typeof URI
 
 declare module 'fp-ts/lib/HKT' {
   interface URItoKind2<E, A> {
@@ -17,28 +170,62 @@ declare module 'fp-ts/lib/HKT' {
 }
 
 /**
- * @since 0.1.0
+ * @category instances
+ * @since 0.1.18
  */
-export const URI = 'StateIO'
-
-/**
- * @since 0.1.0
- */
-export type URI = typeof URI
-
-/**
- * @since 0.1.0
- */
-export interface StateIO<S, A> {
-  (s: S): IO<[A, S]>
+export const Functor: Functor2<URI> = {
+  URI,
+  map: T.map
 }
 
 /**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Applicative: Applicative2<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  of
+}
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Apply: Apply2<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap
+}
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Monad: Monad2<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  chain: T.chain,
+  of
+}
+
+/**
+ * @category instances
  * @since 0.1.0
  */
-export function run<S, A>(ma: StateIO<S, A>, s: S): A {
-  return ma(s)()[0]
+export const stateIO: Monad2<URI> = {
+  URI,
+  map: T.map,
+  of: T.of,
+  ap: T.ap,
+  chain: T.chain
 }
+
+// -------------------------------------------------------------------------------------
+// utils
+// -------------------------------------------------------------------------------------
 
 /**
  * @since 0.1.0
@@ -53,87 +240,4 @@ export const execState: <S, A>(ma: StateIO<S, A>, s: S) => IO<S> = T.execState
 /**
  * @since 0.1.0
  */
-export const fromIO: <S, A>(ma: IO<A>) => StateIO<S, A> = T.fromM
-
-/**
- * @since 0.1.0
- */
-export const fromState: <S, A>(ma: State<S, A>) => StateIO<S, A> = T.fromState
-
-/**
- * @since 0.1.0
- */
-export const get: <S>() => StateIO<S, S> = T.get
-
-/**
- * @since 0.1.0
- */
-export const put: <S>(s: S) => StateIO<S, void> = T.put
-
-/**
- * @since 0.1.0
- */
-export const modify: <S>(f: (s: S) => S) => StateIO<S, void> = T.modify
-
-/**
- * @since 0.1.0
- */
-export const gets: <S, A>(f: (s: S) => A) => StateIO<S, A> = T.gets
-
-/**
- * @since 0.1.10
- */
-export function fromIOK<A extends Array<unknown>, B>(f: (...a: A) => IO<B>): <R>(...a: A) => StateIO<R, B> {
-  return (...a) => fromIO(f(...a))
-}
-
-/**
- * @since 0.1.10
- */
-export function chainIOK<A, B>(f: (a: A) => IO<B>): <R>(ma: StateIO<R, A>) => StateIO<R, B> {
-  return chain<any, A, B>(fromIOK(f))
-}
-
-/**
- * @since 0.1.0
- */
-export const stateIO: Monad2<URI> = {
-  URI,
-  map: T.map,
-  of: T.of,
-  ap: T.ap,
-  chain: T.chain
-}
-
-const { ap, apFirst, apSecond, chain, chainFirst, flatten, map } = pipeable(stateIO)
-
-export {
-  /**
-   * @since 0.1.0
-   */
-  ap,
-  /**
-   * @since 0.1.0
-   */
-  apFirst,
-  /**
-   * @since 0.1.0
-   */
-  apSecond,
-  /**
-   * @since 0.1.0
-   */
-  chain,
-  /**
-   * @since 0.1.0
-   */
-  chainFirst,
-  /**
-   * @since 0.1.0
-   */
-  flatten,
-  /**
-   * @since 0.1.0
-   */
-  map
-}
+export const run: <S, A>(ma: StateIO<S, A>, s: S) => A = (ma, s) => ma(s)()[0]

--- a/src/StateTaskEither.ts
+++ b/src/StateTaskEither.ts
@@ -1,19 +1,308 @@
 /**
  * @since 0.1.0
  */
+import { Applicative3 } from 'fp-ts/lib/Applicative'
+import { Apply3 } from 'fp-ts/lib/Apply'
 import { Either } from 'fp-ts/lib/Either'
+import { identity, Predicate, Refinement } from 'fp-ts/lib/function'
+import { Functor3 } from 'fp-ts/lib/Functor'
 import { IO } from 'fp-ts/lib/IO'
 import { IOEither } from 'fp-ts/lib/IOEither'
 import { Monad3 } from 'fp-ts/lib/Monad'
 import { MonadThrow3 } from 'fp-ts/lib/MonadThrow'
+import { Option } from 'fp-ts/lib/Option'
+import { pipe } from 'fp-ts/lib/pipeable'
 import { State } from 'fp-ts/lib/State'
 import { getStateM } from 'fp-ts/lib/StateT'
 import { Task } from 'fp-ts/lib/Task'
 import * as TE from 'fp-ts/lib/TaskEither'
+
 import TaskEither = TE.TaskEither
-import { pipeable } from 'fp-ts/lib/pipeable'
 
 const T = getStateM(TE.taskEither)
+
+// -------------------------------------------------------------------------------------
+// model
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category model
+ * @since 0.1.0
+ */
+export interface StateTaskEither<S, E, A> {
+  (s: S): TaskEither<E, [A, S]>
+}
+
+// -------------------------------------------------------------------------------------
+// constructors
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const get: <S>() => StateTaskEither<S, never, S> = T.get
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const put: <S>(s: S) => StateTaskEither<S, never, void> = T.put
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const modify: <S>(f: (s: S) => S) => StateTaskEither<S, never, void> = T.modify
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const gets: <S, A>(f: (s: S) => A) => StateTaskEither<S, never, A> = T.gets
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const left: <S, E>(e: E) => StateTaskEither<S, E, never> = (e) => fromTaskEither(TE.left(e))
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const right: <S, A>(a: A) => StateTaskEither<S, never, A> = T.of
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const leftIO: <S, E>(me: IO<E>) => StateTaskEither<S, E, never> = (me) => fromTaskEither(TE.leftIO(me))
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const rightIO: <S, A>(ma: IO<A>) => StateTaskEither<S, never, A> = (ma) => fromTaskEither(TE.rightIO(ma))
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const leftTask: <S, E>(me: Task<E>) => StateTaskEither<S, E, never> = (me) => fromTaskEither(TE.leftTask(me))
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const rightTask: <S, A>(ma: Task<A>) => StateTaskEither<S, never, A> = (ma) => fromTaskEither(TE.rightTask(ma))
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const leftState: <S, E>(me: State<S, E>) => StateTaskEither<S, E, never> = (me) => (s) => TE.left(me(s)[0])
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const rightState: <S, A>(ma: State<S, A>) => StateTaskEither<S, never, A> = T.fromState
+
+/**
+ * @category constructors
+ * @since 0.1.18
+ */
+export const fromOption: <E>(onNone: () => E) => <R, A>(ma: Option<A>) => StateTaskEither<R, E, A> = (onNone) => (ma) =>
+  ma._tag === 'None' ? left(onNone()) : right(ma.value)
+
+/**
+ * @category constructors
+ * @since 0.1.18
+ */
+export const fromEither: <R, E, A>(ma: Either<E, A>) => StateTaskEither<R, E, A> = (ma) =>
+  ma._tag === 'Left' ? left(ma.left) : right(ma.right)
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const fromIOEither: <S, E, A>(ma: IOEither<E, A>) => StateTaskEither<S, E, A> = (ma) =>
+  fromTaskEither(TE.fromIOEither(ma))
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const fromTaskEither: <S, E, A>(ma: TaskEither<E, A>) => StateTaskEither<S, E, A> = T.fromM
+
+/**
+ * @category constructors
+ * @since 0.1.10
+ */
+export const fromEitherK: <E, A extends Array<unknown>, B>(
+  f: (...a: A) => Either<E, B>
+) => <S>(...a: A) => StateTaskEither<S, E, B> = (f) => (...a) => fromEither(f(...a))
+
+/**
+ * @category constructors
+ * @since 0.1.10
+ */
+export const fromIOEitherK: <E, A extends Array<unknown>, B>(
+  f: (...a: A) => IOEither<E, B>
+) => <S>(...a: A) => StateTaskEither<S, E, B> = (f) => (...a) => fromIOEither(f(...a))
+
+/**
+ * @category constructors
+ * @since 0.1.10
+ */
+export const fromTaskEitherK: <E, A extends Array<unknown>, B>(
+  f: (...a: A) => TaskEither<E, B>
+) => <S>(...a: A) => StateTaskEither<S, E, B> = (f) => (...a) => fromTaskEither(f(...a))
+
+/**
+ * @category constructors
+ * @since 0.1.18
+ */
+export const fromPredicate: {
+  <E, A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <R>(a: A) => StateTaskEither<R, E, B>
+  <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <R>(a: A) => StateTaskEither<R, E, A>
+} = <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E) => <R>(a: A): StateTaskEither<R, E, A> =>
+  predicate(a) ? right(a) : left(onFalse(a))
+
+// -------------------------------------------------------------------------------------
+// combinators
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 0.1.18
+ */
+export const filterOrElse: {
+  <E, A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <R>(
+    ma: StateTaskEither<R, E, A>
+  ) => StateTaskEither<R, E, B>
+  <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <R>(ma: StateTaskEither<R, E, A>) => StateTaskEither<R, E, A>
+} = <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E) => <R>(
+  ma: StateTaskEither<R, E, A>
+): StateTaskEither<R, E, A> => T.chain(ma, (a) => (predicate(a) ? right(a) : left(onFalse(a))))
+
+// -------------------------------------------------------------------------------------
+// pipeables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category Functor
+ * @since 0.1.18
+ */
+export const map: <A, B>(f: (a: A) => B) => <R, E>(fa: StateTaskEither<R, E, A>) => StateTaskEither<R, E, B> = (f) => (
+  fa
+) => T.map(fa, f)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const ap: <R, E, A>(
+  fa: StateTaskEither<R, E, A>
+) => <B>(fab: StateTaskEither<R, E, (a: A) => B>) => StateTaskEither<R, E, B> = (fa) => (fab) => T.ap(fab, fa)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const apFirst = <R, E, B>(fb: StateTaskEither<R, E, B>) => <A>(
+  fa: StateTaskEither<R, E, A>
+): StateTaskEither<R, E, A> =>
+  pipe(
+    fa,
+    map((a) => (_: B) => a),
+    ap(fb)
+  )
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const apSecond = <R, E, B>(fb: StateTaskEither<R, E, B>) => <A>(
+  fa: StateTaskEither<R, E, A>
+): StateTaskEither<R, E, B> =>
+  pipe(
+    fa,
+    map(() => (b: B) => b),
+    ap(fb)
+  )
+
+/**
+ * @category Applicative
+ * @since 0.1.18
+ */
+export const of: <R, E, A>(a: A) => StateTaskEither<R, E, A> = right
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const chain: <R, E, A, B>(
+  f: (a: A) => StateTaskEither<R, E, B>
+) => (ma: StateTaskEither<R, E, A>) => StateTaskEither<R, E, B> = (f) => (ma) => T.chain(ma, f)
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const chainFirst: <R, E, A, B>(
+  f: (a: A) => StateTaskEither<R, E, B>
+) => (ma: StateTaskEither<R, E, A>) => StateTaskEither<R, E, A> = (f) => (ma) =>
+  T.chain(ma, (a) => T.map(f(a), () => a))
+
+/**
+ * @category Monad
+ * @since 0.1.10
+ */
+export const chainEitherK = <E, A, B>(
+  f: (a: A) => Either<E, B>
+): (<S>(ma: StateTaskEither<S, E, A>) => StateTaskEither<S, E, B>) => chain<any, E, A, B>(fromEitherK(f))
+
+/**
+ * @category Monad
+ * @since 0.1.10
+ */
+export const chainIOEitherK = <E, A, B>(
+  f: (a: A) => IOEither<E, B>
+): (<S>(ma: StateTaskEither<S, E, A>) => StateTaskEither<S, E, B>) => chain<any, E, A, B>(fromIOEitherK(f))
+
+/**
+ * @category Monad
+ * @since 0.1.10
+ */
+export const chainTaskEitherK = <E, A, B>(
+  f: (a: A) => TaskEither<E, B>
+): (<S>(ma: StateTaskEither<S, E, A>) => StateTaskEither<S, E, B>) => chain<any, E, A, B>(fromTaskEitherK(f))
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const flatten: <R, E, A>(mma: StateTaskEither<R, E, StateTaskEither<R, E, A>>) => StateTaskEither<R, E, A> = (
+  mma
+) => T.chain(mma, identity)
+
+// -------------------------------------------------------------------------------------
+// instances
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category instances
+ * @since 0.1.0
+ */
+export const URI = 'StateTaskEither'
+
+/**
+ * @category instances
+ * @since 0.1.0
+ */
+export type URI = typeof URI
 
 declare module 'fp-ts/lib/HKT' {
   interface URItoKind3<R, E, A> {
@@ -22,28 +311,74 @@ declare module 'fp-ts/lib/HKT' {
 }
 
 /**
- * @since 0.1.0
+ * @category instances
+ * @since 0.1.18
  */
-export const URI = 'StateTaskEither'
-
-/**
- * @since 0.1.0
- */
-export type URI = typeof URI
-
-/**
- * @since 0.1.0
- */
-export interface StateTaskEither<S, E, A> {
-  (s: S): TaskEither<E, [A, S]>
+export const Functor: Functor3<URI> = {
+  URI,
+  map: T.map,
 }
 
 /**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Applicative: Applicative3<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  of,
+}
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Apply: Apply3<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+}
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Monad: Monad3<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  chain: T.chain,
+  of,
+}
+
+/**
+ * @category instances
  * @since 0.1.0
  */
-export function run<S, E, A>(ma: StateTaskEither<S, E, A>, s: S): Promise<Either<E, [A, S]>> {
-  return ma(s)()
+export const stateTaskEither: Monad3<URI> & MonadThrow3<URI> = {
+  URI,
+  map: T.map,
+  of: right,
+  ap: T.ap,
+  chain: T.chain,
+  throwError: left,
 }
+
+/**
+ * Like `stateTaskEither` but `ap` is sequential
+ *
+ * @category instances
+ * @since 0.1.0
+ */
+export const stateTaskEitherSeq: typeof stateTaskEither = {
+  ...stateTaskEither,
+  ap: (mab, ma) => T.chain(mab, (f) => T.map(ma, f)),
+}
+
+// -------------------------------------------------------------------------------------
+// utils
+// -------------------------------------------------------------------------------------
 
 /**
  * @since 0.1.0
@@ -58,219 +393,4 @@ export const execState: <S, E, A>(ma: StateTaskEither<S, E, A>, s: S) => TaskEit
 /**
  * @since 0.1.0
  */
-export function left<S, E>(e: E): StateTaskEither<S, E, never> {
-  return fromTaskEither(TE.left(e))
-}
-
-/**
- * @since 0.1.0
- */
-export const right: <S, A>(a: A) => StateTaskEither<S, never, A> = T.of
-
-/**
- * @since 0.1.0
- */
-export function rightTask<S, A>(ma: Task<A>): StateTaskEither<S, never, A> {
-  return fromTaskEither(TE.rightTask(ma))
-}
-
-/**
- * @since 0.1.0
- */
-export function leftTask<S, E>(me: Task<E>): StateTaskEither<S, E, never> {
-  return fromTaskEither(TE.leftTask(me))
-}
-
-/**
- * @since 0.1.0
- */
-export const fromTaskEither: <S, E, A>(ma: TaskEither<E, A>) => StateTaskEither<S, E, A> = T.fromM
-
-/**
- * @since 0.1.0
- */
-export function fromIOEither<S, E, A>(ma: IOEither<E, A>): StateTaskEither<S, E, A> {
-  return fromTaskEither(TE.fromIOEither(ma))
-}
-
-/**
- * @since 0.1.0
- */
-export function rightIO<S, A>(ma: IO<A>): StateTaskEither<S, never, A> {
-  return fromTaskEither(TE.rightIO(ma))
-}
-
-/**
- * @since 0.1.0
- */
-export function leftIO<S, E>(me: IO<E>): StateTaskEither<S, E, never> {
-  return fromTaskEither(TE.leftIO(me))
-}
-
-/**
- * @since 0.1.0
- */
-export const rightState: <S, A>(ma: State<S, A>) => StateTaskEither<S, never, A> = T.fromState
-
-/**
- * @since 0.1.0
- */
-export function leftState<S, E>(me: State<S, E>): StateTaskEither<S, E, never> {
-  return s => TE.left(me(s)[0])
-}
-
-/**
- * @since 0.1.0
- */
-export const get: <S>() => StateTaskEither<S, never, S> = T.get
-
-/**
- * @since 0.1.0
- */
-export const put: <S>(s: S) => StateTaskEither<S, never, void> = T.put
-
-/**
- * @since 0.1.0
- */
-export const modify: <S>(f: (s: S) => S) => StateTaskEither<S, never, void> = T.modify
-
-/**
- * @since 0.1.0
- */
-export const gets: <S, A>(f: (s: S) => A) => StateTaskEither<S, never, A> = T.gets
-
-/**
- * @since 0.1.10
- */
-export function fromEitherK<E, A extends Array<unknown>, B>(
-  f: (...a: A) => Either<E, B>
-): <S>(...a: A) => StateTaskEither<S, E, B> {
-  return (...a) => fromEither(f(...a))
-}
-
-/**
- * @since 0.1.10
- */
-export function chainEitherK<E, A, B>(
-  f: (a: A) => Either<E, B>
-): <S>(ma: StateTaskEither<S, E, A>) => StateTaskEither<S, E, B> {
-  return chain<any, E, A, B>(fromEitherK(f))
-}
-
-/**
- * @since 0.1.10
- */
-export function fromIOEitherK<E, A extends Array<unknown>, B>(
-  f: (...a: A) => IOEither<E, B>
-): <S>(...a: A) => StateTaskEither<S, E, B> {
-  return (...a) => fromIOEither(f(...a))
-}
-
-/**
- * @since 0.1.10
- */
-export function chainIOEitherK<E, A, B>(
-  f: (a: A) => IOEither<E, B>
-): <S>(ma: StateTaskEither<S, E, A>) => StateTaskEither<S, E, B> {
-  return chain<any, E, A, B>(fromIOEitherK(f))
-}
-
-/**
- * @since 0.1.10
- */
-export function fromTaskEitherK<E, A extends Array<unknown>, B>(
-  f: (...a: A) => TaskEither<E, B>
-): <S>(...a: A) => StateTaskEither<S, E, B> {
-  return (...a) => fromTaskEither(f(...a))
-}
-
-/**
- * @since 0.1.10
- */
-export function chainTaskEitherK<E, A, B>(
-  f: (a: A) => TaskEither<E, B>
-): <S>(ma: StateTaskEither<S, E, A>) => StateTaskEither<S, E, B> {
-  return chain<any, E, A, B>(fromTaskEitherK(f))
-}
-
-/**
- * @since 0.1.0
- */
-export const stateTaskEither: Monad3<URI> & MonadThrow3<URI> = {
-  URI,
-  map: T.map,
-  of: right,
-  ap: T.ap,
-  chain: T.chain,
-  throwError: left
-}
-
-/**
- * Like `stateTaskEither` but `ap` is sequential
- * @since 0.1.0
- */
-export const stateTaskEitherSeq: typeof stateTaskEither = {
-  ...stateTaskEither,
-  ap: (mab, ma) => T.chain(mab, f => T.map(ma, f))
-}
-
-const {
-  ap,
-  apFirst,
-  apSecond,
-  chain,
-  chainFirst,
-  flatten,
-  map,
-  filterOrElse,
-  fromEither,
-  fromOption,
-  fromPredicate
-} = pipeable(stateTaskEither)
-
-export {
-  /**
-   * @since 0.1.0
-   */
-  ap,
-  /**
-   * @since 0.1.0
-   */
-  apFirst,
-  /**
-   * @since 0.1.0
-   */
-  apSecond,
-  /**
-   * @since 0.1.0
-   */
-  chain,
-  /**
-   * @since 0.1.0
-   */
-  chainFirst,
-  /**
-   * @since 0.1.0
-   */
-  flatten,
-  /**
-   * @since 0.1.0
-   */
-  map,
-  /**
-   * @since 0.1.0
-   */
-  filterOrElse,
-  /**
-   * @since 0.1.0
-   */
-  fromEither,
-  /**
-   * @since 0.1.0
-   */
-  fromOption,
-  /**
-   * @since 0.1.0
-   */
-  fromPredicate
-}
+export const run: <S, E, A>(ma: StateTaskEither<S, E, A>, s: S) => Promise<Either<E, [A, S]>> = (ma, s) => ma(s)()

--- a/src/Task/getLine.ts
+++ b/src/Task/getLine.ts
@@ -7,17 +7,15 @@ import { Task } from 'fp-ts/lib/Task'
 /**
  * @since 0.1.8
  */
-export function getLine(question: string): Task<string> {
-  return () =>
-    new Promise(resolve => {
-      const rl = createInterface({
-        input: process.stdin,
-        output: process.stdout
-      })
-
-      rl.question(question, answer => {
-        rl.close()
-        resolve(answer)
-      })
+export const getLine: (question: string) => Task<string> = (question) => () =>
+  new Promise((resolve) => {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
     })
-}
+
+    rl.question(question, (answer) => {
+      rl.close()
+      resolve(answer)
+    })
+  })

--- a/src/Task/withTimeout.ts
+++ b/src/Task/withTimeout.ts
@@ -23,8 +23,8 @@ import { getRaceMonoid, Task, delay, of } from 'fp-ts/lib/Task'
  *
  * @since 0.1.0
  */
-export function withTimeout<A>(onTimeout: A, millis: number): (ma: Task<A>) => Task<A> {
+export const withTimeout = <A>(onTimeout: A, millis: number): ((ma: Task<A>) => Task<A>) => {
   const M = getRaceMonoid<A>()
   const fallback = delay(millis)(of(onTimeout))
-  return ma => M.concat(ma, fallback)
+  return (ma) => M.concat(ma, fallback)
 }

--- a/src/TaskOption.ts
+++ b/src/TaskOption.ts
@@ -2,27 +2,294 @@
  * @since 0.1.0
  */
 import { Alternative1 } from 'fp-ts/lib/Alternative'
-import { task, of, Task, map as taskMap } from 'fp-ts/lib/Task'
-import { Monad1 } from 'fp-ts/lib/Monad'
-import {
-  Option,
-  fromEither as optionFromEither,
-  fromNullable as optionFromNullable,
-  toUndefined as optionToUndefined,
-  toNullable as optionToNullable,
-  chain as optionChain,
-  mapNullable as optionMapNullable,
-  some as optionSome,
-  none as optionNone,
-  option
-} from 'fp-ts/lib/Option'
-import { getOptionM } from 'fp-ts/lib/OptionT'
-import { pipeable } from 'fp-ts/lib/pipeable'
-import { TaskEither } from 'fp-ts/lib/TaskEither'
-import { Lazy } from 'fp-ts/lib/function'
+import { Applicative1 } from 'fp-ts/lib/Applicative'
+import { Apply1 } from 'fp-ts/lib/Apply'
+import { Separated, Compactable1 } from 'fp-ts/lib/Compactable'
+import { Either } from 'fp-ts/lib/Either'
 import { Filterable1, getFilterableComposition } from 'fp-ts/lib/Filterable'
+import { identity, Lazy, Predicate, Refinement } from 'fp-ts/lib/function'
+import { Functor1 } from 'fp-ts/lib/Functor'
+import { Monad1 } from 'fp-ts/lib/Monad'
+import * as O from 'fp-ts/lib/Option'
+import { getOptionM } from 'fp-ts/lib/OptionT'
+import { pipe } from 'fp-ts/lib/pipeable'
+import { task, of as taskOf, map as taskMap, Task } from 'fp-ts/lib/Task'
+import { TaskEither } from 'fp-ts/lib/TaskEither'
 
+const F = getFilterableComposition(task, O.option)
 const T = getOptionM(task)
+
+// -------------------------------------------------------------------------------------
+// model
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category model
+ * @since 0.1.0
+ */
+export interface TaskOption<A> extends Task<O.Option<A>> {}
+
+// -------------------------------------------------------------------------------------
+// constructors
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const none: TaskOption<never> = T.none()
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const some: <A>(a: A) => TaskOption<A> = T.of
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const fromOption: <A>(ma: O.Option<A>) => TaskOption<A> = taskOf
+
+/**
+ * @category constructors
+ * @since 0.1.10
+ */
+export const fromOptionK: <A extends Array<unknown>, B>(f: (...a: A) => O.Option<B>) => (...a: A) => TaskOption<B> = (
+  f
+) => (...a) => fromOption(f(...a))
+
+/**
+ * @category constructors
+ * @since 0.1.0
+ */
+export const fromTask: <A>(as: Task<A>) => TaskOption<A> = T.fromM
+
+/**
+ * @category constructors
+ * @since 0.1.4
+ */
+export const fromNullable: <A>(a: A) => TaskOption<NonNullable<A>> = (a) => fromOption(O.fromNullable(a))
+
+/**
+ * @category constructors
+ * @since 0.1.4
+ */
+export const fromTaskEither: <A>(ma: TaskEither<any, A>) => TaskOption<A> = (ma) => task.map(ma, O.fromEither)
+
+/**
+ * @category constructors
+ * @since 0.1.5
+ */
+export const tryCatch: <A>(f: Lazy<Promise<A>>) => TaskOption<A> = (f) => () =>
+  f().then(
+    (a) => O.some(a),
+    () => O.none
+  )
+
+// -------------------------------------------------------------------------------------
+// destructors
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category destructors
+ * @since 0.1.0
+ */
+export const fold: <A, B>(onNone: () => Task<B>, onSome: (a: A) => Task<B>) => (as: TaskOption<A>) => Task<B> = (
+  onNone,
+  onSome
+) => (as) => T.fold(as, onNone, onSome)
+
+/**
+ * @category destructors
+ * @since 0.1.0
+ */
+export const getOrElse: <A>(onNone: () => Task<A>) => (as: TaskOption<A>) => Task<A> = (onNone) => (as) =>
+  T.getOrElse(as, onNone)
+
+/**
+ * @category destructors
+ * @since 0.1.4
+ */
+export const toUndefined: <A>(ma: TaskOption<A>) => Task<A | undefined> = (ma) => task.map(ma, O.toUndefined)
+
+/**
+ * @category destructors
+ * @since 0.1.4
+ */
+export const toNullable: <A>(ma: TaskOption<A>) => Task<A | null> = (ma) => task.map(ma, O.toNullable)
+
+// -------------------------------------------------------------------------------------
+// combinators
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 0.1.5
+ */
+export const mapNullable: <A, B>(f: (a: A) => B | null | undefined) => (ma: TaskOption<A>) => TaskOption<B> = (f) =>
+  taskMap(O.mapNullable(f))
+
+// -------------------------------------------------------------------------------------
+// pipeables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category Functor
+ * @since 0.1.18
+ */
+export const map: <A, B>(f: (a: A) => B) => (fa: TaskOption<A>) => TaskOption<B> = (f) => (fa) => T.map(fa, f)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const ap: <A>(fa: TaskOption<A>) => <B>(fab: TaskOption<(a: A) => B>) => TaskOption<B> = (fa) => (fab) =>
+  T.ap(fab, fa)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const apFirst = <B>(fb: TaskOption<B>) => <A>(fa: TaskOption<A>): TaskOption<A> =>
+  pipe(
+    fa,
+    map((a) => (_: B) => a),
+    ap(fb)
+  )
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const apSecond = <B>(fb: TaskOption<B>) => <A>(fa: TaskOption<A>): TaskOption<B> =>
+  pipe(
+    fa,
+    map(() => (b: B) => b),
+    ap(fb)
+  )
+
+/**
+ * @category Applicative
+ * @since 0.1.18
+ */
+export const of: <A>(a: A) => TaskOption<A> = some
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const chain: <A, B>(f: (a: A) => TaskOption<B>) => (ma: TaskOption<A>) => TaskOption<B> = (f) => (ma) =>
+  T.chain(ma, f)
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const chainFirst: <A, B>(f: (a: A) => TaskOption<B>) => (ma: TaskOption<A>) => TaskOption<A> = (f) => (ma) =>
+  T.chain(ma, (a) => T.map(f(a), () => a))
+
+/**
+ * @category Monad
+ * @since 0.1.4
+ */
+export const chainTask: <A, B>(f: (a: A) => Task<B>) => (ma: TaskOption<A>) => TaskOption<B> = (f) => (ma) =>
+  T.chain(ma, (a) => fromTask(f(a)))
+
+/**
+ * @category Monad
+ * @since 0.1.4
+ */
+export const chainOption: <A, B>(f: (a: A) => O.Option<B>) => (ma: TaskOption<A>) => TaskOption<B> = (f) =>
+  taskMap(O.chain(f))
+
+/**
+ * @category Monad
+ * @since 0.1.10
+ */
+export const chainOptionK: <A, B>(f: (a: A) => O.Option<B>) => (ma: TaskOption<A>) => TaskOption<B> = (f) =>
+  chain(fromOptionK(f))
+
+/**
+ * @category Monad
+ * @since 0.1.18
+ */
+export const flatten: <A>(mma: TaskOption<TaskOption<A>>) => TaskOption<A> = (mma) => T.chain(mma, identity)
+
+/**
+ * @category Alternative
+ * @since 0.1.18
+ */
+export const alt: <A>(that: () => TaskOption<A>) => (fa: TaskOption<A>) => TaskOption<A> = (that) => (fa) =>
+  T.alt(fa, that)
+
+/**
+ * @category Alternative
+ * @since 0.1.18
+ */
+export const zero: <A>() => TaskOption<A> = T.none
+
+/**
+ * @category Compactable
+ * @since 0.1.18
+ */
+export const compact: <A>(fa: TaskOption<O.Option<A>>) => TaskOption<A> = F.compact
+
+/**
+ * @category Compactable
+ * @since 0.1.18
+ */
+export const separate: <A, B>(ma: TaskOption<Either<A, B>>) => Separated<TaskOption<A>, TaskOption<B>> = F.separate
+
+/**
+ * @category Filterable
+ * @since 0.1.18
+ */
+export const filter: {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: TaskOption<A>) => TaskOption<B>
+  <A>(predicate: Predicate<A>): (fa: TaskOption<A>) => TaskOption<A>
+} = <A>(predicate: Predicate<A>) => (fa: TaskOption<A>): TaskOption<A> => F.filter(fa, predicate)
+
+/**
+ * @category Filterable
+ * @since 0.1.18
+ */
+export const filterMap: <A, B>(f: (a: A) => O.Option<B>) => (fa: TaskOption<A>) => TaskOption<B> = (f) => (fa) =>
+  F.filterMap(fa, f)
+
+/**
+ * @category Filterable
+ * @since 0.1.18
+ */
+export const partition: {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: TaskOption<A>) => Separated<TaskOption<A>, TaskOption<B>>
+  <A>(predicate: Predicate<A>): (fa: TaskOption<A>) => Separated<TaskOption<A>, TaskOption<A>>
+} = <A>(predicate: Predicate<A>) => (fa: TaskOption<A>): Separated<TaskOption<A>, TaskOption<A>> =>
+  F.partition(fa, predicate)
+
+/**
+ * @category Filterable
+ * @since 0.1.18
+ */
+export const partitionMap: <A, B, C>(
+  f: (a: A) => Either<B, C>
+) => (fa: TaskOption<A>) => Separated<TaskOption<B>, TaskOption<C>> = (f) => (fa) => F.partitionMap(fa, f)
+
+// -------------------------------------------------------------------------------------
+// instances
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category instances
+ * @since 0.1.0
+ */
+const URI = 'TaskOption'
+
+/**
+ * @category instances
+ * @since 0.1.0
+ */
+export type URI = typeof URI
 
 declare module 'fp-ts/lib/HKT' {
   interface URItoKind<A> {
@@ -31,129 +298,83 @@ declare module 'fp-ts/lib/HKT' {
 }
 
 /**
- * @since 0.1.0
+ * @category instances
+ * @since 0.1.18
  */
-export const URI = 'TaskOption'
-
-/**
- * @since 0.1.0
- */
-export type URI = typeof URI
-
-/**
- * @since 0.1.0
- */
-export interface TaskOption<A> extends Task<Option<A>> {}
-
-/**
- * @since 0.1.0
- */
-export const fromTask: <A>(as: Task<A>) => TaskOption<A> = T.fromM
-
-/**
- * @since 0.1.0
- */
-export const fromOption: <A>(ma: Option<A>) => TaskOption<A> = of
-
-/**
- * @since 0.1.0
- */
-export const none: TaskOption<never> = T.none()
-
-/**
- * @since 0.1.0
- */
-export const some: <A>(a: A) => TaskOption<A> = T.of
-
-/**
- * @since 0.1.0
- */
-export function fold<A, B>(onNone: () => Task<B>, onSome: (a: A) => Task<B>): (as: TaskOption<A>) => Task<B> {
-  return as => T.fold(as, onNone, onSome)
+export const Functor: Functor1<URI> = {
+  URI,
+  map: T.map,
 }
 
 /**
- * @since 0.1.0
+ * @category instances
+ * @since 0.1.18
  */
-export function getOrElse<A>(onNone: () => Task<A>): (as: TaskOption<A>) => Task<A> {
-  return as => T.getOrElse(as, onNone)
+export const Applicative: Applicative1<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  of,
 }
 
 /**
- * @since 0.1.4
+ * @category instances
+ * @since 0.1.18
  */
-export function fromNullable<A>(a: A): TaskOption<NonNullable<A>> {
-  return fromOption(optionFromNullable(a))
+export const Apply: Apply1<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
 }
 
 /**
- * @since 0.1.4
+ * @category instances
+ * @since 0.1.18
  */
-export function fromTaskEither<A>(ma: TaskEither<any, A>): TaskOption<A> {
-  return task.map(ma, optionFromEither)
+export const Monad: Monad1<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  chain: T.chain,
+  of,
 }
 
 /**
- * @since 0.1.4
+ * @category instances
+ * @since 0.1.18
  */
-export function toUndefined<A>(ma: TaskOption<A>): Task<A | undefined> {
-  return task.map(ma, optionToUndefined)
+export const Alternative: Alternative1<URI> = {
+  URI,
+  map: T.map,
+  ap: T.ap,
+  alt: T.alt,
+  of,
+  zero,
 }
 
 /**
- * @since 0.1.4
+ * @category instances
+ * @since 0.1.18
  */
-export function toNullable<A>(ma: TaskOption<A>): Task<A | null> {
-  return task.map(ma, optionToNullable)
+export const Compactable: Compactable1<URI> = {
+  URI,
+  compact,
+  separate,
+}
+
+export const Filterable: Filterable1<URI> = {
+  URI,
+  map: T.map,
+  compact: F.compact,
+  filter: F.filter,
+  filterMap: F.filterMap,
+  separate: F.separate,
+  partition: F.partition,
+  partitionMap: F.partitionMap,
 }
 
 /**
- * @since 0.1.4
- */
-export function chainTask<A, B>(f: (a: A) => Task<B>): (ma: TaskOption<A>) => TaskOption<B> {
-  return ma => T.chain(ma, a => fromTask(f(a)))
-}
-
-/**
- * @since 0.1.4
- */
-export function chainOption<A, B>(f: (a: A) => Option<B>): (ma: TaskOption<A>) => TaskOption<B> {
-  return taskMap(optionChain(f))
-}
-
-/**
- * @since 0.1.5
- */
-export function mapNullable<A, B>(f: (a: A) => B | null | undefined): (ma: TaskOption<A>) => TaskOption<B> {
-  return taskMap(optionMapNullable(f))
-}
-
-/**
- * @since 0.1.5
- */
-export function tryCatch<A>(f: Lazy<Promise<A>>): TaskOption<A> {
-  return () =>
-    f().then(
-      a => optionSome(a),
-      () => optionNone
-    )
-}
-
-/**
- * @since 0.1.10
- */
-export function fromOptionK<A extends Array<unknown>, B>(f: (...a: A) => Option<B>): (...a: A) => TaskOption<B> {
-  return (...a) => fromOption(f(...a))
-}
-
-/**
- * @since 0.1.10
- */
-export function chainOptionK<A, B>(f: (a: A) => Option<B>): (ma: TaskOption<A>) => TaskOption<B> {
-  return chain(fromOptionK(f))
-}
-
-/**
+ * @category instances
  * @since 0.1.0
  */
 export const taskOption: Monad1<URI> & Alternative1<URI> & Filterable1<URI> = {
@@ -163,81 +384,5 @@ export const taskOption: Monad1<URI> & Alternative1<URI> & Filterable1<URI> = {
   chain: T.chain,
   alt: T.alt,
   zero: T.none,
-  ...getFilterableComposition(task, option)
-}
-
-const {
-  alt,
-  ap,
-  apFirst,
-  apSecond,
-  chain,
-  chainFirst,
-  flatten,
-  map,
-  partition,
-  partitionMap,
-  filter,
-  filterMap,
-  compact,
-  separate
-} = pipeable(taskOption)
-
-export {
-  /**
-   * @since 0.1.0
-   */
-  alt,
-  /**
-   * @since 0.1.0
-   */
-  ap,
-  /**
-   * @since 0.1.0
-   */
-  apFirst,
-  /**
-   * @since 0.1.0
-   */
-  apSecond,
-  /**
-   * @since 0.1.0
-   */
-  chain,
-  /**
-   * @since 0.1.0
-   */
-  chainFirst,
-  /**
-   * @since 0.1.0
-   */
-  flatten,
-  /**
-   * @since 0.1.0
-   */
-  map,
-  /**
-   * @since 0.1.5
-   */
-  partition,
-  /**
-   * @since 0.1.5
-   */
-  partitionMap,
-  /**
-   * @since 0.1.5
-   */
-  filter,
-  /**
-   * @since 0.1.5
-   */
-  filterMap,
-  /**
-   * @since 0.1.5
-   */
-  compact,
-  /**
-   * @since 0.1.5
-   */
-  separate
+  ...getFilterableComposition(task, O.option),
 }

--- a/src/TaskOption.ts
+++ b/src/TaskOption.ts
@@ -362,6 +362,10 @@ export const Compactable: Compactable1<URI> = {
   separate,
 }
 
+/**
+ * @category instances
+ * @since 0.1.18
+ */
 export const Filterable: Filterable1<URI> = {
   URI,
   map: T.map,

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -271,18 +271,6 @@ const traverse_ = <F>(F: ApplicativeHKT<F>): (<A, B>(ta: Zipper<A>, f: (a: A) =>
       traverseF(ta.rights, f)
     )
 }
-// TODO: add pipeable sequence fp-ts version >= 2.6.3
-const sequence_ = <F>(F: ApplicativeHKT<F>): (<A>(ta: Zipper<HKT<F, A>>) => HKT<F, Zipper<A>>) => {
-  const sequenceF = A.array.sequence(F)
-  return <A>(ta: Zipper<HKT<F, A>>) =>
-    F.ap(
-      F.ap(
-        F.map(sequenceF(ta.lefts), (lefts) => (focus: A) => (rights: Array<A>) => make(lefts, focus, rights)),
-        ta.focus
-      ),
-      sequenceF(ta.rights)
-    )
-}
 
 // -------------------------------------------------------------------------------------
 // pipeables
@@ -366,6 +354,24 @@ export const reduce: <A, B>(b: B, f: (b: B, a: A) => B) => (fa: Zipper<A>) => B 
  */
 export const reduceRight: <A, B>(b: B, f: (a: A, b: B) => B) => (fa: Zipper<A>) => B = (b, f) => (fa) =>
   reduceRight_(fa, b, f)
+
+/**
+ * @category Traversable
+ * @since 0.1.18
+ */
+export const sequence: Traversable1<URI>['sequence'] = <F>(
+  F: ApplicativeHKT<F>
+): (<A>(ta: Zipper<HKT<F, A>>) => HKT<F, Zipper<A>>) => {
+  const sequenceF = A.array.sequence(F)
+  return <A>(ta: Zipper<HKT<F, A>>) =>
+    F.ap(
+      F.ap(
+        F.map(sequenceF(ta.lefts), (lefts) => (focus: A) => (rights: Array<A>) => make(lefts, focus, rights)),
+        ta.focus
+      ),
+      sequenceF(ta.rights)
+    )
+}
 
 /**
  * @category Comonad
@@ -485,7 +491,7 @@ export const Traversable: Traversable1<URI> = {
   reduce: reduce_,
   reduceRight: reduceRight_,
   traverse: traverse_,
-  sequence: sequence_,
+  sequence,
 }
 
 /**
@@ -518,6 +524,6 @@ export const zipper: Applicative1<URI> &
   reduceRight: reduceRight_,
   foldMap: foldMap_,
   traverse: traverse_,
-  sequence: sequence_,
+  sequence,
   mapWithIndex: mapWithIndex_,
 }

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -12,38 +12,30 @@
  *
  * @since 0.1.6
  */
-import { Applicative, Applicative1 } from 'fp-ts/lib/Applicative'
+import { Applicative as ApplicativeHKT, Applicative1 } from 'fp-ts/lib/Applicative'
+import { Apply1 } from 'fp-ts/lib/Apply'
 import * as A from 'fp-ts/lib/Array'
 import { Comonad1 } from 'fp-ts/lib/Comonad'
-import { decrement, increment } from 'fp-ts/lib/function'
+import { Extend1 } from 'fp-ts/lib/Extend'
+import { Foldable1 } from 'fp-ts/lib/Foldable'
+import { decrement, increment, identity } from 'fp-ts/lib/function'
+import { Functor1 } from 'fp-ts/lib/Functor'
+import { FunctorWithIndex1 } from 'fp-ts/lib/FunctorWithIndex'
 import { HKT } from 'fp-ts/lib/HKT'
 import { Monoid } from 'fp-ts/lib/Monoid'
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
 import { none, Option, some } from 'fp-ts/lib/Option'
+import { pipe } from 'fp-ts/lib/pipeable'
 import { Semigroup } from 'fp-ts/lib/Semigroup'
 import { Show } from 'fp-ts/lib/Show'
-import { pipe, pipeable } from 'fp-ts/lib/pipeable'
-import { Foldable1 } from 'fp-ts/lib/Foldable'
 import { Traversable1 } from 'fp-ts/lib/Traversable'
-import { FunctorWithIndex1 } from 'fp-ts/lib/FunctorWithIndex'
 
-declare module 'fp-ts/lib/HKT' {
-  interface URItoKind<A> {
-    Zipper: Zipper<A>
-  }
-}
+// -------------------------------------------------------------------------------------
+// model
+// -------------------------------------------------------------------------------------
 
 /**
- * @since 0.1.6
- */
-export const URI = 'Zipper'
-
-/**
- * @since 0.1.6
- */
-export type URI = typeof URI
-
-/**
+ * @category model
  * @since 0.1.6
  */
 export interface Zipper<A> {
@@ -52,56 +44,90 @@ export interface Zipper<A> {
   readonly rights: Array<A>
 }
 
+// -------------------------------------------------------------------------------------
+// constructors
+// -------------------------------------------------------------------------------------
+
 /**
  * Creates a new zipper.
+ *
+ * @category constructors
  * @since 0.1.6
  */
-export function make<A>(lefts: Array<A>, focus: A, rights: Array<A>): Zipper<A> {
-  return { lefts, focus, rights }
+export const make: <A>(lefts: Array<A>, focus: A, rights: Array<A>) => Zipper<A> = (lefts, focus, rights) => ({
+  lefts,
+  focus,
+  rights,
+})
+
+/**
+ * @category constructors
+ * @since 0.1.6
+ */
+export const fromArray: <A>(as: Array<A>, focusIndex?: number) => Option<Zipper<A>> = (as, focusIndex = 0) => {
+  if (A.isEmpty(as) || A.isOutOfBound(focusIndex, as)) {
+    return none
+  } else {
+    return some(make(pipe(as, A.takeLeft(focusIndex)), as[focusIndex], pipe(as, A.dropLeft(focusIndex + 1))))
+  }
 }
 
 /**
+ * @category constructors
  * @since 0.1.6
  */
-export function length<A>(fa: Zipper<A>): number {
-  return fa.lefts.length + 1 + fa.rights.length
-}
+export const fromNonEmptyArray: <A>(nea: NonEmptyArray<A>) => Zipper<A> = (nea) => make(A.empty, nea[0], nea.slice(1))
+
+// -------------------------------------------------------------------------------------
+// destructors
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category destructors
+ * @since 0.1.18
+ */
+export const isOutOfBound: <A>(index: number, fa: Zipper<A>) => boolean = (index, fa) =>
+  index < 0 || index >= length(fa)
+
+/**
+ * @category destructors
+ * @since 0.1.6
+ */
+export const length: <A>(fa: Zipper<A>) => number = (fa) => fa.lefts.length + 1 + fa.rights.length
+
+/**
+ * @category destructors
+ * @since 0.1.6
+ */
+export const toArray: <A>(fa: Zipper<A>) => Array<A> = (fa) => A.snoc(fa.lefts, fa.focus).concat(fa.rights)
+
+// -------------------------------------------------------------------------------------
+// combinators
+// -------------------------------------------------------------------------------------
 
 /**
  * Updates the focus of the zipper.
+ *
+ * @category combinators
  * @since 0.1.6
  */
-export function update<A>(a: A): (fa: Zipper<A>) => Zipper<A> {
-  return fa => make(fa.lefts, a, fa.rights)
-}
+export const update: <A>(a: A) => (fa: Zipper<A>) => Zipper<A> = (a) => (fa) => make(fa.lefts, a, fa.rights)
 
 /**
  * Applies `f` to the focus and update with the result.
+ *
+ * @category combinators
  * @since 0.1.6
  */
-export function modify<A>(f: (a: A) => A): (fa: Zipper<A>) => Zipper<A> {
-  return fa => pipe(fa, update(f(fa.focus)))
-}
-
-/**
- * @since 0.1.6
- */
-export function toArray<A>(fa: Zipper<A>): Array<A> {
-  return A.snoc(fa.lefts, fa.focus).concat(fa.rights)
-}
-
-/**
- * @since 0.1.6
- */
-export function isOutOfBound<A>(index: number, fa: Zipper<A>): boolean {
-  return index < 0 || index >= length(fa)
-}
+export const modify: <A>(f: (a: A) => A) => (fa: Zipper<A>) => Zipper<A> = (f) => (fa) => pipe(fa, update(f(fa.focus)))
 
 /**
  * Moves focus in the zipper, or `None` if there is no such element.
+ *
+ * @category combinators
  * @since 0.1.6
  */
-export function move<A>(f: (currentIndex: number) => number, fa: Zipper<A>): Option<Zipper<A>> {
+export const move: <A>(f: (currentIndex: number) => number, fa: Zipper<A>) => Option<Zipper<A>> = (f, fa) => {
   const newIndex = f(fa.lefts.length)
   if (isOutOfBound(newIndex, fa)) {
     return none
@@ -112,25 +138,27 @@ export function move<A>(f: (currentIndex: number) => number, fa: Zipper<A>): Opt
 
 /**
  * Moves focus of the zipper up.
+ *
+ * @category combinators
  * @since 0.1.6
  */
-export function up<A>(fa: Zipper<A>): Option<Zipper<A>> {
-  return move(decrement, fa)
-}
+export const up: <A>(fa: Zipper<A>) => Option<Zipper<A>> = (fa) => move(decrement, fa)
 
 /**
  * Moves focus of the zipper down.
+ *
+ * @category combinators
  * @since 0.1.6
  */
-export function down<A>(fa: Zipper<A>): Option<Zipper<A>> {
-  return move(increment, fa)
-}
+export const down: <A>(fa: Zipper<A>) => Option<Zipper<A>> = (fa) => move(increment, fa)
 
 /**
  * Moves focus to the start of the zipper.
+ *
+ * @category combinators
  * @since 0.1.6
  */
-export function start<A>(fa: Zipper<A>): Zipper<A> {
+export const start: <A>(fa: Zipper<A>) => Zipper<A> = (fa) => {
   if (A.isEmpty(fa.lefts)) {
     return fa
   } else {
@@ -140,9 +168,11 @@ export function start<A>(fa: Zipper<A>): Zipper<A> {
 
 /**
  * Moves focus to the end of the zipper.
+ *
+ * @category combinators
  * @since 0.1.6
  */
-export function end<A>(fa: Zipper<A>): Zipper<A> {
+export const end: <A>(fa: Zipper<A>) => Zipper<A> = (fa) => {
   const len = fa.rights.length
   if (len === 0) {
     return fa
@@ -153,26 +183,30 @@ export function end<A>(fa: Zipper<A>): Zipper<A> {
 
 /**
  * Inserts an element to the left of the focus and focuses on the new element.
+ *
+ * @category combinators
  * @since 0.1.6
  */
-export function insertLeft<A>(a: A): (fa: Zipper<A>) => Zipper<A> {
-  return fa => make(fa.lefts, a, A.cons(fa.focus, fa.rights))
-}
+export const insertLeft: <A>(a: A) => (fa: Zipper<A>) => Zipper<A> = (a) => (fa) =>
+  make(fa.lefts, a, A.cons(fa.focus, fa.rights))
 
 /**
  * Inserts an element to the right of the focus and focuses on the new element.
+ *
+ * @category combinators
  * @since 0.1.6
  */
-export function insertRight<A>(a: A): (fa: Zipper<A>) => Zipper<A> {
-  return fa => make(A.snoc(fa.lefts, fa.focus), a, fa.rights)
-}
+export const insertRight: <A>(a: A) => (fa: Zipper<A>) => Zipper<A> = (a) => (fa) =>
+  make(A.snoc(fa.lefts, fa.focus), a, fa.rights)
 
 /**
  * Deletes the element at focus and moves the focus to the left. If there is no element on the left,
  * the focus is moved to the right.
+ *
+ * @category combinators
  * @since 0.1.6
  */
-export function deleteLeft<A>(fa: Zipper<A>): Option<Zipper<A>> {
+export const deleteLeft: <A>(fa: Zipper<A>) => Option<Zipper<A>> = (fa) => {
   const len = fa.lefts.length
   return fromArray(fa.lefts.concat(fa.rights), len > 0 ? len - 1 : 0)
 }
@@ -180,93 +214,293 @@ export function deleteLeft<A>(fa: Zipper<A>): Option<Zipper<A>> {
 /**
  * Deletes the element at focus and moves the focus to the right. If there is no element on the right,
  * the focus is moved to the left.
+ *
+ * @category combinators
  * @since 0.1.6
  */
-export function deleteRight<A>(fa: Zipper<A>): Option<Zipper<A>> {
+export const deleteRight: <A>(fa: Zipper<A>) => Option<Zipper<A>> = (fa) => {
   const lenl = fa.lefts.length
   const lenr = fa.rights.length
   return fromArray(fa.lefts.concat(fa.rights), lenr > 0 ? lenl : lenl - 1)
 }
 
-/**
- * @since 0.1.6
- */
-export function getShow<A>(S: Show<A>): Show<Zipper<A>> {
-  const SA = A.getShow(S)
-  return {
-    show: fa => `Zipper(${SA.show(fa.lefts)}, ${S.show(fa.focus)}, ${SA.show(fa.rights)})`
-  }
-}
+// -------------------------------------------------------------------------------------
+// non-pipeables
+// -------------------------------------------------------------------------------------
 
-/**
- * @since 0.1.6
- */
-export function fromArray<A>(as: Array<A>, focusIndex: number = 0): Option<Zipper<A>> {
-  if (A.isEmpty(as) || A.isOutOfBound(focusIndex, as)) {
-    return none
-  } else {
-    return some(make(pipe(as, A.takeLeft(focusIndex)), as[focusIndex], pipe(as, A.dropLeft(focusIndex + 1))))
-  }
+const map_: Functor1<URI>['map'] = (fa, f) => make(fa.lefts.map(f), f(fa.focus), fa.rights.map(f))
+const mapWithIndex_: FunctorWithIndex1<URI, number>['mapWithIndex'] = (fa, f) => {
+  const l = fa.lefts.length
+  return make(
+    fa.lefts.map((a, i) => f(i, a)),
+    f(l, fa.focus),
+    fa.rights.map((a, i) => f(l + 1 + i, a))
+  )
 }
-
-/**
- * @since 0.1.6
- */
-export function fromNonEmptyArray<A>(nea: NonEmptyArray<A>): Zipper<A> {
-  return make(A.empty, nea[0], nea.slice(1))
+const ap_: Apply1<URI>['ap'] = (fab, fa) =>
+  make(A.array.ap(fab.lefts, fa.lefts), fab.focus(fa.focus), A.array.ap(fab.rights, fa.rights))
+const extend_: Extend1<URI>['extend'] = (fa, f) => {
+  const lefts = fa.lefts.map((a, i) =>
+    f(make(pipe(fa.lefts, A.takeLeft(i)), a, A.snoc(pipe(fa.lefts, A.dropLeft(i + 1)), fa.focus).concat(fa.rights)))
+  )
+  const rights = fa.rights.map((a, i) =>
+    f(make(A.snoc(fa.lefts, fa.focus).concat(pipe(fa.rights, A.takeLeft(i))), a, pipe(fa.rights, A.dropLeft(i + 1))))
+  )
+  return make(lefts, f(fa), rights)
 }
-
-/**
- * @since 0.1.6
- */
-export function of<A>(focus: A): Zipper<A> {
-  return make(A.empty, focus, A.empty)
+const reduce_: Foldable1<URI>['reduce'] = (fa, b, f) => fa.rights.reduce(f, f(fa.lefts.reduce(f, b), fa.focus))
+const reduceRight_: Foldable1<URI>['reduceRight'] = (fa, b, f) => {
+  const rights = fa.rights.reduceRight((acc, a) => f(a, acc), b)
+  const focus = f(fa.focus, rights)
+  return fa.lefts.reduceRight((acc, a) => f(a, acc), focus)
 }
-
-function traverse<F>(F: Applicative<F>): <A, B>(ta: Zipper<A>, f: (a: A) => HKT<F, B>) => HKT<F, Zipper<B>> {
+const foldMap_: Foldable1<URI>['foldMap'] = (M) => (fa, f) => {
+  const lefts = fa.lefts.reduce((acc, a) => M.concat(acc, f(a)), M.empty)
+  const rights = fa.rights.reduce((acc, a) => M.concat(acc, f(a)), M.empty)
+  return M.concat(M.concat(lefts, f(fa.focus)), rights)
+}
+// TODO: add pipeable traverse fp-ts version >= 2.6.3
+const traverse_ = <F>(F: ApplicativeHKT<F>): (<A, B>(ta: Zipper<A>, f: (a: A) => HKT<F, B>) => HKT<F, Zipper<B>>) => {
   const traverseF = A.array.traverse(F)
   return <A, B>(ta: Zipper<A>, f: (a: A) => HKT<F, B>) =>
     F.ap(
       F.ap(
-        F.map(traverseF(ta.lefts, f), lefts => (focus: B) => (rights: Array<B>) => make(lefts, focus, rights)),
+        F.map(traverseF(ta.lefts, f), (lefts) => (focus: B) => (rights: Array<B>) => make(lefts, focus, rights)),
         f(ta.focus)
       ),
       traverseF(ta.rights, f)
     )
 }
-
-function sequence<F>(F: Applicative<F>): <A>(ta: Zipper<HKT<F, A>>) => HKT<F, Zipper<A>> {
+// TODO: add pipeable sequence fp-ts version >= 2.6.3
+const sequence_ = <F>(F: ApplicativeHKT<F>): (<A>(ta: Zipper<HKT<F, A>>) => HKT<F, Zipper<A>>) => {
   const sequenceF = A.array.sequence(F)
   return <A>(ta: Zipper<HKT<F, A>>) =>
     F.ap(
       F.ap(
-        F.map(sequenceF(ta.lefts), lefts => (focus: A) => (rights: Array<A>) => make(lefts, focus, rights)),
+        F.map(sequenceF(ta.lefts), (lefts) => (focus: A) => (rights: Array<A>) => make(lefts, focus, rights)),
         ta.focus
       ),
       sequenceF(ta.rights)
     )
 }
 
+// -------------------------------------------------------------------------------------
+// pipeables
+// -------------------------------------------------------------------------------------
+
 /**
+ * @category Functor
+ * @since 0.1.18
+ */
+export const map: <A, B>(f: (a: A) => B) => (fa: Zipper<A>) => Zipper<B> = (f) => (fa) => map_(fa, f)
+
+/**
+ * @category FunctorWithIndex
+ * @since 0.1.18
+ */
+export const mapWithIndex: <A, B>(f: (i: number, a: A) => B) => (fa: Zipper<A>) => Zipper<B> = (f) => (fa) =>
+  mapWithIndex_(fa, f)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const ap: <A>(fa: Zipper<A>) => <B>(fab: Zipper<(a: A) => B>) => Zipper<B> = (fa) => (fab) => ap_(fab, fa)
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const apFirst = <B>(fb: Zipper<B>) => <A>(fa: Zipper<A>): Zipper<A> =>
+  pipe(
+    fa,
+    map((a) => (_: B) => a),
+    ap(fb)
+  )
+
+/**
+ * @category Apply
+ * @since 0.1.18
+ */
+export const apSecond = <B>(fb: Zipper<B>) => <A>(fa: Zipper<A>): Zipper<B> =>
+  pipe(
+    fa,
+    map(() => (b: B) => b),
+    ap(fb)
+  )
+
+/**
+ * @category Applicative
  * @since 0.1.6
  */
-export function getSemigroup<A>(S: Semigroup<A>): Semigroup<Zipper<A>> {
-  return {
-    concat: (x, y) => make(x.lefts.concat(y.lefts), S.concat(x.focus, y.focus), x.rights.concat(y.rights))
+export const of: <A>(focus: A) => Zipper<A> = (focus) => make(A.empty, focus, A.empty)
+
+/**
+ * @category Extend
+ * @since 0.1.18
+ */
+export const extend: <A, B>(f: (fa: Zipper<A>) => B) => (wa: Zipper<A>) => Zipper<B> = (f) => (wa) => extend_(wa, f)
+
+/**
+ * @category Extend
+ * @since 0.1.18
+ */
+export const duplicate: <A>(wa: Zipper<A>) => Zipper<Zipper<A>> = extend(identity)
+
+/**
+ * @category Foldable
+ * @since 0.1.18
+ */
+export const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: Zipper<A>) => M = (M) => (f) => (fa) =>
+  foldMap_(M)(fa, f)
+
+/**
+ * @category Foldable
+ * @since 0.1.18
+ */
+export const reduce: <A, B>(b: B, f: (b: B, a: A) => B) => (fa: Zipper<A>) => B = (b, f) => (fa) => reduce_(fa, b, f)
+
+/**
+ * @category Foldable
+ * @since 0.1.18
+ */
+export const reduceRight: <A, B>(b: B, f: (a: A, b: B) => B) => (fa: Zipper<A>) => B = (b, f) => (fa) =>
+  reduceRight_(fa, b, f)
+
+/**
+ * @category Comonad
+ * @since 0.1.18
+ */
+export const extract: Comonad1<URI>['extract'] = (fa) => fa.focus
+
+// -------------------------------------------------------------------------------------
+// instances
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category instances
+ * @since 0.1.6
+ */
+export const URI = 'Zipper'
+
+/**
+ * @category instances
+ * @since 0.1.6
+ */
+export type URI = typeof URI
+
+declare module 'fp-ts/lib/HKT' {
+  interface URItoKind<A> {
+    Zipper: Zipper<A>
   }
 }
 
 /**
+ * @category instances
  * @since 0.1.6
  */
-export function getMonoid<A>(M: Monoid<A>): Monoid<Zipper<A>> {
+export const getShow: <A>(S: Show<A>) => Show<Zipper<A>> = (S) => {
+  const SA = A.getShow(S)
   return {
-    ...getSemigroup(M),
-    empty: make(A.empty, M.empty, A.empty)
+    show: (fa) => `Zipper(${SA.show(fa.lefts)}, ${S.show(fa.focus)}, ${SA.show(fa.rights)})`,
   }
 }
 
 /**
+ * @category instances
+ * @since 0.1.6
+ */
+export const getSemigroup: <A>(S: Semigroup<A>) => Semigroup<Zipper<A>> = (S) => ({
+  concat: (x, y) => make(x.lefts.concat(y.lefts), S.concat(x.focus, y.focus), x.rights.concat(y.rights)),
+})
+
+/**
+ * @category instances
+ * @since 0.1.6
+ */
+export const getMonoid: <A>(M: Monoid<A>) => Monoid<Zipper<A>> = (M) => ({
+  ...getSemigroup(M),
+  empty: make(A.empty, M.empty, A.empty),
+})
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Functor: Functor1<URI> = {
+  URI,
+  map: map_,
+}
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const FunctorWithIndex: FunctorWithIndex1<URI, number> = {
+  URI,
+  map: map_,
+  mapWithIndex: mapWithIndex_,
+}
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Applicative: Applicative1<URI> = {
+  URI,
+  map: map_,
+  ap: ap_,
+  of,
+}
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Apply: Apply1<URI> = {
+  URI,
+  map: map_,
+  ap: ap_,
+}
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Foldable: Foldable1<URI> = {
+  URI,
+  foldMap: foldMap_,
+  reduce: reduce_,
+  reduceRight: reduceRight_,
+}
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Traversable: Traversable1<URI> = {
+  URI,
+  map: map_,
+  foldMap: foldMap_,
+  reduce: reduce_,
+  reduceRight: reduceRight_,
+  traverse: traverse_,
+  sequence: sequence_,
+}
+
+/**
+ * @category instances
+ * @since 0.1.18
+ */
+export const Comonad: Comonad1<URI> = {
+  URI,
+  map: map_,
+  extend: extend_,
+  extract,
+}
+
+/**
+ * @category instances
  * @since 0.1.6
  */
 export const zipper: Applicative1<URI> &
@@ -275,83 +509,15 @@ export const zipper: Applicative1<URI> &
   Comonad1<URI> &
   FunctorWithIndex1<URI, number> = {
   URI,
-  map: (z, f) => make(z.lefts.map(f), f(z.focus), z.rights.map(f)),
+  map: map_,
   of,
-  ap: (fab, fa) => make(A.array.ap(fab.lefts, fa.lefts), fab.focus(fa.focus), A.array.ap(fab.rights, fa.rights)),
-  extend: (fa, f) => {
-    const lefts = fa.lefts.map((a, i) =>
-      f(make(pipe(fa.lefts, A.takeLeft(i)), a, A.snoc(pipe(fa.lefts, A.dropLeft(i + 1)), fa.focus).concat(fa.rights)))
-    )
-    const rights = fa.rights.map((a, i) =>
-      f(make(A.snoc(fa.lefts, fa.focus).concat(pipe(fa.rights, A.takeLeft(i))), a, pipe(fa.rights, A.dropLeft(i + 1))))
-    )
-    return make(lefts, f(fa), rights)
-  },
-  extract: <A>(fa: Zipper<A>): A => fa.focus,
-  reduce: (fa, b, f) => fa.rights.reduce(f, f(fa.lefts.reduce(f, b), fa.focus)),
-  reduceRight: (fa, b, f) => {
-    const rights = fa.rights.reduceRight((acc, a) => f(a, acc), b)
-    const focus = f(fa.focus, rights)
-    return fa.lefts.reduceRight((acc, a) => f(a, acc), focus)
-  },
-  foldMap: M => (fa, f) => {
-    const lefts = fa.lefts.reduce((acc, a) => M.concat(acc, f(a)), M.empty)
-    const rights = fa.rights.reduce((acc, a) => M.concat(acc, f(a)), M.empty)
-    return M.concat(M.concat(lefts, f(fa.focus)), rights)
-  },
-  traverse,
-  sequence,
-  mapWithIndex: (fa, f) => {
-    const l = fa.lefts.length
-    return make(
-      fa.lefts.map((a, i) => f(i, a)),
-      f(l, fa.focus),
-      fa.rights.map((a, i) => f(l + 1 + i, a))
-    )
-  }
-}
-
-const { ap, apFirst, apSecond, duplicate, extend, foldMap, map, reduce, reduceRight, mapWithIndex } = pipeable(zipper)
-
-export {
-  /**
-   * @since 0.1.6
-   */
-  ap,
-  /**
-   * @since 0.1.11
-   */
-  apFirst,
-  /**
-   * @since 0.1.11
-   */
-  apSecond,
-  /**
-   * @since 0.1.11
-   */
-  duplicate,
-  /**
-   * @since 0.1.11
-   */
-  extend,
-  /**
-   * @since 0.1.11
-   */
-  foldMap,
-  /**
-   * @since 0.1.6
-   */
-  map,
-  /**
-   * @since 0.1.6
-   */
-  reduce,
-  /**
-   * @since 0.1.6
-   */
-  reduceRight,
-  /**
-   * @since 0.1.17
-   */
-  mapWithIndex
+  ap: ap_,
+  extend: extend_,
+  extract,
+  reduce: reduce_,
+  reduceRight: reduceRight_,
+  foldMap: foldMap_,
+  traverse: traverse_,
+  sequence: sequence_,
+  mapWithIndex: mapWithIndex_,
 }

--- a/test/IOOption.ts
+++ b/test/IOOption.ts
@@ -1,137 +1,292 @@
-import { io } from 'fp-ts/lib/IO'
-import { semigroupSum } from 'fp-ts/lib/Semigroup'
-import * as O from 'fp-ts/lib/Option'
-import { pipe } from 'fp-ts/lib/pipeable'
 import * as assert from 'assert'
+import * as E from 'fp-ts/lib/Either'
+import { monoidSum } from 'fp-ts/lib/Monoid'
+import * as O from 'fp-ts/lib/Option'
+import { io } from 'fp-ts/lib/IO'
 import * as _ from '../src/IOOption'
 import * as IOE from 'fp-ts/lib/IOEither'
-import { monoidSum } from 'fp-ts/lib/Monoid'
+import { pipe } from 'fp-ts/lib/pipeable'
+import { semigroupSum } from 'fp-ts/lib/Semigroup'
 
 describe('IOOption', () => {
-  it('fold', () => {
-    const g = (n: number) => io.of(n > 2)
-    const ioo1 = pipe(
-      _.some(1),
-      _.fold(() => io.of(false), g)
-    )
-    const ioo2 = pipe(
-      _.none,
-      _.fold(() => io.of(true), g)
-    )
-    assert.strictEqual(ioo1(), false)
-    assert.strictEqual(ioo2(), true)
+  describe('pipeables', () => {
+    it('map', () => {
+      const f = (n: number): number => n + 1
+      assert.deepStrictEqual(pipe(_.some(1), _.map(f))(), O.some(2))
+      assert.deepStrictEqual(pipe(_.none, _.map(f))(), O.none)
+    })
+
+    it('ap', () => {
+      const fab = _.of((n: number) => n + 1)
+      assert.deepStrictEqual(pipe(fab, _.ap(_.some(1)))(), O.some(2))
+      assert.deepStrictEqual(pipe(fab, _.ap(_.none))(), O.none)
+    })
+
+    it('apFirst', () => {
+      const fb = _.some('a')
+      assert.deepStrictEqual(pipe(_.some(1), _.apFirst(fb))(), O.some(1))
+      assert.deepStrictEqual(pipe(_.none, _.apFirst(fb))(), O.none)
+    })
+
+    it('apSecond', () => {
+      const fa = _.some(1)
+      const fb = _.some('a')
+      assert.deepStrictEqual(pipe(fa, _.apSecond(fb))(), O.some('a'))
+    })
+
+    it('chain', () => {
+      const f = (n: number) => _.some(n + 1)
+      assert.deepStrictEqual(pipe(_.some(1), _.chain(f))(), O.some(2))
+      assert.deepStrictEqual(pipe(_.none, _.chain(f))(), O.none)
+    })
+
+    it('chainFirst', () => {
+      const f = (n: number) => _.of(n + 1)
+      assert.deepStrictEqual(pipe(_.some(1), _.chainFirst(f))(), O.some(1))
+      assert.deepStrictEqual(pipe(_.none, _.chainFirst(f))(), O.none)
+    })
+
+    it('chainOptionK', () => {
+      const f = (n: number) => O.some(n % 10)
+      assert.deepStrictEqual(pipe(_.some(12), _.chainOptionK(f))(), O.some(2))
+      assert.deepStrictEqual(pipe(_.none, _.chainOptionK(f))(), O.none)
+    })
+
+    it('flatten', () => {
+      assert.deepStrictEqual(pipe(_.some(_.some(1)), _.flatten)(), O.some(1))
+      assert.deepStrictEqual(pipe(_.none, _.flatten)(), O.none)
+    })
+
+    it('alt', () => {
+      assert.deepStrictEqual(
+        pipe(
+          _.some(1),
+          _.alt(() => _.some(2))
+        )(),
+        O.some(1)
+      )
+      assert.deepStrictEqual(
+        pipe(
+          _.some(1),
+          _.alt(() => _.none as _.IOOption<number>)
+        )(),
+        O.some(1)
+      )
+      assert.deepStrictEqual(
+        pipe(
+          _.none,
+          _.alt(() => _.some(1))
+        )(),
+        O.some(1)
+      )
+      assert.deepStrictEqual(
+        pipe(
+          _.none,
+          _.alt(() => _.none as _.IOOption<number>)
+        )(),
+        O.none
+      )
+    })
+
+    it('zero', () => {
+      assert.deepStrictEqual(_.zero()(), O.none)
+    })
+
+    it('compact', () => {
+      assert.deepStrictEqual(_.compact(_.none)(), O.none)
+      assert.deepStrictEqual(_.compact(_.some(O.none))(), O.none)
+      assert.deepStrictEqual(_.compact(_.some(O.some(1)))(), O.some(1))
+    })
+
+    it('separate', () => {
+      const a = _.separate(_.none)
+      assert.deepStrictEqual(a.left(), O.none)
+      assert.deepStrictEqual(a.right(), O.none)
+
+      const b = _.separate(_.some(E.left(1)))
+      assert.deepStrictEqual(b.left(), O.some(1))
+      assert.deepStrictEqual(b.right(), O.none)
+
+      const c = _.separate(_.some(E.right(1)))
+      assert.deepStrictEqual(c.left(), O.none)
+      assert.deepStrictEqual(c.right(), O.some(1))
+    })
+
+    it('filter', () => {
+      const predicate = (n: number): boolean => n === 2
+      assert.deepStrictEqual(pipe(_.none, _.filter(predicate))(), O.none)
+      assert.deepStrictEqual(pipe(_.some(1), _.filter(predicate))(), O.none)
+      assert.deepStrictEqual(pipe(_.some(2), _.filter(predicate))(), O.some(2))
+    })
+
+    it('filterMap', () => {
+      const predicate = (n: number): boolean => n === 2
+      const f = (n: number): O.Option<number> => (predicate(n) ? O.some(n + 1) : O.none)
+      assert.deepStrictEqual(pipe(_.none, _.filterMap(f))(), O.none)
+      assert.deepStrictEqual(pipe(_.some(1), _.filterMap(f))(), O.none)
+      assert.deepStrictEqual(pipe(_.some(2), _.filterMap(f))(), O.some(3))
+    })
+
+    it('partition', () => {
+      const predicate = (n: number): boolean => n > 2
+
+      const a = pipe(_.none, _.partition(predicate))
+      assert.deepStrictEqual(a.left(), O.none)
+      assert.deepStrictEqual(a.right(), O.none)
+
+      const b = pipe(_.some(1), _.partition(predicate))
+      assert.deepStrictEqual(b.left(), O.some(1))
+      assert.deepStrictEqual(b.right(), O.none)
+
+      const c = pipe(_.some(3), _.partition(predicate))
+      assert.deepStrictEqual(c.left(), O.none)
+      assert.deepStrictEqual(c.right(), O.some(3))
+    })
+
+    it('partitionMap', () => {
+      const predicate = (n: number): boolean => n > 2
+      const f = (n: number): E.Either<number, number> => (predicate(n) ? E.right(n + 1) : E.left(n - 1))
+
+      const a = pipe(_.none, _.partitionMap(f))
+      assert.deepStrictEqual(a.left(), O.none)
+      assert.deepStrictEqual(a.right(), O.none)
+
+      const b = pipe(_.some(1), _.partitionMap(f))
+      assert.deepStrictEqual(b.left(), O.some(0))
+      assert.deepStrictEqual(b.right(), O.none)
+
+      const c = pipe(_.some(3), _.partitionMap(f))
+      assert.deepStrictEqual(c.left(), O.none)
+      assert.deepStrictEqual(c.right(), O.some(4))
+    })
   })
 
-  it('fromNullable', () => {
-    const ma1 = _.fromNullable(null)
-    const ma2 = _.fromNullable(undefined)
-    const ma3 = _.fromNullable(42)
-    assert.deepStrictEqual(ma1(), O.none)
-    assert.deepStrictEqual(ma2(), O.none)
-    assert.deepStrictEqual(ma3(), O.some(42))
+  describe('constructors', () => {
+    it('fromNullable', () => {
+      const ma1 = _.fromNullable(null)
+      const ma2 = _.fromNullable(undefined)
+      const ma3 = _.fromNullable(42)
+      assert.deepStrictEqual(ma1(), O.none)
+      assert.deepStrictEqual(ma2(), O.none)
+      assert.deepStrictEqual(ma3(), O.some(42))
+    })
+
+    it('fromOptionK', () => {
+      const f = (n: number) => O.some(n % 10)
+      assert.deepStrictEqual(_.fromOptionK(f)(12)(), O.some(2))
+    })
+
+    it('fromIOEither', async () => {
+      const ma1 = _.fromIOEither(IOE.right(42))
+      const ma2 = _.fromIOEither(IOE.left('ouch!'))
+      assert.deepStrictEqual(ma1(), O.some(42))
+      assert.deepStrictEqual(ma2(), O.none)
+    })
   })
 
-  it('getOrElse', () => {
-    const v = io.of(42)
-    const ioo1 = pipe(
-      _.some(1),
-      _.getOrElse(() => v)
-    )
-    const ioo2 = pipe(
-      _.none,
-      _.getOrElse(() => v)
-    )
-    assert.deepStrictEqual(ioo1(), 1)
-    assert.deepStrictEqual(ioo2(), 42)
+  describe('destructors', () => {
+    it('fold', () => {
+      const g = (n: number) => io.of(n > 2)
+      const ioo1 = pipe(
+        _.some(1),
+        _.fold(() => io.of(false), g)
+      )
+      const ioo2 = pipe(
+        _.none,
+        _.fold(() => io.of(true), g)
+      )
+      assert.strictEqual(ioo1(), false)
+      assert.strictEqual(ioo2(), true)
+    })
+
+    it('getOrElse', () => {
+      const v = io.of(42)
+      const ioo1 = pipe(
+        _.some(1),
+        _.getOrElse(() => v)
+      )
+      const ioo2 = pipe(
+        _.none,
+        _.getOrElse(() => v)
+      )
+      assert.deepStrictEqual(ioo1(), 1)
+      assert.deepStrictEqual(ioo2(), 42)
+    })
+
+    it('toUndefined', () => {
+      const ioo1 = pipe(_.some(6), _.toUndefined)
+      const ioo2 = pipe(_.none, _.toUndefined)
+      assert.deepStrictEqual(ioo1(), 6)
+      assert.deepStrictEqual(ioo2(), undefined)
+    })
+
+    it('toNullable', () => {
+      const ioo1 = pipe(_.some(6), _.toNullable)
+      const ioo2 = pipe(_.none, _.toNullable)
+      assert.deepStrictEqual(ioo1(), 6)
+      assert.deepStrictEqual(ioo2(), null)
+    })
   })
 
-  it('fromIOEither', async () => {
-    const ma1 = _.fromIOEither(IOE.right(42))
-    const ma2 = _.fromIOEither(IOE.left('ouch!'))
-    assert.deepStrictEqual(ma1(), O.some(42))
-    assert.deepStrictEqual(ma2(), O.none)
-  })
-
-  it('toUndefined', () => {
-    const ioo1 = pipe(_.some(6), _.toUndefined)
-    const ioo2 = pipe(_.none, _.toUndefined)
-    assert.deepStrictEqual(ioo1(), 6)
-    assert.deepStrictEqual(ioo2(), undefined)
-  })
-
-  it('toNullable', () => {
-    const ioo1 = pipe(_.some(6), _.toNullable)
-    const ioo2 = pipe(_.none, _.toNullable)
-    assert.deepStrictEqual(ioo1(), 6)
-    assert.deepStrictEqual(ioo2(), null)
-  })
-
-  it('mapNullable', async () => {
-    interface X {
-      a?: {
-        b?: {
-          c?: {
-            d: number
+  describe('combinators', () => {
+    it('mapNullable', async () => {
+      interface X {
+        a?: {
+          b?: {
+            c?: {
+              d: number
+            }
           }
         }
       }
-    }
-    const x1: X = { a: {} }
-    const x2: X = { a: { b: {} } }
-    const x3: X = { a: { b: { c: { d: 1 } } } }
-    assert.deepStrictEqual(
-      pipe(
-        _.fromNullable(x1.a),
-        _.mapNullable(x => x.b),
-        _.mapNullable(x => x.c),
-        _.mapNullable(x => x.d)
-      )(),
-      O.none
-    )
-    assert.deepStrictEqual(
-      pipe(
-        _.fromNullable(x2.a),
-        _.mapNullable(x => x.b),
-        _.mapNullable(x => x.c),
-        _.mapNullable(x => x.d)
-      )(),
-      O.none
-    )
-    assert.deepStrictEqual(
-      pipe(
-        _.fromNullable(x3.a),
-        _.mapNullable(x => x.b),
-        _.mapNullable(x => x.c),
-        _.mapNullable(x => x.d)
-      )(),
-      O.some(1)
-    )
+      const x1: X = { a: {} }
+      const x2: X = { a: { b: {} } }
+      const x3: X = { a: { b: { c: { d: 1 } } } }
+      assert.deepStrictEqual(
+        pipe(
+          _.fromNullable(x1.a),
+          _.mapNullable(x => x.b),
+          _.mapNullable(x => x.c),
+          _.mapNullable(x => x.d)
+        )(),
+        O.none
+      )
+      assert.deepStrictEqual(
+        pipe(
+          _.fromNullable(x2.a),
+          _.mapNullable(x => x.b),
+          _.mapNullable(x => x.c),
+          _.mapNullable(x => x.d)
+        )(),
+        O.none
+      )
+      assert.deepStrictEqual(
+        pipe(
+          _.fromNullable(x3.a),
+          _.mapNullable(x => x.b),
+          _.mapNullable(x => x.c),
+          _.mapNullable(x => x.d)
+        )(),
+        O.some(1)
+      )
+    })
   })
 
-  it('getApplySemigroup', () => {
-    const S = _.getApplySemigroup(semigroupSum)
-    assert.deepStrictEqual(S.concat(_.none, _.none)(), O.none)
-    assert.deepStrictEqual(S.concat(_.some(1), _.none)(), O.none)
-    assert.deepStrictEqual(S.concat(_.none, _.some(1))(), O.none)
-    assert.deepStrictEqual(S.concat(_.some(1), _.some(2))(), O.some(3))
-  })
+  describe('instances', () => {
+    it('getApplySemigroup', () => {
+      const S = _.getApplySemigroup(semigroupSum)
+      assert.deepStrictEqual(S.concat(_.none, _.none)(), O.none)
+      assert.deepStrictEqual(S.concat(_.some(1), _.none)(), O.none)
+      assert.deepStrictEqual(S.concat(_.none, _.some(1))(), O.none)
+      assert.deepStrictEqual(S.concat(_.some(1), _.some(2))(), O.some(3))
+    })
 
-  it('getApplyMonoid', () => {
-    const M = _.getApplyMonoid(monoidSum)
-    assert.deepStrictEqual(M.concat(M.empty, _.none)(), O.none)
-    assert.deepStrictEqual(M.concat(_.none, M.empty)(), O.none)
-    assert.deepStrictEqual(M.concat(M.empty, _.some(1))(), O.some(1))
-    assert.deepStrictEqual(M.concat(_.some(1), M.empty)(), O.some(1))
-  })
-
-  it('fromOptionK', () => {
-    const f = (n: number) => O.some(n % 10)
-    assert.deepStrictEqual(_.fromOptionK(f)(12)(), O.some(2))
-  })
-
-  it('chainOptionK', () => {
-    const f = (n: number) => O.some(n % 10)
-    const ioo = pipe(_.some(12), _.chainOptionK(f))
-    assert.deepStrictEqual(ioo(), O.some(2))
+    it('getApplyMonoid', () => {
+      const M = _.getApplyMonoid(monoidSum)
+      assert.deepStrictEqual(M.concat(M.empty, _.none)(), O.none)
+      assert.deepStrictEqual(M.concat(_.none, M.empty)(), O.none)
+      assert.deepStrictEqual(M.concat(M.empty, _.some(1))(), O.some(1))
+      assert.deepStrictEqual(M.concat(_.some(1), M.empty)(), O.some(1))
+    })
   })
 })

--- a/test/List.ts
+++ b/test/List.ts
@@ -32,7 +32,7 @@ describe('List', () => {
   })
 
   it('of', () => {
-    fc.assert(fc.property(elementArb, a => eqListElement.equals(L.of(a), pipe(a, A.of, L.fromArray))))
+    fc.assert(fc.property(elementArb, (a) => eqListElement.equals(L.of(a), pipe(a, A.of, L.fromArray))))
   })
 
   it('isNil', () => {
@@ -48,13 +48,13 @@ describe('List', () => {
   it('head', () => {
     const eq = O.getEq(Eq.eqNumber)
 
-    fc.assert(fc.property(listArb, l => eq.equals(L.head(l), A.head(L.toArray(l)))))
+    fc.assert(fc.property(listArb, (l) => eq.equals(L.head(l), A.head(L.toArray(l)))))
   })
 
   it('tail', () => {
     const eq = O.getEq(eqListElement)
 
-    fc.assert(fc.property(listArb, l => eq.equals(L.tail(l), pipe(l, L.toArray, A.tail, O.map(L.fromArray)))))
+    fc.assert(fc.property(listArb, (l) => eq.equals(L.tail(l), pipe(l, L.toArray, A.tail, O.map(L.fromArray)))))
   })
 
   it('foldLeft', () => {
@@ -67,14 +67,14 @@ describe('List', () => {
       (_, tail) => 1 + aLen(tail)
     )
 
-    fc.assert(fc.property(listArb, l => Eq.eqNumber.equals(lLen(l), aLen(L.toArray(l)))))
+    fc.assert(fc.property(listArb, (l) => Eq.eqNumber.equals(lLen(l), aLen(L.toArray(l)))))
   })
 
   it('findIndex', () => {
     const f = (a: number): boolean => a % 2 === 0
     const eq = O.getEq(Eq.eqNumber)
 
-    fc.assert(fc.property(listArb, l => eq.equals(L.findIndex(f)(l), A.findIndex(f)(L.toArray(l)))))
+    fc.assert(fc.property(listArb, (l) => eq.equals(L.findIndex(f)(l), A.findIndex(f)(L.toArray(l)))))
   })
 
   it('dropLeft', () => {
@@ -89,14 +89,16 @@ describe('List', () => {
     const isLTThree = (n: number) => n < 3
 
     fc.assert(
-      fc.property(listArb, l =>
+      fc.property(listArb, (l) =>
         eqListElement.equals(L.dropLeftWhile(isLTThree)(l), pipe(l, L.toArray, A.dropLeftWhile(isLTThree), L.fromArray))
       )
     )
   })
 
   it('reverse', () => {
-    fc.assert(fc.property(listArb, l => eqListElement.equals(L.reverse(l), pipe(l, L.toArray, A.reverse, L.fromArray))))
+    fc.assert(
+      fc.property(listArb, (l) => eqListElement.equals(L.reverse(l), pipe(l, L.toArray, A.reverse, L.fromArray)))
+    )
   })
 
   it('map', () => {
@@ -104,38 +106,38 @@ describe('List', () => {
       eqListElement.equals(pipe(l, L.map(f)), pipe(l, L.toArray, A.map(f), L.fromArray))
 
     assert.ok(checkProperty(identity, L.of(6)))
-    fc.assert(fc.property(listArb, l => checkProperty((a: number) => a ** 2, l)))
+    fc.assert(fc.property(listArb, (l) => checkProperty((a: number) => a ** 2, l)))
   })
 
   it('reduce', () => {
     const f = (a: number, b: number): number => a + b
 
     fc.assert(
-      fc.property(listArb, l => Eq.eqNumber.equals(pipe(l, L.reduce(0, f)), pipe(l, L.toArray, A.reduce(0, f))))
+      fc.property(listArb, (l) => Eq.eqNumber.equals(pipe(l, L.reduce(0, f)), pipe(l, L.toArray, A.reduce(0, f))))
     )
   })
 
   it('foldMap', () => {
     fc.assert(
-      fc.property(listArb, l =>
+      fc.property(listArb, (l) =>
         Eq.eqNumber.equals(pipe(l, L.foldMap(monoidSum)(identity)), pipe(l, L.toArray, A.foldMap(monoidSum)(identity)))
       )
     )
   })
 
   it('toArray/fromArray', () => {
-    fc.assert(fc.property(fc.array(elementArb), as => eqArrayElement.equals(as, pipe(as, L.fromArray, L.toArray))))
+    fc.assert(fc.property(fc.array(elementArb), (as) => eqArrayElement.equals(as, pipe(as, L.fromArray, L.toArray))))
   })
 
   it('toReversedArray', () => {
-    fc.assert(fc.property(listArb, l => eqListElement.equals(l, pipe(l, L.toReversedArray, L.fromArray, L.reverse))))
+    fc.assert(fc.property(listArb, (l) => eqListElement.equals(l, pipe(l, L.toReversedArray, L.fromArray, L.reverse))))
   })
 
   it('reduceRight', () => {
     const f = (a: number, b: number): number => a + b
 
     fc.assert(
-      fc.property(listArb, l =>
+      fc.property(listArb, (l) =>
         Eq.eqNumber.equals(pipe(l, L.reduceRight(0, f)), pipe(l, L.toArray, A.reduceRight(0, f)))
       )
     )
@@ -149,7 +151,7 @@ describe('List', () => {
     const f = (n: number): O.Option<number> => (n % 2 === 0 ? O.none : O.some(n))
 
     fc.assert(
-      fc.property(listArb, l =>
+      fc.property(listArb, (l) =>
         eq.equals(listTraverseO(l, f), pipe(arrayTraverseO(L.toArray(l), f), O.map(L.fromArray)))
       )
     )
@@ -157,13 +159,13 @@ describe('List', () => {
 
   it('sequence', () => {
     const eq = O.getEq(eqListElement)
-    const listSequenceO = L.list.sequence(O.option)
+    const listSequenceO = L.sequence(O.option)
     const arraySequenceO = A.array.sequence(O.option)
-    const elementArb = fc.integer().map(n => (Math.random() > 0.5 ? O.some(n) : O.none))
+    const elementArb = fc.integer().map((n) => (Math.random() > 0.5 ? O.some(n) : O.none))
     const listArb = fc.array(elementArb).map(L.fromArray)
 
     fc.assert(
-      fc.property(listArb, l => eq.equals(listSequenceO(l), pipe(l, L.toArray, arraySequenceO, O.map(L.fromArray))))
+      fc.property(listArb, (l) => eq.equals(listSequenceO(l), pipe(l, L.toArray, arraySequenceO, O.map(L.fromArray))))
     )
   })
 

--- a/test/StateEither.ts
+++ b/test/StateEither.ts
@@ -41,7 +41,7 @@ describe('StateEither', () => {
       assert.deepStrictEqual(e, E.right('aaa'))
     })
 
-    it('chainEitherK', async () => {
+    it('chainEitherK', () => {
       const f = (s: string) => E.right(s.length)
       const x = _.evalState(pipe(_.right('aa'), _.chainEitherK(f)), {})
       assert.deepStrictEqual(x, E.right(2))
@@ -58,7 +58,7 @@ describe('StateEither', () => {
         _.evalState(
           pipe(
             _.right('aaa'),
-            _.filterOrElse(p, s => s.length)
+            _.filterOrElse(p, (s) => s.length)
           ),
           {}
         ),
@@ -68,7 +68,7 @@ describe('StateEither', () => {
         _.evalState(
           pipe(
             _.right('aa'),
-            _.filterOrElse(p, s => s.length)
+            _.filterOrElse(p, (s) => s.length)
           ),
           {}
         ),
@@ -79,13 +79,13 @@ describe('StateEither', () => {
 
   describe('constructors', () => {
     it('rightState', () => {
-      const state: State<{}, number> = s => [1, s]
+      const state: State<{}, number> = (s) => [1, s]
       const e = _.evalState(_.rightState(state), {})
       assert.deepStrictEqual(e, E.right(1))
     })
 
     it('leftState', () => {
-      const state: State<{}, number> = s => [1, s]
+      const state: State<{}, number> = (s) => [1, s]
       const e = _.evalState(_.leftState(state), {})
       assert.deepStrictEqual(e, E.left(1))
     })
@@ -113,13 +113,13 @@ describe('StateEither', () => {
       )
     })
 
-    it('fromEither', async () => {
+    it('fromEither', () => {
       const ei: E.Either<{}, number> = E.right(1)
       const e = _.evalState(_.fromEither(ei), {})
       assert.deepStrictEqual(e, E.right(1))
     })
 
-    it('fromEitherK', async () => {
+    it('fromEitherK', () => {
       const f = (s: Array<string>) => E.right(s.length)
       const x = _.evalState(_.fromEitherK(f)(['a', 'b']), {})
       assert.deepStrictEqual(x, E.right(2))

--- a/test/StateEither.ts
+++ b/test/StateEither.ts
@@ -1,31 +1,152 @@
 import * as assert from 'assert'
 import * as E from 'fp-ts/lib/Either'
+import * as O from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'
 import { State } from 'fp-ts/lib/State'
 import * as _ from '../src/StateEither'
 
 describe('StateEither', () => {
-  describe('Monad', () => {
-    it('map', async () => {
+  describe('pipeables', () => {
+    it('map', () => {
       const len = (s: string): number => s.length
-      const ma = _.right('aaa')
-      const e = _.evalState(_.stateEither.map(ma, len), {})
+      const e = _.evalState(pipe(_.right('aaa'), _.map(len)), {})
       assert.deepStrictEqual(e, E.right(3))
     })
 
-    it('ap', async () => {
+    it('ap', () => {
       const len = (s: string): number => s.length
-      const mab = _.right(len)
-      const ma = _.right('aaa')
-      const e = _.evalState(_.stateEither.ap(mab, ma), {})
+      const e = _.evalState(pipe(_.right(len), _.ap(_.right('aaa'))), {})
       assert.deepStrictEqual(e, E.right(3))
     })
 
-    it('chain', async () => {
+    it('apFirst', () => {
+      const e = _.evalState(pipe(_.right('aaa'), _.apFirst(_.right('bbb'))), {})
+      assert.deepStrictEqual(e, E.right('aaa'))
+    })
+
+    it('apSecond', () => {
+      const e = _.evalState(pipe(_.right('aaa'), _.apSecond(_.right('bbb'))), {})
+      assert.deepStrictEqual(e, E.right('bbb'))
+    })
+
+    it('chain', () => {
       const f = (s: string) => (s.length > 2 ? _.right(s.length) : _.right(0))
-      const ma = _.right('aaa')
-      const e = _.evalState(_.stateEither.chain(ma, f), {})
+      const e = _.evalState(pipe(_.right('aaa'), _.chain(f)), {})
       assert.deepStrictEqual(e, E.right(3))
+    })
+
+    it('chainFirst', () => {
+      const f = (s: string) => (s.length > 2 ? _.right(s.length) : _.right(0))
+      const e = _.evalState(pipe(_.right('aaa'), _.chainFirst(f)), {})
+      assert.deepStrictEqual(e, E.right('aaa'))
+    })
+
+    it('chainEitherK', async () => {
+      const f = (s: string) => E.right(s.length)
+      const x = _.evalState(pipe(_.right('aa'), _.chainEitherK(f)), {})
+      assert.deepStrictEqual(x, E.right(2))
+    })
+
+    it('flatten', () => {
+      assert.deepStrictEqual(_.evalState(pipe(_.right(_.right('aaa')), _.flatten), {}), E.right('aaa'))
+      assert.deepStrictEqual(_.evalState(pipe(_.right(_.left('aaa')), _.flatten), {}), E.left('aaa'))
+    })
+
+    it('filterOrElse', () => {
+      const p = (s: string) => s.length > 2
+      assert.deepStrictEqual(
+        _.evalState(
+          pipe(
+            _.right('aaa'),
+            _.filterOrElse(p, s => s.length)
+          ),
+          {}
+        ),
+        E.right('aaa')
+      )
+      assert.deepStrictEqual(
+        _.evalState(
+          pipe(
+            _.right('aa'),
+            _.filterOrElse(p, s => s.length)
+          ),
+          {}
+        ),
+        E.left(2)
+      )
+    })
+  })
+
+  describe('constructors', () => {
+    it('rightState', () => {
+      const state: State<{}, number> = s => [1, s]
+      const e = _.evalState(_.rightState(state), {})
+      assert.deepStrictEqual(e, E.right(1))
+    })
+
+    it('leftState', () => {
+      const state: State<{}, number> = s => [1, s]
+      const e = _.evalState(_.leftState(state), {})
+      assert.deepStrictEqual(e, E.left(1))
+    })
+
+    it('fromOption', () => {
+      assert.deepStrictEqual(
+        _.evalState(
+          pipe(
+            O.some(1),
+            _.fromOption(() => 'none')
+          ),
+          {}
+        ),
+        E.right(1)
+      )
+      assert.deepStrictEqual(
+        _.evalState(
+          pipe(
+            O.none,
+            _.fromOption(() => 'none')
+          ),
+          {}
+        ),
+        E.left('none')
+      )
+    })
+
+    it('fromEither', async () => {
+      const ei: E.Either<{}, number> = E.right(1)
+      const e = _.evalState(_.fromEither(ei), {})
+      assert.deepStrictEqual(e, E.right(1))
+    })
+
+    it('fromEitherK', async () => {
+      const f = (s: Array<string>) => E.right(s.length)
+      const x = _.evalState(_.fromEitherK(f)(['a', 'b']), {})
+      assert.deepStrictEqual(x, E.right(2))
+    })
+
+    it('fromPredicate', () => {
+      const p = (n: number): boolean => n > 2
+      assert.deepStrictEqual(
+        _.evalState(
+          pipe(
+            3,
+            _.fromPredicate(p, () => 'false')
+          ),
+          {}
+        ),
+        E.right(3)
+      )
+      assert.deepStrictEqual(
+        _.evalState(
+          pipe(
+            2,
+            _.fromPredicate(p, () => 'false')
+          ),
+          {}
+        ),
+        E.left('false')
+      )
     })
   })
 
@@ -46,35 +167,5 @@ describe('StateEither', () => {
   it('execState Left', () => {
     const e = _.execState(_.left('aaa'), { a: 0 })
     assert.deepStrictEqual(e, E.left('aaa'))
-  })
-
-  it('rightState', () => {
-    const state: State<{}, number> = s => [1, s]
-    const e = _.evalState(_.rightState(state), {})
-    assert.deepStrictEqual(e, E.right(1))
-  })
-
-  it('leftState', () => {
-    const state: State<{}, number> = s => [1, s]
-    const e = _.evalState(_.leftState(state), {})
-    assert.deepStrictEqual(e, E.left(1))
-  })
-
-  it('fromEither', async () => {
-    const ei: E.Either<{}, number> = E.right(1)
-    const e = _.evalState(_.fromEither(ei), {})
-    assert.deepStrictEqual(e, E.right(1))
-  })
-
-  it('fromEitherK', async () => {
-    const f = (s: Array<string>) => E.right(s.length)
-    const x = _.evalState(_.fromEitherK(f)(['a', 'b']), {})
-    assert.deepStrictEqual(x, E.right(2))
-  })
-
-  it('chainEitherK', async () => {
-    const f = (s: string) => E.right(s.length)
-    const x = _.evalState(pipe(_.right('aa'), _.chainEitherK(f)), {})
-    assert.deepStrictEqual(x, E.right(2))
   })
 })

--- a/test/StateIO.ts
+++ b/test/StateIO.ts
@@ -1,0 +1,82 @@
+import * as assert from 'assert'
+import * as IO from "fp-ts/lib/IO";
+import * as S from 'fp-ts/lib/State'
+import { pipe } from "fp-ts/lib/pipeable";
+
+import * as _ from '../src/StateIO'
+
+describe('StateIO', () => {
+  describe('pipeables', () => {
+    it('map', () => {
+      const double = (n: number) => n * 2
+      assert.deepStrictEqual(_.evalState(pipe(_.of(1), _.map(double)), {})(), 2)
+    })
+
+    it('ap', () => {
+      const double = (n: number) => n * 2
+      assert.deepStrictEqual(_.evalState(pipe(_.of(double), _.ap(_.of(1))), {})(), 2)
+    })
+
+    it('apFirst', () => {
+      assert.deepStrictEqual(_.evalState(pipe(_.of(1), _.apFirst(_.of('a'))), {})(), 1)
+    })
+
+    it('apSecond', () => {
+      assert.deepStrictEqual(_.evalState(pipe(_.of(1), _.apSecond(_.of('a'))), {})(), 'a')
+    })
+
+    it('chain', () => {
+      const f = (n: number) => _.of(n + 1)
+      assert.deepStrictEqual(_.evalState(pipe(_.of(1), _.chain(f)), {})(), 2)
+    })
+
+    it('chainFirst', () => {
+      const f = (n: number) => _.of(n + 1)
+      assert.deepStrictEqual(_.evalState(pipe(_.of(1), _.chainFirst(f)), {})(), 1)
+    })
+
+    it('chainIOK', () => {
+      const f = (n: number): IO.IO<number> => IO.of(n + 1)
+      assert.deepStrictEqual(_.evalState(pipe(_.of(1), _.chainIOK(f)), {})(), 2)
+    })
+
+    it('flatten', () => {
+      assert.deepStrictEqual(_.evalState(pipe(_.of(_.of(1)), _.flatten), {})(), 1)
+    })
+  })
+
+  describe('constructors', () => {
+    it('fromIO', () => {
+      assert.deepStrictEqual(_.evalState(pipe(IO.of(1), _.fromIO), {})(), 1)
+    })
+
+    it('fromState', () => {
+      assert.deepStrictEqual(_.evalState(pipe(S.of(1), _.fromState), {})(), 1)
+    })
+
+    it('fromIOK', () => {
+      const f = (s: string) => IO.of(s.length)
+      assert.deepStrictEqual(_.evalState(pipe('aaa', _.fromIOK(f)), {})(), 3)
+    })
+  })
+
+  it('evalState', () => {
+    const ma = _.of(1)
+    const s = {}
+    const e = _.evalState(ma, s)
+    assert.deepStrictEqual(e(), 1)
+  })
+
+  it('execState', () => {
+    const ma = _.of(1)
+    const s = {}
+    const e = _.execState(ma, s)
+    assert.deepStrictEqual(e(), {})
+  })
+
+  it('run', () => {
+    const ma = _.of(1)
+    const s = {}
+    assert.deepStrictEqual(_.run(ma, s), 1)
+  })
+})

--- a/test/StateTaskEither.ts
+++ b/test/StateTaskEither.ts
@@ -1,0 +1,203 @@
+import * as assert from 'assert'
+import * as E from 'fp-ts/lib/Either'
+import * as IO from 'fp-ts/lib/IO'
+import * as IOE from 'fp-ts/lib/IOEither'
+import * as O from 'fp-ts/lib/Option'
+import * as S from 'fp-ts/lib/State'
+import * as T from 'fp-ts/lib/Task'
+import * as TE from 'fp-ts/lib/TaskEither'
+import { pipe } from 'fp-ts/lib/pipeable'
+
+import * as _ from '../src/StateTaskEither'
+
+describe('StateTaskEither', () => {
+  describe('pipeables', () => {
+    it('map', async () => {
+      const len = (s: string): number => s.length
+      assert.deepStrictEqual(await _.evalState(pipe(_.right('aaa'), _.map(len)), {})(), E.right(3))
+    })
+
+    it('ap', async () => {
+      const len = (s: string): number => s.length
+      assert.deepStrictEqual(await _.evalState(pipe(_.right(len), _.ap(_.right('aaa'))), {})(), E.right(3))
+    })
+
+    it('ap sequential', async () => {
+      const len = (s: string): number => s.length
+      assert.deepStrictEqual(await _.evalState(_.stateTaskEitherSeq.ap(_.right(len), _.right('aaa')), {})(), E.right(3))
+    })
+
+    it('apFirst', async () => {
+      assert.deepStrictEqual(await _.evalState(pipe(_.right('aaa'), _.apFirst(_.right('bbb'))), {})(), E.right('aaa'))
+    })
+
+    it('apSecond', async () => {
+      assert.deepStrictEqual(await _.evalState(pipe(_.right('aaa'), _.apSecond(_.right('bbb'))), {})(), E.right('bbb'))
+    })
+
+    it('chain', async () => {
+      const f = (s: string) => (s.length > 2 ? _.right(s.length) : _.right(0))
+      assert.deepStrictEqual(await _.evalState(pipe(_.right('aaa'), _.chain(f)), {})(), E.right(3))
+    })
+
+    it('chainFirst', async () => {
+      const f = (s: string) => (s.length > 2 ? _.right(s.length) : _.right(0))
+      assert.deepStrictEqual(await _.evalState(pipe(_.right('aaa'), _.chainFirst(f)), {})(), E.right('aaa'))
+    })
+
+    it('chainEitherK', async () => {
+      const f = (s: string) => E.right(s.length)
+      assert.deepStrictEqual(await _.evalState(pipe(_.right('aa'), _.chainEitherK(f)), {})(), E.right(2))
+    })
+
+    it('chainIOEitherK', async () => {
+      const f = (s: string) => IOE.right(s.length)
+      assert.deepStrictEqual(await _.evalState(pipe(_.right('aa'), _.chainIOEitherK(f)), {})(), E.right(2))
+    })
+
+    it('chainTaskEitherK', async () => {
+      const f = (s: string) => TE.right(s.length)
+      assert.deepStrictEqual(await _.evalState(pipe(_.right('aa'), _.chainTaskEitherK(f)), {})(), E.right(2))
+    })
+
+    it('flatten', async () => {
+      assert.deepStrictEqual(await _.evalState(pipe(_.right(_.right('aaa')), _.flatten), {})(), E.right('aaa'))
+      assert.deepStrictEqual(await _.evalState(pipe(_.right(_.left('aaa')), _.flatten), {})(), E.left('aaa'))
+    })
+
+    it('filterOrElse', async () => {
+      const p = (s: string) => s.length > 2
+      assert.deepStrictEqual(
+        await _.evalState(
+          pipe(
+            _.right('aaa'),
+            _.filterOrElse(p, (s) => s.length)
+          ),
+          {}
+        )(),
+        E.right('aaa')
+      )
+      assert.deepStrictEqual(
+        await _.evalState(
+          pipe(
+            _.right('aa'),
+            _.filterOrElse(p, (s) => s.length)
+          ),
+          {}
+        )(),
+        E.left(2)
+      )
+    })
+  })
+
+  describe('constructors', () => {
+    it('leftIO', async () => {
+      const io: IO.IO<number> = IO.of(1)
+      assert.deepStrictEqual(await _.evalState(_.leftIO(io), {})(), E.left(1))
+    })
+
+    it('rightIO', async () => {
+      const io: IO.IO<number> = IO.of(1)
+      assert.deepStrictEqual(await _.evalState(_.rightIO(io), {})(), E.right(1))
+    })
+
+    it('leftTask', async () => {
+      const ta: T.Task<number> = T.of(1)
+      assert.deepStrictEqual(await _.evalState(_.leftTask(ta), {})(), E.left(1))
+    })
+
+    it('rightTask', async () => {
+      const ta: T.Task<number> = T.of(1)
+      assert.deepStrictEqual(await _.evalState(_.rightTask(ta), {})(), E.right(1))
+    })
+
+    it('rightState', async () => {
+      const state: S.State<{}, number> = (s) => [1, s]
+      assert.deepStrictEqual(await _.evalState(_.rightState(state), {})(), E.right(1))
+    })
+
+    it('leftState', async () => {
+      const state: S.State<{}, number> = (s) => [1, s]
+      assert.deepStrictEqual(await _.evalState(_.leftState(state), {})(), E.left(1))
+    })
+
+    it('fromOption', async () => {
+      assert.deepStrictEqual(
+        await _.evalState(
+          pipe(
+            O.some(1),
+            _.fromOption(() => 'none')
+          ),
+          {}
+        )(),
+        E.right(1)
+      )
+      assert.deepStrictEqual(
+        await _.evalState(
+          pipe(
+            O.none,
+            _.fromOption(() => 'none')
+          ),
+          {}
+        )(),
+        E.left('none')
+      )
+    })
+
+    it('fromEither', async () => {
+      assert.deepStrictEqual(await _.evalState(_.fromEither(E.right(1)), {})(), E.right(1))
+      assert.deepStrictEqual(await _.evalState(_.fromEither(E.left(1)), {})(), E.left(1))
+    })
+
+    it('fromEitherK', async () => {
+      const f = (s: Array<string>) => E.right(s.length)
+      assert.deepStrictEqual(await _.evalState(_.fromEitherK(f)(['a', 'b']), {})(), E.right(2))
+    })
+
+    it('fromPredicate', async () => {
+      const p = (n: number): boolean => n > 2
+      assert.deepStrictEqual(
+        await _.evalState(
+          pipe(
+            3,
+            _.fromPredicate(p, () => 'false')
+          ),
+          {}
+        )(),
+        E.right(3)
+      )
+      assert.deepStrictEqual(
+        await _.evalState(
+          pipe(
+            2,
+            _.fromPredicate(p, () => 'false')
+          ),
+          {}
+        )(),
+        E.left('false')
+      )
+    })
+  })
+
+  it('evalState', async () => {
+    const ma = _.right('aaa')
+    const s = {}
+    assert.deepStrictEqual(await _.evalState(ma, s)(), E.right('aaa'))
+  })
+
+  it('execState Right', async () => {
+    const ma = _.right('aaa')
+    const s = {}
+    assert.deepStrictEqual(await _.execState(ma, s)(), E.right(s))
+  })
+
+  it('execState Left', async () => {
+    assert.deepStrictEqual(await _.execState(_.left('aaa'), { a: 0 })(), E.left('aaa'))
+  })
+
+  it('run', async () => {
+    const ma: _.StateTaskEither<{}, never, number> = _.of(1)
+    const s = {}
+    assert.deepStrictEqual(await _.run(ma, s), E.right([1, {}]))
+  })
+})

--- a/test/TaskOption.ts
+++ b/test/TaskOption.ts
@@ -1,100 +1,240 @@
 import * as assert from 'assert'
+import * as E from 'fp-ts/lib/Either'
 import * as O from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'
-import { task } from 'fp-ts/lib/Task'
+import * as T from 'fp-ts/lib/Task'
 import * as TE from 'fp-ts/lib/TaskEither'
+
 import * as _ from '../src/TaskOption'
 
 describe('TaskOption', () => {
-  it('fold', async () => {
-    const g = (n: number) => task.of(n > 2)
-    const te1 = pipe(
-      _.some(1),
-      _.fold(() => task.of(false), g)
-    )
-    const te2 = pipe(
-      _.none,
-      _.fold(() => task.of(true), g)
-    )
-    const b1 = await te1()
-    const b2 = await te2()
-    assert.deepStrictEqual(b1, false)
-    assert.deepStrictEqual(b2, true)
+  describe('pipeables', () => {
+    it('map', async () => {
+      const double = (n: number) => n * 2
+      assert.deepStrictEqual(await pipe(_.some(2), _.map(double))(), O.some(4))
+      assert.deepStrictEqual(await pipe(_.none, _.map(double))(), O.none)
+    })
+
+    it('ap', async () => {
+      const double = (n: number) => n * 2
+      assert.deepStrictEqual(await pipe(_.some(double), _.ap(_.some(2)))(), O.some(4))
+      assert.deepStrictEqual(await pipe(_.some(double), _.ap(_.none))(), O.none)
+      assert.deepStrictEqual(await pipe(_.none, _.ap(_.some(2)))(), O.none)
+      assert.deepStrictEqual(await pipe(_.none, _.ap(_.none))(), O.none)
+    })
+
+    it('apFirst', async () => {
+      assert.deepStrictEqual(await pipe(_.some('a'), _.apFirst(_.some('b')))(), O.some('a'))
+    })
+
+    it('apSecond', async () => {
+      assert.deepStrictEqual(await pipe(_.some('a'), _.apSecond(_.some('b')))(), O.some('b'))
+    })
+
+    it('chain', async () => {
+      const f = (n: number) => _.some(n * 2)
+      const g = () => _.none
+      assert.deepStrictEqual(await pipe(_.some(1), _.chain(f))(), O.some(2))
+      assert.deepStrictEqual(await pipe(_.none, _.chain(f))(), O.none)
+      assert.deepStrictEqual(await pipe(_.some(1), _.chain(g))(), O.none)
+      assert.deepStrictEqual(await pipe(_.none, _.chain(g))(), O.none)
+    })
+
+    it('chainFirst', async () => {
+      const f = (n: number) => _.some(n * 2)
+      assert.deepStrictEqual(await pipe(_.some(1), _.chainFirst(f))(), O.some(1))
+    })
+
+    it('chainTask', async () => {
+      const f = (n: number) => T.of(n * 2)
+      const ma = pipe(_.some(42), _.chainTask(f))
+      assert.deepStrictEqual(await ma(), O.some(84))
+    })
+
+    it('chainOption', async () => {
+      const f = (n: number) => O.some(n - 10)
+      const ma = pipe(_.some(42), _.chainOption(f))
+      assert.deepStrictEqual(await ma(), O.some(32))
+    })
+
+    it('chainOptionK', async () => {
+      const f = (s: string) => O.some(s.length)
+      assert.deepStrictEqual(await pipe(_.some('a'), _.chainOptionK(f))(), O.some(1))
+    })
+
+    it('flatten', async () => {
+      assert.deepStrictEqual(await pipe(_.some(_.some(1)), _.flatten)(), O.some(1))
+    })
+
+    it('alt', async () => {
+      assert.deepStrictEqual(
+        await pipe(
+          _.some(1),
+          _.alt(() => _.some(2))
+        )(),
+        O.some(1)
+      )
+      assert.deepStrictEqual(
+        await pipe(
+          _.some(2),
+          _.alt(() => _.none as _.TaskOption<number>)
+        )(),
+        O.some(2)
+      )
+      assert.deepStrictEqual(
+        await pipe(
+          _.none,
+          _.alt(() => _.some(1))
+        )(),
+        O.some(1)
+      )
+      assert.deepStrictEqual(
+        await pipe(
+          _.none,
+          _.alt(() => _.none)
+        )(),
+        O.none
+      )
+    })
+
+    it('compact', async () => {
+      assert.deepStrictEqual(await _.compact(_.none)(), O.none)
+      assert.deepStrictEqual(await _.compact(_.some(O.none))(), O.none)
+      assert.deepStrictEqual(await _.compact(_.some(O.some('123')))(), O.some('123'))
+    })
+
+    it('separate', async () => {
+      const a = _.separate(_.none)
+      assert.deepStrictEqual(await a.left(), O.none)
+      assert.deepStrictEqual(await a.right(), O.none)
+
+      const b = _.separate(_.some(E.left('123')))
+      assert.deepStrictEqual(await b.left(), O.some('123'))
+      assert.deepStrictEqual(await b.right(), O.none)
+
+      const c = _.separate(_.some(E.right('123')))
+      assert.deepStrictEqual(await c.left(), O.none)
+      assert.deepStrictEqual(await c.right(), O.some('123'))
+    })
+
+    it('filter', async () => {
+      const predicate = (a: number) => a === 2
+      assert.deepStrictEqual(await pipe(_.none, _.filter(predicate))(), O.none)
+      assert.deepStrictEqual(await pipe(_.some(1), _.filter(predicate))(), O.none)
+      assert.deepStrictEqual(await pipe(_.some(2), _.filter(predicate))(), O.some(2))
+    })
+
+    it('filterMap', async () => {
+      const p = (n: number): boolean => n > 2
+      const f = (n: number) => (p(n) ? O.some(n + 1) : O.none)
+      assert.deepStrictEqual(await pipe(_.none, _.filterMap(f))(), O.none)
+      assert.deepStrictEqual(await pipe(_.some(1), _.filterMap(f))(), O.none)
+      assert.deepStrictEqual(await pipe(_.some(3), _.filterMap(f))(), O.some(4))
+    })
+
+    it('partition', async () => {
+      const p = (n: number): boolean => n > 2
+
+      const a = pipe(_.none, _.partition(p))
+      assert.deepStrictEqual(await a.left(), O.none)
+      assert.deepStrictEqual(await a.right(), O.none)
+
+      const b = pipe(_.some(1), _.partition(p))
+      assert.deepStrictEqual(await b.left(), O.some(1))
+      assert.deepStrictEqual(await b.right(), O.none)
+
+      const c = pipe(_.some(3), _.partition(p))
+      assert.deepStrictEqual(await c.left(), O.none)
+      assert.deepStrictEqual(await c.right(), O.some(3))
+    })
+
+    it('partitionMap', async () => {
+      const p = (n: number): boolean => n > 2
+      const f = (n: number) => (p(n) ? E.right(n + 1) : E.left(n - 1))
+
+      const a = pipe(_.none, _.partitionMap(f))
+      assert.deepStrictEqual(await a.left(), O.none)
+      assert.deepStrictEqual(await a.right(), O.none)
+
+      const b = pipe(_.some(1), _.partitionMap(f))
+      assert.deepStrictEqual(await b.left(), O.some(0))
+      assert.deepStrictEqual(await b.right(), O.none)
+
+      const c = pipe(_.some(3), _.partitionMap(f))
+      assert.deepStrictEqual(await c.left(), O.none)
+      assert.deepStrictEqual(await c.right(), O.some(4))
+    })
   })
 
-  it('getOrElse', async () => {
-    const v = task.of(42)
-    const te1 = pipe(
-      _.some(1),
-      _.getOrElse(() => v)
-    )
-    const te2 = pipe(
-      _.fromOption<number>(O.none),
-      _.getOrElse(() => v)
-    )
-    const n1 = await te1()
-    const n2 = await te2()
-    assert.deepStrictEqual(n1, 1)
-    assert.deepStrictEqual(n2, 42)
+  describe('constructors', () => {
+    it('fromTask', async () => {
+      assert.deepStrictEqual(await _.fromTask(T.of(1))(), O.some(1))
+    })
+
+    it('fromTaskEither', async () => {
+      assert.deepStrictEqual(await _.fromTaskEither(TE.taskEither.of(42))(), O.some(42))
+      assert.deepStrictEqual(await _.fromTaskEither(TE.left('ouch!'))(), O.none)
+    })
+
+    it('fromNullable', async () => {
+      assert.deepStrictEqual(await _.fromNullable(null)(), O.none)
+      assert.deepStrictEqual(await _.fromNullable(undefined)(), O.none)
+      assert.deepStrictEqual(await _.fromNullable(42)(), O.some(42))
+    })
+
+    it('tryCatch', async () => {
+      const e1 = await _.tryCatch(() => Promise.resolve(1))()
+      assert.deepStrictEqual(e1, O.some(1))
+
+      const e2 = await _.tryCatch(() => Promise.reject(undefined))()
+      assert.deepStrictEqual(e2, O.none)
+    })
   })
 
-  it('fromTask', async () => {
-    const ma = _.fromTask(task.of(1))
-    const n = await ma()
-    assert.deepStrictEqual(n, O.some(1))
-  })
+  describe('destructors', () => {
+    it('fold', async () => {
+      const g = (n: number) => T.of(n > 2)
+      const te1 = pipe(
+        _.some(1),
+        _.fold(() => T.of(false), g)
+      )
+      const te2 = pipe(
+        _.none,
+        _.fold(() => T.of(true), g)
+      )
+      const b1 = await te1()
+      const b2 = await te2()
+      assert.deepStrictEqual(b1, false)
+      assert.deepStrictEqual(b2, true)
+    })
 
-  it('fromNullable', async () => {
-    const ma1 = _.fromNullable(null)
-    const ma2 = _.fromNullable(undefined)
-    const ma3 = _.fromNullable(42)
-    const n1 = await ma1()
-    const n2 = await ma2()
-    const n3 = await ma3()
-    assert.deepStrictEqual(n1, O.none)
-    assert.deepStrictEqual(n2, O.none)
-    assert.deepStrictEqual(n3, O.some(42))
-  })
+    it('getOrElse', async () => {
+      const v = T.of(42)
+      assert.deepStrictEqual(
+        await pipe(
+          _.some(1),
+          _.getOrElse(() => v)
+        )(),
+        1
+      )
+      assert.deepStrictEqual(
+        await pipe(
+          _.fromOption<number>(O.none),
+          _.getOrElse(() => v)
+        )(),
+        42
+      )
+    })
 
-  it('fromTaskEither', async () => {
-    const ma1 = _.fromTaskEither(TE.taskEither.of(42))
-    const ma2 = _.fromTaskEither(TE.left('ouch!'))
-    const n1 = await ma1()
-    const n2 = await ma2()
-    assert.deepStrictEqual(n1, O.some(42))
-    assert.deepStrictEqual(n2, O.none)
-  })
+    it('toUndefined', async () => {
+      assert.deepStrictEqual(await _.toUndefined(_.some(42))(), 42)
+      assert.deepStrictEqual(await _.toUndefined(_.none)(), undefined)
+    })
 
-  it('toUndefined', async () => {
-    const ma1 = _.toUndefined(_.some(42))
-    const ma2 = _.toUndefined(_.none)
-    const n1 = await ma1()
-    const n2 = await ma2()
-    assert.deepStrictEqual(n1, 42)
-    assert.deepStrictEqual(n2, undefined)
-  })
-
-  it('toNullable', async () => {
-    const ma1 = _.toNullable(_.some(42))
-    const ma2 = _.toNullable(_.none)
-    const n1 = await ma1()
-    const n2 = await ma2()
-    assert.deepStrictEqual(n1, 42)
-    assert.deepStrictEqual(n2, null)
-  })
-
-  it('chainTask', async () => {
-    const f = (n: number) => task.of(n * 2)
-    const ma = pipe(_.some(42), _.chainTask(f))
-    const n = await ma()
-    assert.deepStrictEqual(n, O.some(84))
-  })
-
-  it('chainOption', async () => {
-    const f = (n: number) => O.some(n - 10)
-    const ma = pipe(_.some(42), _.chainOption(f))
-    const n = await ma()
-    assert.deepStrictEqual(n, O.some(32))
+    it('toNullable', async () => {
+      assert.deepStrictEqual(await _.toNullable(_.some(42))(), 42)
+      assert.deepStrictEqual(await _.toNullable(_.none)(), null)
+    })
   })
 
   it('mapNullable', async () => {
@@ -113,49 +253,29 @@ describe('TaskOption', () => {
     assert.deepStrictEqual(
       await pipe(
         _.fromNullable(x1.a),
-        _.mapNullable(x => x.b),
-        _.mapNullable(x => x.c),
-        _.mapNullable(x => x.d)
+        _.mapNullable((x) => x.b),
+        _.mapNullable((x) => x.c),
+        _.mapNullable((x) => x.d)
       )(),
       O.none
     )
     assert.deepStrictEqual(
       await pipe(
         _.fromNullable(x2.a),
-        _.mapNullable(x => x.b),
-        _.mapNullable(x => x.c),
-        _.mapNullable(x => x.d)
+        _.mapNullable((x) => x.b),
+        _.mapNullable((x) => x.c),
+        _.mapNullable((x) => x.d)
       )(),
       O.none
     )
     assert.deepStrictEqual(
       await pipe(
         _.fromNullable(x3.a),
-        _.mapNullable(x => x.b),
-        _.mapNullable(x => x.c),
-        _.mapNullable(x => x.d)
+        _.mapNullable((x) => x.b),
+        _.mapNullable((x) => x.c),
+        _.mapNullable((x) => x.d)
       )(),
       O.some(1)
     )
-  })
-
-  it('tryCatch', async () => {
-    const e1 = await _.tryCatch(() => Promise.resolve(1))()
-    assert.deepStrictEqual(e1, O.some(1))
-    const e2 = await _.tryCatch(() => Promise.reject(undefined))()
-    assert.deepStrictEqual(e2, O.none)
-  })
-
-  it('filter', async () => {
-    const predicate = (a: number) => a === 2
-    assert.deepStrictEqual(await pipe(_.none, _.filter(predicate))(), O.none)
-    assert.deepStrictEqual(await pipe(_.some(1), _.filter(predicate))(), O.none)
-    assert.deepStrictEqual(await pipe(_.some(2), _.filter(predicate))(), O.some(2))
-  })
-
-  it('chainOptionK', async () => {
-    const f = (s: string) => O.some(s.length)
-    const x = await pipe(_.some('a'), _.chainOptionK(f))()
-    assert.deepStrictEqual(x, O.some(1))
   })
 })

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -1,4 +1,3 @@
-import * as Z from '../src/Zipper'
 import * as assert from 'assert'
 import { identity } from 'fp-ts/lib/function'
 import { monoidString, monoidSum } from 'fp-ts/lib/Monoid'
@@ -7,220 +6,240 @@ import { pipe } from 'fp-ts/lib/pipeable'
 import { semigroupSum } from 'fp-ts/lib/Semigroup'
 import { showString } from 'fp-ts/lib/Show'
 
+import * as _ from '../src/Zipper'
+
 const len = (s: string): number => s.length
 const prepend = (a: string) => (s: string): string => a + s
 const append = (a: string) => (s: string): string => s + a
 
 describe('Zipper', () => {
-  it('Zipper', () => {
-    const expected: Z.Zipper<string> = {
-      lefts: ['a', 'b'],
-      focus: 'c',
-      rights: ['d', 'e']
-    }
-    assert.deepStrictEqual(Z.make(['a', 'b'], 'c', ['d', 'e']), expected)
+  describe('pipeables', () => {
+    it('map', () => {
+      const fa = _.make(['a', 'bb'], 'ccc', ['dddd'])
+      assert.deepStrictEqual(pipe(fa, _.map(len)), _.make([1, 2], 3, [4]))
+    })
+
+    it('mapWithIndex', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d'])
+      assert.deepStrictEqual(
+        pipe(
+          fa,
+          _.mapWithIndex((i, a) => a + i)
+        ),
+        _.make(['a0', 'b1'], 'c2', ['d3'])
+      )
+    })
+
+    it('ap', () => {
+      const fa = _.make(['a'], 'b', ['c'])
+      const fab = _.make([prepend('P1'), append('A1')], prepend('P2'), [append('A2')])
+      assert.deepStrictEqual(pipe(fab, _.ap(fa)), _.make(['P1a', 'aA1'], 'P2b', ['cA2']))
+    })
+
+    it('apFirst', () => {
+      const fa = _.make(['a'], 'b', ['c'])
+      const fb = _.make(['d'], 'e', ['f'])
+      assert.deepStrictEqual(pipe(fa, _.apFirst(fb)), _.make(['a'], 'b', ['c']))
+    })
+
+    it('apSecond', () => {
+      const fa = _.make(['a'], 'b', ['c'])
+      const fb = _.make(['d'], 'e', ['f'])
+      assert.deepStrictEqual(pipe(fa, _.apSecond(fb)), _.make(['d'], 'e', ['f']))
+    })
+
+    it('of', () => {
+      assert.deepStrictEqual(_.of(1), _.make([], 1, []))
+    })
+
+    it('extend', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d', 'e'])
+      const S = _.getShow(showString)
+      const f = (fa: _.Zipper<string>): string => S.show(fa)
+      assert.deepStrictEqual(
+        pipe(fa, _.extend(f)),
+        _.make(
+          ['Zipper([], "a", ["b", "c", "d", "e"])', 'Zipper(["a"], "b", ["c", "d", "e"])'],
+          'Zipper(["a", "b"], "c", ["d", "e"])',
+          ['Zipper(["a", "b", "c"], "d", ["e"])', 'Zipper(["a", "b", "c", "d"], "e", [])']
+        )
+      )
+    })
+
+    it('reduce', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d'])
+      assert.deepStrictEqual(
+        pipe(
+          fa,
+          _.reduce('', (b, a) => b + a)
+        ),
+        'abcd'
+      )
+    })
+
+    it('foldMap', () => {
+      const fa = _.make(['a'], 'b', ['c'])
+      assert.strictEqual(pipe(fa, _.foldMap(monoidString)(identity)), 'abc')
+    })
+
+    it('reduceRight', () => {
+      const fa = _.make(['a'], 'b', ['c'])
+      const f = (a: string, acc: string) => acc + a
+      assert.strictEqual(pipe(fa, _.reduceRight('', f)), 'cba')
+    })
+
+    it('traverse', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d'])
+      assert.deepStrictEqual(_.Traversable.traverse(O.option)(fa, O.some), O.some(fa))
+      assert.deepStrictEqual(
+        _.Traversable.traverse(O.option)(fa, (a) => (a === 'a' ? O.none : O.some(a))),
+        O.none
+      )
+    })
+
+    it('sequence', () => {
+      const sequence = _.Traversable.sequence(O.option)
+      const x1 = _.make([O.some('a'), O.some('b')], O.some('c'), [O.some('d')])
+      assert.deepStrictEqual(sequence(x1), O.some(_.make(['a', 'b'], 'c', ['d'])))
+      const x2 = _.make([O.some('a'), O.some('b')], O.none, [O.some('d')])
+      assert.deepStrictEqual(sequence(x2), O.none)
+    })
+
+    it('extract', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d'])
+      assert.strictEqual(_.extract(fa), 'c')
+    })
   })
 
-  it('length', () => {
-    const fa = Z.make(['a', 'b'], 'c', ['d', 'e'])
-    assert.deepStrictEqual(Z.length(fa), 5)
+  describe('constructors', () => {
+    it('make', () => {
+      const expected: _.Zipper<string> = {
+        lefts: ['a', 'b'],
+        focus: 'c',
+        rights: ['d', 'e'],
+      }
+      assert.deepStrictEqual(_.make(['a', 'b'], 'c', ['d', 'e']), expected)
+    })
+
+    it('fromArray', () => {
+      assert.deepStrictEqual(_.fromArray([]), O.none)
+      assert.deepStrictEqual(_.fromArray([1]), O.some(_.make([], 1, [])))
+      assert.deepStrictEqual(_.fromArray([1], 0), O.some(_.make([], 1, [])))
+      assert.deepStrictEqual(_.fromArray([1], 1), O.none)
+      assert.deepStrictEqual(_.fromArray([1, 2, 3], 1), O.some(_.make([1], 2, [3])))
+    })
+
+    it('fromNonEmptyArray', () => {
+      assert.deepStrictEqual(_.fromNonEmptyArray([1]), _.make([], 1, []))
+      assert.deepStrictEqual(_.fromNonEmptyArray([1, 2, 3]), _.make([], 1, [2, 3]))
+    })
   })
 
-  it('update', () => {
-    const fa = Z.make(['a', 'b'], 'c', ['d'])
-    assert.deepStrictEqual(pipe(fa, Z.update('e')), Z.make(['a', 'b'], 'e', ['d']))
+  describe('destructors', () => {
+    it('isOutOfBound', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d'])
+      assert.deepStrictEqual(_.isOutOfBound(-1, fa), true)
+      assert.deepStrictEqual(_.isOutOfBound(4, fa), true)
+      assert.deepStrictEqual(_.isOutOfBound(2, fa), false)
+    })
+
+    it('length', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d', 'e'])
+      assert.deepStrictEqual(_.length(fa), 5)
+    })
+
+    it('toArray', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d'])
+      assert.deepStrictEqual(_.toArray(fa), ['a', 'b', 'c', 'd'])
+    })
   })
 
-  it('modify', () => {
-    const fa = Z.make(['a', 'b'], 'c', ['d'])
-    assert.deepStrictEqual(pipe(fa, Z.modify(append('!'))), Z.make(['a', 'b'], 'c!', ['d']))
-  })
+  describe('combinators', () => {
+    it('update', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d'])
+      assert.deepStrictEqual(pipe(fa, _.update('e')), _.make(['a', 'b'], 'e', ['d']))
+    })
 
-  it('toArray', () => {
-    const fa = Z.make(['a', 'b'], 'c', ['d'])
-    assert.deepStrictEqual(Z.toArray(fa), ['a', 'b', 'c', 'd'])
-  })
+    it('modify', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d'])
+      assert.deepStrictEqual(pipe(fa, _.modify(append('!'))), _.make(['a', 'b'], 'c!', ['d']))
+    })
 
-  it('isOutOfBound', () => {
-    const fa = Z.make(['a', 'b'], 'c', ['d'])
-    assert.deepStrictEqual(Z.isOutOfBound(-1, fa), true)
-    assert.deepStrictEqual(Z.isOutOfBound(4, fa), true)
-    assert.deepStrictEqual(Z.isOutOfBound(2, fa), false)
-  })
+    it('up', () => {
+      assert.deepStrictEqual(_.up(_.make(['a', 'b'], 'c', ['d'])), O.some(_.make(['a'], 'b', ['c', 'd'])))
+      assert.deepStrictEqual(_.up(_.make([], 'c', ['d'])), O.none)
+    })
 
-  it('up', () => {
-    assert.deepStrictEqual(Z.up(Z.make(['a', 'b'], 'c', ['d'])), O.some(Z.make(['a'], 'b', ['c', 'd'])))
-    assert.deepStrictEqual(Z.up(Z.make([], 'c', ['d'])), O.none)
-  })
+    it('down', () => {
+      assert.deepStrictEqual(_.down(_.make(['a', 'b'], 'c', ['d', 'e'])), O.some(_.make(['a', 'b', 'c'], 'd', ['e'])))
+      assert.deepStrictEqual(_.down(_.make(['a', 'b'], 'c', [])), O.none)
+    })
 
-  it('down', () => {
-    assert.deepStrictEqual(Z.down(Z.make(['a', 'b'], 'c', ['d', 'e'])), O.some(Z.make(['a', 'b', 'c'], 'd', ['e'])))
-    assert.deepStrictEqual(Z.down(Z.make(['a', 'b'], 'c', [])), O.none)
-  })
+    it('start', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d', 'e'])
+      assert.deepStrictEqual(_.start(fa), _.make([], 'a', ['b', 'c', 'd', 'e']))
+      const start = _.make([], 1, [2])
+      assert.deepStrictEqual(_.start(start), start)
+    })
 
-  it('start', () => {
-    const fa = Z.make(['a', 'b'], 'c', ['d', 'e'])
-    assert.deepStrictEqual(Z.start(fa), Z.make([], 'a', ['b', 'c', 'd', 'e']))
-    const start = Z.make([], 1, [2])
-    assert.deepStrictEqual(Z.start(start), start)
-  })
+    it('end', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d', 'e'])
+      assert.deepStrictEqual(_.end(fa), _.make(['a', 'b', 'c', 'd'], 'e', []))
+      const end = _.make([1], 2, [])
+      assert.deepStrictEqual(_.end(end), end)
+    })
 
-  it('end', () => {
-    const fa = Z.make(['a', 'b'], 'c', ['d', 'e'])
-    assert.deepStrictEqual(Z.end(fa), Z.make(['a', 'b', 'c', 'd'], 'e', []))
-    const end = Z.make([1], 2, [])
-    assert.deepStrictEqual(Z.end(end), end)
-  })
+    it('insertLeft', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d', 'e'])
+      assert.deepStrictEqual(pipe(fa, _.insertLeft('f')), _.make(['a', 'b'], 'f', ['c', 'd', 'e']))
+    })
 
-  it('insertLeft', () => {
-    assert.deepStrictEqual(
-      pipe(Z.make(['a', 'b'], 'c', ['d', 'e']), Z.insertLeft('f')),
-      Z.make(['a', 'b'], 'f', ['c', 'd', 'e'])
-    )
-  })
+    it('insertRight', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d', 'e'])
+      assert.deepStrictEqual(pipe(fa, _.insertRight('f')), _.make(['a', 'b', 'c'], 'f', ['d', 'e']))
+    })
 
-  it('insertRight', () => {
-    assert.deepStrictEqual(
-      pipe(Z.make(['a', 'b'], 'c', ['d', 'e']), Z.insertRight('f')),
-      Z.make(['a', 'b', 'c'], 'f', ['d', 'e'])
-    )
-  })
+    it('deleteLeft', () => {
+      assert.deepStrictEqual(_.deleteLeft(_.make(['a', 'b'], 'c', ['d', 'e'])), O.some(_.make(['a'], 'b', ['d', 'e'])))
+      assert.deepStrictEqual(
+        _.deleteLeft(_.make(['a', 'b', 'c'], 'd', ['e', 'f'])),
+        O.some(_.make(['a', 'b'], 'c', ['e', 'f']))
+      )
+      assert.deepStrictEqual(_.deleteLeft(_.make([], 'c', ['d', 'e'])), O.some(_.make([], 'd', ['e'])))
+      assert.deepStrictEqual(_.deleteLeft(_.make([], 1, [])), O.none)
+    })
 
-  it('deleteLeft', () => {
-    assert.deepStrictEqual(Z.deleteLeft(Z.make(['a', 'b'], 'c', ['d', 'e'])), O.some(Z.make(['a'], 'b', ['d', 'e'])))
-    assert.deepStrictEqual(
-      Z.deleteLeft(Z.make(['a', 'b', 'c'], 'd', ['e', 'f'])),
-      O.some(Z.make(['a', 'b'], 'c', ['e', 'f']))
-    )
-    assert.deepStrictEqual(Z.deleteLeft(Z.make([], 'c', ['d', 'e'])), O.some(Z.make([], 'd', ['e'])))
-    assert.deepStrictEqual(Z.deleteLeft(Z.make([], 1, [])), O.none)
-  })
-
-  it('deleteRight', () => {
-    assert.deepStrictEqual(Z.deleteRight(Z.make(['a', 'b'], 'c', ['d', 'e'])), O.some(Z.make(['a', 'b'], 'd', ['e'])))
-    assert.deepStrictEqual(
-      Z.deleteRight(Z.make(['a', 'b'], 'c', ['d', 'e', 'f'])),
-      O.some(Z.make(['a', 'b'], 'd', ['e', 'f']))
-    )
-    assert.deepStrictEqual(Z.deleteRight(Z.make(['a', 'b'], 'c', [])), O.some(Z.make(['a'], 'b', [])))
-    assert.deepStrictEqual(Z.deleteRight(Z.make([], 1, [])), O.none)
-  })
-
-  it('map', () => {
-    const fa = Z.make(['a', 'bb'], 'ccc', ['dddd'])
-    assert.deepStrictEqual(Z.zipper.map(fa, len), Z.make([1, 2], 3, [4]))
-  })
-
-  it('of', () => {
-    assert.deepStrictEqual(Z.zipper.of(1), Z.make([], 1, []))
-  })
-
-  it('ap', () => {
-    const fa = Z.make(['a'], 'b', ['c'])
-    const fab = Z.make([prepend('P1'), append('A1')], prepend('P2'), [append('A2')])
-    assert.deepStrictEqual(Z.zipper.ap(fab, fa), Z.make(['P1a', 'aA1'], 'P2b', ['cA2']))
-  })
-
-  it('fromArray', () => {
-    assert.deepStrictEqual(Z.fromArray([]), O.none)
-    assert.deepStrictEqual(Z.fromArray([1]), O.some(Z.make([], 1, [])))
-    assert.deepStrictEqual(Z.fromArray([1], 0), O.some(Z.make([], 1, [])))
-    assert.deepStrictEqual(Z.fromArray([1], 1), O.none)
-    assert.deepStrictEqual(Z.fromArray([1, 2, 3], 1), O.some(Z.make([1], 2, [3])))
-  })
-
-  it('fromNonEmptyArray', () => {
-    assert.deepStrictEqual(Z.fromNonEmptyArray([1]), Z.make([], 1, []))
-    assert.deepStrictEqual(Z.fromNonEmptyArray([1, 2, 3]), Z.make([], 1, [2, 3]))
+    it('deleteRight', () => {
+      assert.deepStrictEqual(_.deleteRight(_.make(['a', 'b'], 'c', ['d', 'e'])), O.some(_.make(['a', 'b'], 'd', ['e'])))
+      assert.deepStrictEqual(
+        _.deleteRight(_.make(['a', 'b'], 'c', ['d', 'e', 'f'])),
+        O.some(_.make(['a', 'b'], 'd', ['e', 'f']))
+      )
+      assert.deepStrictEqual(_.deleteRight(_.make(['a', 'b'], 'c', [])), O.some(_.make(['a'], 'b', [])))
+      assert.deepStrictEqual(_.deleteRight(_.make([], 1, [])), O.none)
+    })
   })
 
   it('getSemigroup', () => {
-    const S = Z.getSemigroup(semigroupSum)
-    const x = Z.make([1, 2], 3, [4])
-    const y = Z.make([5], 6, [7])
-    assert.deepStrictEqual(S.concat(x, y), Z.make([1, 2, 5], 9, [4, 7]))
+    const S = _.getSemigroup(semigroupSum)
+    const x = _.make([1, 2], 3, [4])
+    const y = _.make([5], 6, [7])
+    assert.deepStrictEqual(S.concat(x, y), _.make([1, 2, 5], 9, [4, 7]))
   })
 
   it('getMonoid', () => {
-    const M = Z.getMonoid(monoidSum)
-    const x = Z.make([1, 2], 3, [4])
+    const M = _.getMonoid(monoidSum)
+    const x = _.make([1, 2], 3, [4])
     assert.deepStrictEqual(M.concat(x, M.empty), x)
     assert.deepStrictEqual(M.concat(M.empty, x), x)
   })
 
-  it('reduce', () => {
-    const fa = Z.make(['a', 'b'], 'c', ['d'])
-    assert.deepStrictEqual(
-      Z.zipper.reduce(fa, '', (b: string, a: string) => b + a),
-      'abcd'
-    )
-  })
-
-  it('foldMap', () => {
-    const foldMap = Z.zipper.foldMap(monoidString)
-    const x1 = Z.make(['a'], 'b', ['c'])
-    const f1 = identity
-    assert.strictEqual(foldMap(x1, f1), 'abc')
-  })
-
-  it('reduceRight', () => {
-    const foldr = Z.zipper.reduceRight
-    const x1 = Z.make(['a'], 'b', ['c'])
-    const init1 = ''
-    const f1 = (a: string, acc: string) => acc + a
-    assert.strictEqual(foldr(x1, init1, f1), 'cba')
-  })
-
-  it('traverse', () => {
-    const fa = Z.make(['a', 'b'], 'c', ['d'])
-    assert.deepStrictEqual(Z.zipper.traverse(O.option)(fa, O.some), O.some(fa))
-    assert.deepStrictEqual(
-      Z.zipper.traverse(O.option)(fa, a => (a === 'a' ? O.none : O.some(a))),
-      O.none
-    )
-  })
-
-  it('sequence', () => {
-    const sequence = Z.zipper.sequence(O.option)
-    const x1 = Z.make([O.some('a'), O.some('b')], O.some('c'), [O.some('d')])
-    assert.deepStrictEqual(sequence(x1), O.some(Z.make(['a', 'b'], 'c', ['d'])))
-    const x2 = Z.make([O.some('a'), O.some('b')], O.none, [O.some('d')])
-    assert.deepStrictEqual(sequence(x2), O.none)
-  })
-
-  it('extract', () => {
-    const fa = Z.make(['a', 'b'], 'c', ['d'])
-    assert.strictEqual(Z.zipper.extract(fa), 'c')
-  })
-
   it('getShow', () => {
-    const S = Z.getShow(showString)
-    assert.strictEqual(S.show(Z.make([], 'a', [])), 'Zipper([], "a", [])')
-    assert.strictEqual(S.show(Z.make(['b'], 'a', [])), 'Zipper(["b"], "a", [])')
-    assert.strictEqual(S.show(Z.make(['b', 'c'], 'a', [])), 'Zipper(["b", "c"], "a", [])')
-    assert.strictEqual(S.show(Z.make(['b', 'c'], 'a', ['d'])), 'Zipper(["b", "c"], "a", ["d"])')
-    assert.strictEqual(S.show(Z.make(['b', 'c'], 'a', ['d', 'e'])), 'Zipper(["b", "c"], "a", ["d", "e"])')
-  })
-
-  it('extend', () => {
-    const fa = Z.make(['a', 'b'], 'c', ['d', 'e'])
-    const S = Z.getShow(showString)
-    const f = (fa: Z.Zipper<string>): string => S.show(fa)
-    assert.deepStrictEqual(
-      Z.zipper.extend(fa, f),
-      Z.make(
-        ['Zipper([], "a", ["b", "c", "d", "e"])', 'Zipper(["a"], "b", ["c", "d", "e"])'],
-        'Zipper(["a", "b"], "c", ["d", "e"])',
-        ['Zipper(["a", "b", "c"], "d", ["e"])', 'Zipper(["a", "b", "c", "d"], "e", [])']
-      )
-    )
-  })
-
-  it('mapWithIndex', () => {
-    const fa = Z.make(['a', 'b'], 'c', ['d'])
-    assert.deepStrictEqual(
-      Z.zipper.mapWithIndex(fa, (i, a) => a + i),
-      Z.make(['a0', 'b1'], 'c2', ['d3'])
-    )
+    const S = _.getShow(showString)
+    assert.strictEqual(S.show(_.make([], 'a', [])), 'Zipper([], "a", [])')
+    assert.strictEqual(S.show(_.make(['b'], 'a', [])), 'Zipper(["b"], "a", [])')
+    assert.strictEqual(S.show(_.make(['b', 'c'], 'a', [])), 'Zipper(["b", "c"], "a", [])')
+    assert.strictEqual(S.show(_.make(['b', 'c'], 'a', ['d'])), 'Zipper(["b", "c"], "a", ["d"])')
+    assert.strictEqual(S.show(_.make(['b', 'c'], 'a', ['d', 'e'])), 'Zipper(["b", "c"], "a", ["d", "e"])')
   })
 })

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -98,7 +98,7 @@ describe('Zipper', () => {
     })
 
     it('sequence', () => {
-      const sequence = _.Traversable.sequence(O.option)
+      const sequence = _.sequence(O.option)
       const x1 = _.make([O.some('a'), O.some('b')], O.some('c'), [O.some('d')])
       assert.deepStrictEqual(sequence(x1), O.some(_.make(['a', 'b'], 'c', ['d'])))
       const x2 = _.make([O.some('a'), O.some('b')], O.none, [O.some('d')])


### PR DESCRIPTION
This PR attempts to improve the tree-shakability of `fp-ts-contrib` by removing `pipeable` from all modules. In addition, each  module had its "mega" typeclass instance broken into smaller instances. Tests were also added for some modules that were missing them. A summary of all changes can be found below.

**Note**: because the version of `fp-ts` currently used by `fp-ts-contrib` is < `v2.6.3`, I could not make use of `PipeableTraverse` to create pipeable versions of `traverse`. I marked modules where pipeable `traverse` can be added in the future with a `TODO`.

# 0.1.18

- **New Feature**

  - `ArrayOption`
    - add `zero` method (@IMax153)
    - split "mega" `arrayOption` instance into individual typeclass instances (@IMax153)
      - Add `Functor` instance (@IMax153)
      - Add `Applicative` instance (@IMax153)
      - Add `Apply` instance (@IMax153)
      - Add `Monad` instance (@IMax153)
      - Add `Alt` instance (@IMax153)
      - Add `Alternative` instance (@IMax153)
  - `Free`
    - split "mega" `free` instance into individual typeclass instances (@IMax153)
      - Add `Functor` instance (@IMax153)
      - Add `Applicative` instance (@IMax153)
      - Add `Apply` instance (@IMax153)
  - `IOOption`
    - add `zero` method (@IMax153)
    - split "mega" `ioOption` instance into individual typeclass instances (@IMax153)
      - Add `Functor` instance (@IMax153)
      - Add `Applicative` instance (@IMax153)
      - Add `Apply` instance (@IMax153)
      - Add `Monad` instance (@IMax153)
      - Add `Alt` instance (@IMax153)
      - Add `Alternative` instance (@IMax153)
      - Add `Compactable` instance (@IMax153)
      - Add `Filterable` instance (@IMax153)
  - `List`
    - split "mega" `list` instance into individual typeclass instances (@IMax153)
      - Add `Functor` instance (@IMax153)
      - Add `Foldable` instance (@IMax153)
      - Add `Traversable` instance (@IMax153)
  - `ReaderIO`
    - split "mega" `readerIO` instance into individual typeclass instances (@IMax153)
      - Add `Functor` instance (@IMax153)
      - Add `Applicative` instance (@IMax153)
      - Add `Apply` instance (@IMax153)
      - Add `Monad` instance (@IMax153)
  - `StateEither`
    - split "mega" `stateEither` instance into individual typeclass instances (@IMax153)
      - Add `Functor` instance (@IMax153)
      - Add `Applicative` instance (@IMax153)
      - Add `Apply` instance (@IMax153)
      - Add `Monad` instance (@IMax153)
      - Add `MonadThrow` instance (@IMax153)
  - `StateIO`
    - split "mega" `stateIO` instance into individual typeclass instances (@IMax153)
      - Add `Functor` instance (@IMax153)
      - Add `Applicative` instance (@IMax153)
      - Add `Apply` instance (@IMax153)
      - Add `Monad` instance (@IMax153)
  - `StateTaskEither`
    - split "mega" `stateTaskEither` instance into individual typeclass instances (@IMax153)
      - Add `Functor` instance (@IMax153)
      - Add `Applicative` instance (@IMax153)
      - Add `Apply` instance (@IMax153)
      - Add `Monad` instance (@IMax153)
  - `TaskOption`
    - split "mega" `taskOption` instance into individual typeclass instances (@IMax153)
      - Add `Functor` instance (@IMax153)
      - Add `Applicative` instance (@IMax153)
      - Add `Apply` instance (@IMax153)
      - Add `Monad` instance (@IMax153)
      - Add `Alternative` instance (@IMax153)
      - Add `Compactable` instance (@IMax153)
      - Add `Filterable` instance (@IMax153)
  - `Zipper`
    - split "mega" `zipper` instance into individual typeclass instances (@IMax153)
      - Add `Functor` instance (@IMax153)
      - Add `FunctorWithIndex` instance (@IMax153)
      - Add `Applicative` instance (@IMax153)
      - Add `Apply` instance (@IMax153)
      - Add `Foldable` instance (@IMax153)
      - Add `Traversable` instance (@IMax153)
      - Add `Comonad` instance (@IMax153)

- **Polish**

  - standardize export declarations in all modules (@IMax153)
  - add category tags to all module exports (@IMax153)

- **Internal**
  - remove pipeable from all modules (@IMax153)
  - add tests for `StateIO` (@IMax153)
  - add tests for `StateTaskEither` (@IMax153)
