### PR TITLE
Add moveByFindFirst to Zipper

### DIFF
--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -53,6 +53,7 @@ Added in v0.1.6
   - [insertRight](#insertright)
   - [modify](#modify)
   - [move](#move)
+  - [moveByFindFirst](#movebyfindfirst)
   - [start](#start)
   - [up](#up)
   - [update](#update)
@@ -334,6 +335,20 @@ export declare const move: <A>(f: (currentIndex: number) => number, fa: Zipper<A
 ```
 
 Added in v0.1.6
+
+## moveByFindFirst
+
+Use a function to find and focus the first matching element in the array. If
+no element matches, `None` is returned. If an element matches,
+`Some<Zipper<A>>` is returned.
+
+**Signature**
+
+```ts
+export declare const moveByFindFirst: <A>(predicate: Predicate<A>) => (fa: Zipper<A>) => O.Option<Zipper<A>>
+```
+
+Added in v0.1.25
 
 ## start
 

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -202,6 +202,21 @@ export const findIndex = <A>(predicate: Predicate<A>) => (fa: Zipper<A>): Option
   )
 
 /**
+ * Use a function to find and focus the first matching element in the array. If
+ * no element matches, `None` is returned. If an element matches,
+ * `Some<Zipper<A>>` is returned.
+ *
+ * @category combinators
+ * @since 0.1.25
+ */
+export const moveByFindFirst = <A>(predicate: Predicate<A>) => (fa: Zipper<A>): Option<Zipper<A>> =>
+  pipe(
+    fa,
+    findIndex(predicate),
+    O.chain((i) => (i === fa.lefts.length ? O.some(fa) : move(() => i, fa)))
+  )
+
+/**
  * Moves focus of the zipper up.
  *
  * @category combinators

--- a/test/Zipper.ts
+++ b/test/Zipper.ts
@@ -273,4 +273,11 @@ describe('Zipper', () => {
     assert.deepStrictEqual(_.findIndex((x) => x === 'b')(_.make([], 'a', ['b', 'c'])), O.some(1))
     assert.deepStrictEqual(_.findIndex((x) => x === 'b')(_.make([], 'a', [])), O.none)
   })
+
+  it('moveByFindFirst', () => {
+    assert.deepStrictEqual(_.moveByFindFirst((a) => a === 0)(_.make([], 0, [])), O.some(_.make([], 0, [])))
+    assert.deepStrictEqual(_.moveByFindFirst((a) => a === 1)(_.make([], 0, [])), O.none)
+    assert.deepStrictEqual(_.moveByFindFirst((a) => a === 0)(_.make([0], 1, [])), O.some(_.make([], 0, [1])))
+    assert.deepStrictEqual(_.moveByFindFirst((a) => a === 1)(_.make([], 0, [1])), O.some(_.make([0], 1, [])))
+  })
 })


### PR DESCRIPTION
This combinator will allow the consumer to move the focus via a
predicate.

See https://github.com/JordanMartinez/purescript-arrays-zipper/blob/d2f0622e7f5c5c52510b9ff6d68c4c32517b5414/src/Data/Zipper/ArrayZipper.purs#L252