### PR TITLE
Add ReaderIO constructors/combinators to ReaderTaskEither

### DIFF
--- a/docs/modules/ReaderTaskEither.ts.md
+++ b/docs/modules/ReaderTaskEither.ts.md
@@ -1,0 +1,113 @@
+---
+title: ReaderTaskEither.ts
+nav_order: 15
+parent: Modules
+---
+
+## ReaderTaskEither overview
+
+Added in v0.1.27
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [combinators](#combinators)
+  - [chainFirstReaderIOK](#chainfirstreaderiok)
+  - [chainFirstReaderIOKW](#chainfirstreaderiokw)
+  - [chainReaderIOK](#chainreaderiok)
+  - [chainReaderIOKW](#chainreaderiokw)
+  - [fromReaderIOK](#fromreaderiok)
+- [constructors](#constructors)
+  - [leftReaderIO](#leftreaderio)
+  - [rightReaderIO](#rightreaderio)
+
+---
+
+# combinators
+
+## chainFirstReaderIOK
+
+**Signature**
+
+```ts
+export declare const chainFirstReaderIOK: <A, R, B>(
+  f: (a: A) => RIO.ReaderIO<R, B>
+) => <E = never>(ma: RTE.ReaderTaskEither<R, E, A>) => RTE.ReaderTaskEither<R, E, A>
+```
+
+Added in v0.1.27
+
+## chainFirstReaderIOKW
+
+Less strict version of [`chainFirstReaderIOK`](#chainfirstreaderiok).
+
+**Signature**
+
+```ts
+export declare const chainFirstReaderIOKW: <A, R2, B>(
+  f: (a: A) => RIO.ReaderIO<R2, B>
+) => <R1, E = never>(ma: RTE.ReaderTaskEither<R1, E, A>) => RTE.ReaderTaskEither<R1 & R2, E, A>
+```
+
+Added in v0.1.27
+
+## chainReaderIOK
+
+**Signature**
+
+```ts
+export declare const chainReaderIOK: <A, R, B>(
+  f: (a: A) => RIO.ReaderIO<R, B>
+) => <E = never>(ma: RTE.ReaderTaskEither<R, E, A>) => RTE.ReaderTaskEither<R, E, B>
+```
+
+Added in v0.1.27
+
+## chainReaderIOKW
+
+Less strict version of [`chainReaderIOK`](#chainreaderiok).
+
+**Signature**
+
+```ts
+export declare const chainReaderIOKW: <A, R2, B>(
+  f: (a: A) => RIO.ReaderIO<R2, B>
+) => <R1, E = never>(ma: RTE.ReaderTaskEither<R1, E, A>) => RTE.ReaderTaskEither<R1 & R2, E, B>
+```
+
+Added in v0.1.27
+
+## fromReaderIOK
+
+**Signature**
+
+```ts
+export declare const fromReaderIOK: <A extends readonly unknown[], R, B>(
+  f: (...a: A) => RIO.ReaderIO<R, B>
+) => <E = never>(...a: A) => RTE.ReaderTaskEither<R, E, B>
+```
+
+Added in v0.1.27
+
+# constructors
+
+## leftReaderIO
+
+**Signature**
+
+```ts
+export declare const leftReaderIO: <R, E = never, A = never>(me: RIO.ReaderIO<R, E>) => RTE.ReaderTaskEither<R, E, A>
+```
+
+Added in v0.1.27
+
+## rightReaderIO
+
+**Signature**
+
+```ts
+export declare const rightReaderIO: <R, E = never, A = never>(ma: RIO.ReaderIO<R, A>) => RTE.ReaderTaskEither<R, E, A>
+```
+
+Added in v0.1.27

--- a/docs/modules/RegExp.ts.md
+++ b/docs/modules/RegExp.ts.md
@@ -1,6 +1,6 @@
 ---
 title: RegExp.ts
-nav_order: 15
+nav_order: 16
 parent: Modules
 ---
 

--- a/docs/modules/Semialign/NonEmptyArray.ts.md
+++ b/docs/modules/Semialign/NonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semialign/NonEmptyArray.ts
-nav_order: 17
+nav_order: 18
 parent: Modules
 ---
 

--- a/docs/modules/Semialign/index.ts.md
+++ b/docs/modules/Semialign/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semialign/index.ts
-nav_order: 16
+nav_order: 17
 parent: Modules
 ---
 

--- a/docs/modules/StateEither.ts.md
+++ b/docs/modules/StateEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateEither.ts
-nav_order: 18
+nav_order: 19
 parent: Modules
 ---
 

--- a/docs/modules/StateIO.ts.md
+++ b/docs/modules/StateIO.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateIO.ts
-nav_order: 19
+nav_order: 20
 parent: Modules
 ---
 

--- a/docs/modules/StateTaskEither.ts.md
+++ b/docs/modules/StateTaskEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateTaskEither.ts
-nav_order: 20
+nav_order: 21
 parent: Modules
 ---
 

--- a/docs/modules/Task/getLine.ts.md
+++ b/docs/modules/Task/getLine.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Task/getLine.ts
-nav_order: 21
+nav_order: 22
 parent: Modules
 ---
 

--- a/docs/modules/Task/withTimeout.ts.md
+++ b/docs/modules/Task/withTimeout.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Task/withTimeout.ts
-nav_order: 22
+nav_order: 23
 parent: Modules
 ---
 

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskOption.ts
-nav_order: 23
+nav_order: 24
 parent: Modules
 ---
 

--- a/docs/modules/Zipper.ts.md
+++ b/docs/modules/Zipper.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Zipper.ts
-nav_order: 25
+nav_order: 26
 parent: Modules
 ---
 

--- a/docs/modules/time.ts.md
+++ b/docs/modules/time.ts.md
@@ -1,6 +1,6 @@
 ---
 title: time.ts
-nav_order: 24
+nav_order: 25
 parent: Modules
 ---
 

--- a/dtslint/ts3.5/ReaderTaskEither.ts
+++ b/dtslint/ts3.5/ReaderTaskEither.ts
@@ -52,6 +52,11 @@ pipe(
   _.chainReaderIOK(() => RIO.of(1))
 )
 
+pipe(
+  RTE.right<R1, string, number>(1),
+  _.chainReaderIOK(() => RIO.of<R2, boolean>(true)) // $ExpectError
+)
+
 //
 // chainFirstReaderIOKW
 //
@@ -70,4 +75,9 @@ pipe(
 pipe(
   RTE.right<R1, string, number>(1),
   _.chainFirstReaderIOK(() => RIO.of(true))
+)
+
+pipe(
+  RTE.right<R1, string, number>(1),
+  _.chainFirstReaderIOK(() => RIO.of<R2, boolean>(true)) // $ExpectError
 )

--- a/dtslint/ts3.5/ReaderTaskEither.ts
+++ b/dtslint/ts3.5/ReaderTaskEither.ts
@@ -1,0 +1,73 @@
+import { pipe } from 'fp-ts/lib/function'
+import * as _ from '../../src/ReaderTaskEither'
+import * as RTE from 'fp-ts/lib/ReaderTaskEither'
+import * as RIO from '../../src/ReaderIO'
+
+interface R1 {
+  foo: string,
+}
+
+interface R2 {
+  bar: string,
+}
+
+//
+// rightReaderIO
+//
+
+// $ExpectType ReaderTaskEither<R1, never, boolean>
+_.rightReaderIO(RIO.of<R1, boolean>(true))
+
+//
+// leftReaderIO
+//
+
+// $ExpectType ReaderTaskEither<R1, boolean, never>
+_.leftReaderIO(RIO.of<R1, boolean>(true))
+
+//
+// fromReaderIOK
+//
+
+// $ExpectType <E = never>(a: boolean) => ReaderTaskEither<R1, E, boolean>
+_.fromReaderIOK((a: boolean) => RIO.of<R1, boolean>(a))
+
+//
+// chainReaderIOKW
+//
+
+// $ExpectType ReaderTaskEither<R1 & R2, string, boolean>
+pipe(
+  RTE.right<R1, string, number>(1),
+  _.chainReaderIOKW(() => RIO.of<R2, boolean>(true))
+)
+
+//
+// chainReaderIOK
+//
+
+// $ExpectType ReaderTaskEither<R1, string, number>
+pipe(
+  RTE.right<R1, string, number>(1),
+  _.chainReaderIOK(() => RIO.of(1))
+)
+
+//
+// chainFirstReaderIOKW
+//
+
+// $ExpectType ReaderTaskEither<R1 & R2, string, number>
+pipe(
+  RTE.right<R1, string, number>(1),
+  _.chainFirstReaderIOKW(() => RIO.of<R2, boolean>(true)),
+)
+
+//
+// chainFirstReaderIOK
+//
+
+// $ExpectType ReaderTaskEither<R1, string, number>
+pipe(
+  RTE.right<R1, string, number>(1),
+  _.chainFirstReaderIOK(() => RIO.of(true))
+)

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -1,0 +1,78 @@
+/**
+ * @since 0.1.27
+ */
+import { flow } from 'fp-ts/lib/function'
+import * as RTE from 'fp-ts/lib/ReaderTaskEither'
+import * as TE from 'fp-ts/lib/TaskEither'
+import * as RIO from './ReaderIO'
+
+import ReaderIO = RIO.ReaderIO
+import ReaderTaskEither = RTE.ReaderTaskEither
+
+// -------------------------------------------------------------------------------------
+// constructors
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category constructors
+ * @since 0.1.27
+ */
+export const leftReaderIO: <R, E = never, A = never>(me: ReaderIO<R, E>) => ReaderTaskEither<R, E, A> = (me) =>
+  flow(me, TE.leftIO)
+
+/**
+ * @category constructors
+ * @since 0.1.27
+ */
+export const rightReaderIO: <R, E = never, A = never>(ma: ReaderIO<R, A>) => ReaderTaskEither<R, E, A> = (ma) =>
+  flow(ma, TE.rightIO)
+
+// -------------------------------------------------------------------------------------
+// combinators
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 0.1.27
+ */
+export const fromReaderIOK = <A extends ReadonlyArray<unknown>, R, B>(
+  f: (...a: A) => ReaderIO<R, B>
+): (<E = never>(...a: A) => ReaderTaskEither<R, E, B>) => (...a) => rightReaderIO(f(...a))
+
+/**
+ * Less strict version of [`chainReaderIOK`](#chainreaderiok).
+ *
+ * @category combinators
+ * @since 0.1.27
+ */
+export const chainReaderIOKW: <A, R2, B>(
+  f: (a: A) => ReaderIO<R2, B>
+) => <R1, E = never>(ma: ReaderTaskEither<R1, E, A>) => ReaderTaskEither<R1 & R2, E, B> = (f) =>
+  RTE.chainW(fromReaderIOK(f))
+
+/**
+ * @category combinators
+ * @since 0.1.27
+ */
+export const chainReaderIOK: <A, R, B>(
+  f: (a: A) => ReaderIO<R, B>
+) => <E = never>(ma: ReaderTaskEither<R, E, A>) => ReaderTaskEither<R, E, B> = chainReaderIOKW
+
+/**
+ * Less strict version of [`chainFirstReaderIOK`](#chainfirstreaderiok).
+ *
+ * @category combinators
+ * @since 0.1.27
+ */
+export const chainFirstReaderIOKW: <A, R2, B>(
+  f: (a: A) => ReaderIO<R2, B>
+) => <R1, E = never>(ma: ReaderTaskEither<R1, E, A>) => ReaderTaskEither<R1 & R2, E, A> = (f) =>
+  RTE.chainFirstW(fromReaderIOK(f))
+
+/**
+ * @category combinators
+ * @since 0.1.27
+ */
+export const chainFirstReaderIOK: <A, R, B>(
+  f: (a: A) => ReaderIO<R, B>
+) => <E = never>(ma: ReaderTaskEither<R, E, A>) => ReaderTaskEither<R, E, A> = chainFirstReaderIOKW

--- a/test/ReaderIO.ts
+++ b/test/ReaderIO.ts
@@ -1,0 +1,101 @@
+import * as assert from 'assert'
+import { pipe } from 'fp-ts/lib/pipeable'
+import * as R from 'fp-ts/lib/Reader'
+import * as IO from 'fp-ts/lib/IO'
+import * as _ from '../src/ReaderIO'
+
+describe('ReaderIO', () => {
+  // -------------------------------------------------------------------------------------
+  // constructors
+  // -------------------------------------------------------------------------------------
+
+  it('fromIO', () => {
+    assert.deepStrictEqual(_.fromIO(IO.of(1))({})(), 1)
+  })
+
+  it('fromIOK', () => {
+    const f = _.fromIOK((s: string) => IO.of(s.length))
+    assert.deepStrictEqual(pipe(_.of('a'), _.chain(f))({})(), 1)
+  })
+
+  it('fromReader', () => {
+    assert.deepStrictEqual(_.fromReader(R.of(1))({})(), 1)
+  })
+
+  it('ask', () => {
+    assert.deepStrictEqual(_.ask()(1)(), 1)
+  })
+
+  it('asks', () => {
+    assert.deepStrictEqual(_.asks((s: string) => s.length)('foo')(), 3)
+  })
+
+  // -------------------------------------------------------------------------------------
+  // combinators
+  // -------------------------------------------------------------------------------------
+
+  it('local', () => {
+    const f = (s: string) => s.length
+    assert.deepStrictEqual(
+      pipe(
+        _.asks((n: number) => n + 1),
+        _.local(f)
+      )('aaa')(),
+      4
+    )
+  })
+  // -------------------------------------------------------------------------------------
+  // pipeables
+  // -------------------------------------------------------------------------------------
+
+  it('map', () => {
+    const f = (n: number): number => n * 2
+    assert.deepStrictEqual(pipe(_.of(1), _.map(f))({})(), 2)
+  })
+
+  it('ap', () => {
+    const f = (n: number): number => n * 2
+    assert.deepStrictEqual(pipe(_.of(f), _.ap(_.of(1)))({})(), 2)
+  })
+
+  it('apFirst', () => {
+    assert.deepStrictEqual(pipe(_.of('a'), _.apFirst(_.of('b')))({})(), 'a')
+  })
+
+  it('apSecond', () => {
+    assert.deepStrictEqual(pipe(_.of('a'), _.apSecond(_.of('b')))({})(), 'b')
+  })
+
+  it('of', () => {
+    assert.deepStrictEqual(_.fromReader(R.of(1))({})(), 1)
+  })
+
+  it('chain', () => {
+    const f = (a: string) => _.of(a.length)
+    assert.deepStrictEqual(pipe(_.of('foo'), _.chain(f))({})(), 3)
+    assert.deepStrictEqual(_.Monad.chain(_.of('foo'), f)({})(), 3)
+  })
+
+  it('chainFirst', () => {
+    const f = (a: string) => _.of(a.length)
+    assert.deepStrictEqual(pipe(_.of('foo'), _.chainFirst(f))({})(), 'foo')
+  })
+
+  it('chainIOK', () => {
+    const f = (s: string) => IO.of(s.length)
+    assert.deepStrictEqual(pipe(_.of('a'), _.chainIOK(f))(undefined)(), 1)
+  })
+
+  it('flatten', () => {
+    assert.deepStrictEqual(pipe(_.of(_.of('a')), _.flatten)({})(), 'a')
+  })
+
+  // -------------------------------------------------------------------------------------
+  // utils
+  // -------------------------------------------------------------------------------------
+
+  it('run', () => {
+    const f = (a: string) => a.length
+    assert.deepStrictEqual(_.run(_.asks(f), 'foo'), 3)
+  })
+})

--- a/test/ReaderTaskEither.ts
+++ b/test/ReaderTaskEither.ts
@@ -1,0 +1,50 @@
+import * as assert from 'assert'
+import * as E from 'fp-ts/Either'
+import { flow, pipe } from 'fp-ts/function'
+import * as RTE from 'fp-ts/ReaderTaskEither'
+import * as RIO from '../src/ReaderIO'
+import * as _ from '../src/ReaderTaskEither'
+
+const len = (s: string): number => s.length
+
+describe('ReaderTaskEither', () => {
+  // -------------------------------------------------------------------------------------
+  // constructors
+  // -------------------------------------------------------------------------------------
+
+  it('leftReaderIO', async () => {
+    assert.deepStrictEqual(await _.leftReaderIO(RIO.of(1))({})(), E.left(1))
+  })
+
+  it('rightReaderIO', async () => {
+    assert.deepStrictEqual(await _.rightReaderIO(RIO.of(1))({})(), E.right(1))
+  })
+
+  // -------------------------------------------------------------------------------------
+  // combinators
+  // -------------------------------------------------------------------------------------
+
+  it('fromReaderIOK', async () => {
+    assert.deepStrictEqual(await _.fromReaderIOK(RIO.of)(1)(undefined)(), E.right(1))
+  })
+
+  it('chainReaderIOKW', async () => {
+    const f = flow(len, RIO.of)
+    assert.deepStrictEqual(await pipe(RTE.right('a'), _.chainReaderIOKW(f))({})(), E.right(1))
+  })
+
+  it('chainReaderIOK', async () => {
+    const f = flow(len, RIO.of)
+    assert.deepStrictEqual(await pipe(RTE.right('a'), _.chainReaderIOK(f))(undefined)(), E.right(1))
+  })
+
+  it('chainFirstReaderIOKW', async () => {
+    const f = flow(len, RIO.of)
+    assert.deepStrictEqual(await pipe(RTE.right('a'), _.chainFirstReaderIOKW(f))({})(), E.right('a'))
+  })
+
+  it('chainFirstReaderIOK', async () => {
+    const f = flow(len, RIO.of)
+    assert.deepStrictEqual(await pipe(RTE.right('a'), _.chainFirstReaderIOK(f))({})(), E.right('a'))
+  })
+})


### PR DESCRIPTION
This adds ways to turn a `ReaderIO` into a `ReaderTaskEither` in a similar fashion to `ReaderTask`.

(I also wanted to add `orElseFirstReaderIOK(W)`, but that's delayed by #89 as it uses `EitherT`.)