### PR TITLE
Add chainIOK and chainFirstIOK to IOOption

### DIFF
--- a/docs/modules/IOOption.ts.md
+++ b/docs/modules/IOOption.ts.md
@@ -35,6 +35,8 @@ Added in v0.1.14
 - [Monad](#monad)
   - [chain](#chain)
   - [chainFirst](#chainfirst)
+  - [chainFirstIOK](#chainfirstiok)
+  - [chainIOK](#chainiok)
   - [chainOptionK](#chainoptionk)
   - [flatten](#flatten)
 - [combinators](#combinators)
@@ -245,6 +247,26 @@ export declare const chainFirst: <A, B>(f: (a: A) => IOOption<B>) => (ma: IOOpti
 ```
 
 Added in v0.1.18
+
+## chainFirstIOK
+
+**Signature**
+
+```ts
+export declare const chainFirstIOK: <A, B>(f: (a: A) => IO<B>) => (ma: IOOption<A>) => IOOption<A>
+```
+
+Added in v0.1.27
+
+## chainIOK
+
+**Signature**
+
+```ts
+export declare const chainIOK: <A, B>(f: (a: A) => IO<B>) => (ma: IOOption<A>) => IOOption<B>
+```
+
+Added in v0.1.27
 
 ## chainOptionK
 

--- a/src/IOOption.ts
+++ b/src/IOOption.ts
@@ -178,10 +178,24 @@ export const chain: <A, B>(f: (a: A) => IOOption<B>) => (ma: IOOption<A>) => IOO
 
 /**
  * @category Monad
+ * @since 0.1.27
+ */
+export const chainIOK: <A, B>(f: (a: A) => IO<B>) => (ma: IOOption<A>) => IOOption<B> = (f) => (ma) =>
+  T.chain(ma, (a) => T.fromM(f(a)))
+
+/**
+ * @category Monad
  * @since 0.1.18
  */
 export const chainFirst: <A, B>(f: (a: A) => IOOption<B>) => (ma: IOOption<A>) => IOOption<A> = (f) => (ma) =>
   T.chain(ma, (a) => T.map(f(a), () => a))
+
+/**
+ * @category Monad
+ * @since 0.1.27
+ */
+export const chainFirstIOK: <A, B>(f: (a: A) => IO<B>) => (ma: IOOption<A>) => IOOption<A> = (f) => (ma) =>
+  T.chain(ma, (a) => T.map(T.fromM(f(a)), () => a))
 
 /**
  * @category Monad

--- a/test/IOOption.ts
+++ b/test/IOOption.ts
@@ -40,10 +40,22 @@ describe('IOOption', () => {
       assert.deepStrictEqual(pipe(_.none, _.chain(f))(), O.none)
     })
 
+    it('chainIOK', () => {
+      const f = (n: number) => io.of(n + 1)
+      assert.deepStrictEqual(pipe(_.some(1), _.chainIOK(f))(), O.some(2))
+      assert.deepStrictEqual(pipe(_.none, _.chainIOK(f))(), O.none)
+    })
+
     it('chainFirst', () => {
       const f = (n: number) => _.of(n + 1)
       assert.deepStrictEqual(pipe(_.some(1), _.chainFirst(f))(), O.some(1))
       assert.deepStrictEqual(pipe(_.none, _.chainFirst(f))(), O.none)
+    })
+
+    it('chainFirstIOK', () => {
+      const f = (n: number) => io.of(n + 1)
+      assert.deepStrictEqual(pipe(_.some(1), _.chainFirstIOK(f))(), O.some(1))
+      assert.deepStrictEqual(pipe(_.none, _.chainFirstIOK(f))(), O.none)
     })
 
     it('chainOptionK', () => {


### PR DESCRIPTION
Adds `chainIOK` and `chainFirstIOK` combinators to `IOOption`.