### PR TITLE
Add findZ combinator to Zipper

### DIFF
--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -84,6 +84,8 @@ Added in v0.1.6
   - [zipper](#zipper)
 - [model](#model)
   - [Zipper (interface)](#zipper-interface)
+- [utils](#utils)
+  - [findIndex](#findindex)
 
 ---
 
@@ -626,3 +628,17 @@ export interface Zipper<A> {
 ```
 
 Added in v0.1.6
+
+# utils
+
+## findIndex
+
+Find the first index for which a predicate holds.
+
+**Signature**
+
+```ts
+export declare const findIndex: <A>(predicate: Predicate<A>) => (fa: Zipper<A>) => Option<number>
+```
+
+Added in v0.1.24

--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -49,6 +49,7 @@ Added in v0.1.6
   - [deleteRight](#deleteright)
   - [down](#down)
   - [end](#end)
+  - [findZ](#findz)
   - [insertLeft](#insertleft)
   - [insertRight](#insertright)
   - [modify](#modify)
@@ -286,6 +287,19 @@ export declare const end: <A>(fa: Zipper<A>) => Zipper<A>
 ```
 
 Added in v0.1.6
+
+## findZ
+
+Moves focus to the nearest element matching the given predicate, preferring
+the left, or `None` if no element matches.
+
+**Signature**
+
+```ts
+export declare const findZ: <A>(p: Predicate<A>) => (fa: Zipper<A>) => O.Option<Zipper<A>>
+```
+
+Added in v0.1.24
 
 ## insertLeft
 

--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -243,7 +243,7 @@ the focus is moved to the right.
 **Signature**
 
 ```ts
-export declare const deleteLeft: <A>(fa: Zipper<A>) => Option<Zipper<A>>
+export declare const deleteLeft: <A>(fa: Zipper<A>) => O.Option<Zipper<A>>
 ```
 
 Added in v0.1.6
@@ -256,7 +256,7 @@ the focus is moved to the left.
 **Signature**
 
 ```ts
-export declare const deleteRight: <A>(fa: Zipper<A>) => Option<Zipper<A>>
+export declare const deleteRight: <A>(fa: Zipper<A>) => O.Option<Zipper<A>>
 ```
 
 Added in v0.1.6
@@ -268,7 +268,7 @@ Moves focus of the zipper down.
 **Signature**
 
 ```ts
-export declare const down: <A>(fa: Zipper<A>) => Option<Zipper<A>>
+export declare const down: <A>(fa: Zipper<A>) => O.Option<Zipper<A>>
 ```
 
 Added in v0.1.6
@@ -328,7 +328,7 @@ Moves focus in the zipper, or `None` if there is no such element.
 **Signature**
 
 ```ts
-export declare const move: <A>(f: (currentIndex: number) => number, fa: Zipper<A>) => Option<Zipper<A>>
+export declare const move: <A>(f: (currentIndex: number) => number, fa: Zipper<A>) => O.Option<Zipper<A>>
 ```
 
 Added in v0.1.6
@@ -352,7 +352,7 @@ Moves focus of the zipper up.
 **Signature**
 
 ```ts
-export declare const up: <A>(fa: Zipper<A>) => Option<Zipper<A>>
+export declare const up: <A>(fa: Zipper<A>) => O.Option<Zipper<A>>
 ```
 
 Added in v0.1.6
@@ -376,7 +376,7 @@ Added in v0.1.6
 **Signature**
 
 ```ts
-export declare const fromArray: <A>(as: A[], focusIndex?: number | undefined) => Option<Zipper<A>>
+export declare const fromArray: <A>(as: A[], focusIndex?: number | undefined) => O.Option<Zipper<A>>
 ```
 
 Added in v0.1.6
@@ -396,7 +396,7 @@ Added in v0.1.6
 **Signature**
 
 ```ts
-export declare const fromReadonlyArray: <A>(as: readonly A[], focusIndex?: number | undefined) => Option<Zipper<A>>
+export declare const fromReadonlyArray: <A>(as: readonly A[], focusIndex?: number | undefined) => O.Option<Zipper<A>>
 ```
 
 Added in v0.1.23

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -204,6 +204,20 @@ export const findIndex = <A>(predicate: Predicate<A>) => (fa: Zipper<A>): Option
   )
 
 /**
+ * Moves focus to the nearest element matching the given predicate, preferring
+ * the left, or `None` if no element matches.
+ *
+ * @category combinators
+ * @since 0.1.24
+ */
+export const findZ = <A>(p: Predicate<A>) => (fa: Zipper<A>): Option<Zipper<A>> =>
+  pipe(
+    fa,
+    findIndex(p),
+    O.chain((i) => (i === fa.lefts.length ? some(fa) : move(() => i, fa)))
+  )
+
+/**
  * Moves focus of the zipper up.
  *
  * @category combinators

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -24,7 +24,7 @@ import { FunctorWithIndex1 } from 'fp-ts/lib/FunctorWithIndex'
 import { HKT } from 'fp-ts/lib/HKT'
 import { Monoid } from 'fp-ts/lib/Monoid'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
-import { none, Option, some } from 'fp-ts/lib/Option'
+import * as O from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'
 import * as RA from 'fp-ts/lib/ReadonlyArray'
 import { Semigroup } from 'fp-ts/lib/Semigroup'
@@ -33,6 +33,9 @@ import { Traversable1 } from 'fp-ts/lib/Traversable'
 import { ReadonlyNonEmptyArray } from 'fp-ts/ReadonlyNonEmptyArray'
 
 import NonEmptyArray = NEA.NonEmptyArray
+import Option = O.Option
+
+const { none, some } = O
 
 // -------------------------------------------------------------------------------------
 // model

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -18,7 +18,7 @@ import * as A from 'fp-ts/lib/Array'
 import { Comonad1 } from 'fp-ts/lib/Comonad'
 import { Extend1 } from 'fp-ts/lib/Extend'
 import { Foldable1 } from 'fp-ts/lib/Foldable'
-import { decrement, increment, identity } from 'fp-ts/lib/function'
+import { decrement, increment, identity, Predicate } from 'fp-ts/lib/function'
 import { Functor1 } from 'fp-ts/lib/Functor'
 import { FunctorWithIndex1 } from 'fp-ts/lib/FunctorWithIndex'
 import { HKT } from 'fp-ts/lib/HKT'
@@ -182,6 +182,26 @@ export const move: <A>(f: (currentIndex: number) => number, fa: Zipper<A>) => Op
     return fromArray(toNonEmptyArray(fa), newIndex)
   }
 }
+
+/**
+ * Find the first index for which a predicate holds.
+ *
+ * @category utils
+ * @since 0.1.24
+ */
+export const findIndex = <A>(predicate: Predicate<A>) => (fa: Zipper<A>): Option<number> =>
+  pipe(
+    fa.lefts,
+    RA.findIndex(predicate),
+    O.alt(() => (predicate(fa.focus) ? O.some(fa.lefts.length) : O.none)),
+    O.alt(() =>
+      pipe(
+        fa.rights,
+        RA.findIndex(predicate),
+        O.map((i) => fa.lefts.length + 1 + i)
+      )
+    )
+  )
 
 /**
  * Moves focus of the zipper up.

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -273,4 +273,11 @@ describe('Zipper', () => {
     assert.deepStrictEqual(_.findIndex((x) => x === 'b')(_.make([], 'a', ['b', 'c'])), O.some(1))
     assert.deepStrictEqual(_.findIndex((x) => x === 'b')(_.make([], 'a', [])), O.none)
   })
+
+  it('findZ', () => {
+    assert.deepStrictEqual(_.findZ((a) => a === 0)(_.make([], 0, [])), O.some(_.make([], 0, [])))
+    assert.deepStrictEqual(_.findZ((a) => a === 1)(_.make([], 0, [])), O.none)
+    assert.deepStrictEqual(_.findZ((a) => a === 0)(_.make([0], 1, [])), O.some(_.make([], 0, [1])))
+    assert.deepStrictEqual(_.findZ((a) => a === 1)(_.make([], 0, [1])), O.some(_.make([0], 1, [])))
+  })
 })

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -266,4 +266,11 @@ describe('Zipper', () => {
     assert.strictEqual(S.show(_.make(['b', 'c'], 'a', ['d'])), 'Zipper(["b", "c"], "a", ["d"])')
     assert.strictEqual(S.show(_.make(['b', 'c'], 'a', ['d', 'e'])), 'Zipper(["b", "c"], "a", ["d", "e"])')
   })
+
+  it('findIndex', () => {
+    assert.deepStrictEqual(_.findIndex((x) => x === 'b')(_.make(['a', 'b'], 'c', [])), O.some(1))
+    assert.deepStrictEqual(_.findIndex((x) => x === 'b')(_.make(['a'], 'b', ['c'])), O.some(1))
+    assert.deepStrictEqual(_.findIndex((x) => x === 'b')(_.make([], 'a', ['b', 'c'])), O.some(1))
+    assert.deepStrictEqual(_.findIndex((x) => x === 'b')(_.make([], 'a', [])), O.none)
+  })
 })


### PR DESCRIPTION
This combinator will allow the consumer to move the focus via a
predicate.

See https://github.com/scalaz/scalaz/blob/c70e5d8c77eb345cd8a92efbedeeaddf9916c726/core/src/main/scala/scalaz/Zipper.scala#L201