### PR TITLE
Refactor `Zipper` to work with `readonly` and `NonEmpty*`

### DIFF
--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -65,6 +65,7 @@ Added in v0.1.6
   - [length](#length)
   - [toArray](#toarray)
   - [toNonEmptyArray](#tononemptyarray)
+  - [toReadonlyNonEmptyArray](#toreadonlynonemptyarray)
 - [instances](#instances)
   - [Applicative](#applicative-1)
   - [Apply](#apply-1)
@@ -438,6 +439,16 @@ Added in v0.1.6
 
 ```ts
 export declare const toNonEmptyArray: <A>(fa: Zipper<A>) => NEA.NonEmptyArray<A>
+```
+
+Added in v0.1.22
+
+## toReadonlyNonEmptyArray
+
+**Signature**
+
+```ts
+export declare const toReadonlyNonEmptyArray: <A>(fa: Zipper<A>) => ReadonlyNonEmptyArray<A>
 ```
 
 Added in v0.1.22

--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -418,7 +418,7 @@ Creates a new zipper.
 **Signature**
 
 ```ts
-export declare const make: <A>(lefts: A[], focus: A, rights: A[]) => Zipper<A>
+export declare const make: <A>(lefts: readonly A[], focus: A, rights: readonly A[]) => Zipper<A>
 ```
 
 Added in v0.1.6

--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -60,6 +60,7 @@ Added in v0.1.6
   - [fromArray](#fromarray)
   - [fromNonEmptyArray](#fromnonemptyarray)
   - [fromReadonlyArray](#fromreadonlyarray)
+  - [fromReadonlyNonEmptyArray](#fromreadonlynonemptyarray)
   - [make](#make)
 - [destructors](#destructors)
   - [isOutOfBound](#isoutofbound)
@@ -396,6 +397,16 @@ Added in v0.1.6
 
 ```ts
 export declare const fromReadonlyArray: <A>(as: readonly A[], focusIndex?: number | undefined) => Option<Zipper<A>>
+```
+
+Added in v0.1.22
+
+## fromReadonlyNonEmptyArray
+
+**Signature**
+
+```ts
+export declare const fromReadonlyNonEmptyArray: <A>(rnea: ReadonlyNonEmptyArray<A>) => Zipper<A>
 ```
 
 Added in v0.1.22

--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -63,9 +63,9 @@ Added in v0.1.6
 - [destructors](#destructors)
   - [isOutOfBound](#isoutofbound)
   - [length](#length)
-  - [toArray](#toarray)
   - [toNonEmptyArray](#tononemptyarray)
   - [toReadonlyNonEmptyArray](#toreadonlynonemptyarray)
+  - [~~toArray~~](#toarray)
 - [instances](#instances)
   - [Applicative](#applicative-1)
   - [Apply](#apply-1)
@@ -423,16 +423,6 @@ export declare const length: <A>(fa: Zipper<A>) => number
 
 Added in v0.1.6
 
-## toArray
-
-**Signature**
-
-```ts
-export declare const toArray: <A>(fa: Zipper<A>) => A[]
-```
-
-Added in v0.1.6
-
 ## toNonEmptyArray
 
 **Signature**
@@ -452,6 +442,16 @@ export declare const toReadonlyNonEmptyArray: <A>(fa: Zipper<A>) => ReadonlyNonE
 ```
 
 Added in v0.1.22
+
+## ~~toArray~~
+
+**Signature**
+
+```ts
+export declare const toArray: <A>(fa: Zipper<A>) => A[]
+```
+
+Added in v0.1.6
 
 # instances
 

--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -64,6 +64,7 @@ Added in v0.1.6
   - [isOutOfBound](#isoutofbound)
   - [length](#length)
   - [toArray](#toarray)
+  - [toNonEmptyArray](#tononemptyarray)
 - [instances](#instances)
   - [Applicative](#applicative-1)
   - [Apply](#apply-1)
@@ -382,7 +383,7 @@ Added in v0.1.6
 **Signature**
 
 ```ts
-export declare const fromNonEmptyArray: <A>(nea: NonEmptyArray<A>) => Zipper<A>
+export declare const fromNonEmptyArray: <A>(nea: NEA.NonEmptyArray<A>) => Zipper<A>
 ```
 
 Added in v0.1.6
@@ -430,6 +431,16 @@ export declare const toArray: <A>(fa: Zipper<A>) => A[]
 ```
 
 Added in v0.1.6
+
+## toNonEmptyArray
+
+**Signature**
+
+```ts
+export declare const toNonEmptyArray: <A>(fa: Zipper<A>) => NEA.NonEmptyArray<A>
+```
+
+Added in v0.1.22
 
 # instances
 

--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -59,6 +59,7 @@ Added in v0.1.6
 - [constructors](#constructors)
   - [fromArray](#fromarray)
   - [fromNonEmptyArray](#fromnonemptyarray)
+  - [fromReadonlyArray](#fromreadonlyarray)
   - [make](#make)
 - [destructors](#destructors)
   - [isOutOfBound](#isoutofbound)
@@ -388,6 +389,16 @@ export declare const fromNonEmptyArray: <A>(nea: NEA.NonEmptyArray<A>) => Zipper
 ```
 
 Added in v0.1.6
+
+## fromReadonlyArray
+
+**Signature**
+
+```ts
+export declare const fromReadonlyArray: <A>(as: readonly A[], focusIndex?: number | undefined) => Option<Zipper<A>>
+```
+
+Added in v0.1.22
 
 ## make
 

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -98,7 +98,7 @@ export const fromReadonlyNonEmptyArray: <A>(rnea: ReadonlyNonEmptyArray<A>) => Z
  * @category constructors
  * @since 0.1.6
  */
-export const fromNonEmptyArray: <A>(nea: NonEmptyArray<A>) => Zipper<A> = (nea) => make(A.empty, nea[0], nea.slice(1))
+export const fromNonEmptyArray: <A>(nea: NonEmptyArray<A>) => Zipper<A> = fromReadonlyNonEmptyArray
 
 // -------------------------------------------------------------------------------------
 // destructors

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -118,6 +118,7 @@ export const toReadonlyNonEmptyArray: <A>(fa: Zipper<A>) => ReadonlyNonEmptyArra
 /**
  * @category destructors
  * @since 0.1.6
+ * @deprecated Use the new {@link toNonEmptyArray} destructor instead.
  */
 export const toArray: <A>(fa: Zipper<A>) => Array<A> = toNonEmptyArray
 

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -29,6 +29,7 @@ import { pipe } from 'fp-ts/lib/pipeable'
 import { Semigroup } from 'fp-ts/lib/Semigroup'
 import { Show } from 'fp-ts/lib/Show'
 import { Traversable1 } from 'fp-ts/lib/Traversable'
+import { ReadonlyNonEmptyArray } from 'fp-ts/ReadonlyNonEmptyArray'
 
 import NonEmptyArray = NEA.NonEmptyArray
 
@@ -107,6 +108,12 @@ export const toNonEmptyArray: <A>(fa: Zipper<A>) => NonEmptyArray<A> = (fa) =>
     (as) => NEA.concat(fa.lefts, as),
     (as) => NEA.concat(as, fa.rights)
   )
+
+/**
+ * @category destructors
+ * @since 0.1.22
+ */
+export const toReadonlyNonEmptyArray: <A>(fa: Zipper<A>) => ReadonlyNonEmptyArray<A> = toNonEmptyArray
 
 /**
  * @category destructors

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -152,7 +152,7 @@ export const move: <A>(f: (currentIndex: number) => number, fa: Zipper<A>) => Op
   if (isOutOfBound(newIndex, fa)) {
     return none
   } else {
-    return fromArray(toArray(fa), newIndex)
+    return fromArray(toNonEmptyArray(fa), newIndex)
   }
 }
 

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -85,13 +85,7 @@ export const fromReadonlyArray: <A>(as: ReadonlyArray<A>, focusIndex?: number) =
  * @category constructors
  * @since 0.1.6
  */
-export const fromArray: <A>(as: Array<A>, focusIndex?: number) => Option<Zipper<A>> = (as, focusIndex = 0) => {
-  if (A.isEmpty(as) || A.isOutOfBound(focusIndex, as)) {
-    return none
-  } else {
-    return some(make(pipe(as, A.takeLeft(focusIndex)), as[focusIndex], pipe(as, A.dropLeft(focusIndex + 1))))
-  }
-}
+export const fromArray: <A>(as: Array<A>, focusIndex?: number) => Option<Zipper<A>> = fromReadonlyArray
 
 /**
  * @category constructors

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -23,12 +23,14 @@ import { Functor1 } from 'fp-ts/lib/Functor'
 import { FunctorWithIndex1 } from 'fp-ts/lib/FunctorWithIndex'
 import { HKT } from 'fp-ts/lib/HKT'
 import { Monoid } from 'fp-ts/lib/Monoid'
-import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
+import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import { none, Option, some } from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'
 import { Semigroup } from 'fp-ts/lib/Semigroup'
 import { Show } from 'fp-ts/lib/Show'
 import { Traversable1 } from 'fp-ts/lib/Traversable'
+
+import NonEmptyArray = NEA.NonEmptyArray
 
 // -------------------------------------------------------------------------------------
 // model
@@ -94,6 +96,17 @@ export const isOutOfBound: <A>(index: number, fa: Zipper<A>) => boolean = (index
  * @since 0.1.6
  */
 export const length: <A>(fa: Zipper<A>) => number = (fa) => fa.lefts.length + 1 + fa.rights.length
+
+/**
+ * @category destructors
+ * @since 0.1.22
+ */
+export const toNonEmptyArray: <A>(fa: Zipper<A>) => NonEmptyArray<A> = (fa) =>
+  pipe(
+    NEA.of(fa.focus),
+    (as) => NEA.concat(fa.lefts, as),
+    (as) => NEA.concat(as, fa.rights)
+  )
 
 /**
  * @category destructors

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -89,6 +89,13 @@ export const fromArray: <A>(as: Array<A>, focusIndex?: number) => Option<Zipper<
 
 /**
  * @category constructors
+ * @since 0.1.22
+ */
+export const fromReadonlyNonEmptyArray: <A>(rnea: ReadonlyNonEmptyArray<A>) => Zipper<A> = (nea) =>
+  make(A.empty, nea[0], nea.slice(1))
+
+/**
+ * @category constructors
  * @since 0.1.6
  */
 export const fromNonEmptyArray: <A>(nea: NonEmptyArray<A>) => Zipper<A> = (nea) => make(A.empty, nea[0], nea.slice(1))

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -26,6 +26,7 @@ import { Monoid } from 'fp-ts/lib/Monoid'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import { none, Option, some } from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'
+import * as RA from 'fp-ts/lib/ReadonlyArray'
 import { Semigroup } from 'fp-ts/lib/Semigroup'
 import { Show } from 'fp-ts/lib/Show'
 import { Traversable1 } from 'fp-ts/lib/Traversable'
@@ -62,6 +63,23 @@ export const make: <A>(lefts: Array<A>, focus: A, rights: Array<A>) => Zipper<A>
   focus,
   rights
 })
+
+/**
+ * @category constructors
+ * @since 0.1.22
+ */
+export const fromReadonlyArray: <A>(as: ReadonlyArray<A>, focusIndex?: number) => Option<Zipper<A>> = (
+  as,
+  focusIndex = 0
+) => {
+  if (RA.isEmpty(as) || RA.isOutOfBound(focusIndex, as)) {
+    return none
+  } else {
+    return some(
+      make(pipe(as.slice(), A.takeLeft(focusIndex)), as[focusIndex], pipe(as.slice(), A.dropLeft(focusIndex + 1)))
+    )
+  }
+}
 
 /**
  * @category constructors

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -119,7 +119,7 @@ export const toReadonlyNonEmptyArray: <A>(fa: Zipper<A>) => ReadonlyNonEmptyArra
  * @category destructors
  * @since 0.1.6
  */
-export const toArray: <A>(fa: Zipper<A>) => Array<A> = (fa) => A.snoc(fa.lefts, fa.focus).concat(fa.rights)
+export const toArray: <A>(fa: Zipper<A>) => Array<A> = toNonEmptyArray
 
 // -------------------------------------------------------------------------------------
 // combinators

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -58,10 +58,14 @@ export interface Zipper<A> {
  * @category constructors
  * @since 0.1.6
  */
-export const make: <A>(lefts: Array<A>, focus: A, rights: Array<A>) => Zipper<A> = (lefts, focus, rights) => ({
+export const make: <A>(lefts: ReadonlyArray<A>, focus: A, rights: ReadonlyArray<A>) => Zipper<A> = (
   lefts,
   focus,
   rights
+) => ({
+  lefts: lefts.slice(),
+  focus,
+  rights: rights.slice()
 })
 
 /**

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -148,6 +148,11 @@ describe('Zipper', () => {
       assert.deepStrictEqual(_.length(fa), 5)
     })
 
+    it('toNonEmptyArray', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d'])
+      assert.deepStrictEqual(_.toNonEmptyArray(fa), ['a', 'b', 'c', 'd'])
+    })
+
     it('toArray', () => {
       const fa = _.make(['a', 'b'], 'c', ['d'])
       assert.deepStrictEqual(_.toArray(fa), ['a', 'b', 'c', 'd'])

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -153,6 +153,11 @@ describe('Zipper', () => {
       assert.deepStrictEqual(_.toNonEmptyArray(fa), ['a', 'b', 'c', 'd'])
     })
 
+    it('toReadonlyNonEmptyArray', () => {
+      const fa = _.make(['a', 'b'], 'c', ['d'])
+      assert.deepStrictEqual(_.toReadonlyNonEmptyArray(fa), _.toNonEmptyArray(fa))
+    })
+
     it('toArray', () => {
       const fa = _.make(['a', 'b'], 'c', ['d'])
       assert.deepStrictEqual(_.toArray(fa), ['a', 'b', 'c', 'd'])

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -121,6 +121,14 @@ describe('Zipper', () => {
       assert.deepStrictEqual(_.make(['a', 'b'], 'c', ['d', 'e']), expected)
     })
 
+    it('fromReadonlyArray', () => {
+      assert.deepStrictEqual(_.fromReadonlyArray([]), O.none)
+      assert.deepStrictEqual(_.fromReadonlyArray([1]), O.some(_.make([], 1, [])))
+      assert.deepStrictEqual(_.fromReadonlyArray([1], 0), O.some(_.make([], 1, [])))
+      assert.deepStrictEqual(_.fromReadonlyArray([1], 1), O.none)
+      assert.deepStrictEqual(_.fromReadonlyArray([1, 2, 3], 1), O.some(_.make([1], 2, [3])))
+    })
+
     it('fromArray', () => {
       assert.deepStrictEqual(_.fromArray([]), O.none)
       assert.deepStrictEqual(_.fromArray([1]), O.some(_.make([], 1, [])))

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -130,11 +130,11 @@ describe('Zipper', () => {
     })
 
     it('fromArray', () => {
-      assert.deepStrictEqual(_.fromArray([]), O.none)
-      assert.deepStrictEqual(_.fromArray([1]), O.some(_.make([], 1, [])))
-      assert.deepStrictEqual(_.fromArray([1], 0), O.some(_.make([], 1, [])))
-      assert.deepStrictEqual(_.fromArray([1], 1), O.none)
-      assert.deepStrictEqual(_.fromArray([1, 2, 3], 1), O.some(_.make([1], 2, [3])))
+      assert.deepStrictEqual(_.fromArray([]), _.fromReadonlyArray([]))
+      assert.deepStrictEqual(_.fromArray([1]), _.fromReadonlyArray([1]))
+      assert.deepStrictEqual(_.fromArray([1], 0), _.fromReadonlyArray([1], 0))
+      assert.deepStrictEqual(_.fromArray([1], 1), _.fromReadonlyArray([1], 1))
+      assert.deepStrictEqual(_.fromArray([1, 2, 3], 1), _.fromReadonlyArray([1, 2, 3], 1))
     })
 
     it('fromNonEmptyArray', () => {

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -143,8 +143,8 @@ describe('Zipper', () => {
     })
 
     it('fromNonEmptyArray', () => {
-      assert.deepStrictEqual(_.fromNonEmptyArray([1]), _.make([], 1, []))
-      assert.deepStrictEqual(_.fromNonEmptyArray([1, 2, 3]), _.make([], 1, [2, 3]))
+      assert.deepStrictEqual(_.fromNonEmptyArray([1]), _.fromReadonlyNonEmptyArray([1]))
+      assert.deepStrictEqual(_.fromNonEmptyArray([1, 2, 3]), _.fromReadonlyNonEmptyArray([1, 2, 3]))
     })
   })
 

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -137,6 +137,11 @@ describe('Zipper', () => {
       assert.deepStrictEqual(_.fromArray([1, 2, 3], 1), _.fromReadonlyArray([1, 2, 3], 1))
     })
 
+    it('fromReadonlyNonEmptyArray', () => {
+      assert.deepStrictEqual(_.fromReadonlyNonEmptyArray([1]), _.make([], 1, []))
+      assert.deepStrictEqual(_.fromReadonlyNonEmptyArray([1, 2, 3]), _.make([], 1, [2, 3]))
+    })
+
     it('fromNonEmptyArray', () => {
       assert.deepStrictEqual(_.fromNonEmptyArray([1]), _.make([], 1, []))
       assert.deepStrictEqual(_.fromNonEmptyArray([1, 2, 3]), _.make([], 1, [2, 3]))

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -160,7 +160,7 @@ describe('Zipper', () => {
 
     it('toArray', () => {
       const fa = _.make(['a', 'b'], 'c', ['d'])
-      assert.deepStrictEqual(_.toArray(fa), ['a', 'b', 'c', 'd'])
+      assert.deepStrictEqual(_.toArray(fa), _.toNonEmptyArray(fa))
     })
   })
 

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -160,6 +160,7 @@ describe('Zipper', () => {
 
     it('toArray', () => {
       const fa = _.make(['a', 'b'], 'c', ['d'])
+      // tslint:disable-next-line deprecation
       assert.deepStrictEqual(_.toArray(fa), _.toNonEmptyArray(fa))
     })
   })


### PR DESCRIPTION
Every other data-structure in the `fp-ts` ecosystem support both `Array`
and `ReadonlyArray`. This is because most people what use the ecosystem
care for immutability.

This new `toReadonlyArray` has the same runtime implementation as
`toArray`, hence it's just an alias. Also the test makes it clear that
running both with the same input should yield the same output.
