### PR TITLE
Add batchTraverse usage example

### DIFF
--- a/docs/modules/batchTraverse.ts.md
+++ b/docs/modules/batchTraverse.ts.md
@@ -44,4 +44,23 @@ export declare function batchTraverse<M>(
 ): <A, B>(as: Array<Array<A>>, f: (a: A) => HKT<M, B>) => HKT<M, Array<B>>
 ```
 
+**Example**
+```ts
+async function processInStrictSequence() {
+  const numbers = [1,2,3,4];
+  const asyncTransform = (n: number): Task<number> => of(n + 1);
+
+  const result = await pipe(
+    numbers,
+    // process asyncTransform in strict sequence with chunkSize 1:
+    // next asyncTransform only starts after previous is finished
+    (x) =>  batchTraverse(T.task)(A.chunksOf(1)(x), asyncTransform),
+  )();
+
+  assert.deepStrictEqual(result, [2,3,4,5]);
+}
+
+processInStrictSequence();
+```
+
 Added in v0.1.0


### PR DESCRIPTION
I was very pleased to find this function to process Promises/Tasks in strict sequence (to avoid violating a rate limit on a API i am using), but i had difficulty to use it at first. Hopefully this example makes it easier for the next person that struggles with the same problem.
Example is tested.