### PR TITLE
Add asksReaderIO to ReaderIO

### DIFF
--- a/docs/modules/ReaderIO.ts.md
+++ b/docs/modules/ReaderIO.ts.md
@@ -26,6 +26,8 @@ Added in v0.1.0
   - [chainIOK](#chainiok)
   - [flatten](#flatten)
 - [combinators](#combinators)
+  - [asksReaderIO](#asksreaderio)
+  - [asksReaderIOW](#asksreaderiow)
   - [local](#local)
 - [constructors](#constructors)
   - [ask](#ask)
@@ -147,6 +149,30 @@ export declare const flatten: <E, A>(mma: ReaderIO<E, ReaderIO<E, A>>) => Reader
 Added in v0.1.18
 
 # combinators
+
+## asksReaderIO
+
+Effectfully accesses the environment.
+
+**Signature**
+
+```ts
+export declare const asksReaderIO: <R, A>(f: (r: R) => ReaderIO<R, A>) => ReaderIO<R, A>
+```
+
+Added in v0.1.27
+
+## asksReaderIOW
+
+Less strict version of [`asksReaderIO`](#asksreaderio).
+
+**Signature**
+
+```ts
+export declare const asksReaderIOW: <R1, R2, A>(f: (r1: R1) => ReaderIO<R2, A>) => ReaderIO<R1 & R2, A>
+```
+
+Added in v0.1.27
 
 ## local
 

--- a/dtslint/ts3.5/ReaderIO.ts
+++ b/dtslint/ts3.5/ReaderIO.ts
@@ -1,0 +1,26 @@
+import * as _ from '../../src/ReaderIO'
+
+interface R1 {
+  foo: string,
+}
+
+interface R2 {
+  bar: string,
+}
+
+//
+// asksReaderIOW
+//
+
+// $ExpectType ReaderIO<R1 & R2, boolean>
+_.asksReaderIOW((r: R1) => _.of<R2, boolean>(true))
+
+//
+// asksReaderIO
+//
+
+// $ExpectType ReaderIO<R1, boolean>
+_.asksReaderIO((r: R1) => _.of<R1, boolean>(true))
+
+// $ExpectError
+_.asksReaderIO((r: R1) => _.of<R2, boolean>(true))

--- a/src/ReaderIO.ts
+++ b/src/ReaderIO.ts
@@ -73,6 +73,23 @@ export const asks: <R, A>(f: (r: R) => A) => ReaderIO<R, A> = T.asks
  */
 export const local: <Q, R>(f: (f: Q) => R) => <A>(ma: ReaderIO<R, A>) => ReaderIO<Q, A> = (f) => (ma) => T.local(ma, f)
 
+/**
+ * Less strict version of [`asksReaderIO`](#asksreaderio).
+ *
+ * @category combinators
+ * @since 0.1.27
+ */
+// TODO: use R.asksReaderW when fp-ts version >= 2.11.0
+export const asksReaderIOW: <R1, R2, A>(f: (r1: R1) => ReaderIO<R2, A>) => ReaderIO<R1 & R2, A> = (f) => (r) => f(r)(r)
+
+/**
+ * Effectfully accesses the environment.
+ *
+ * @category combinators
+ * @since 0.1.27
+ */
+export const asksReaderIO: <R, A>(f: (r: R) => ReaderIO<R, A>) => ReaderIO<R, A> = asksReaderIOW
+
 // -------------------------------------------------------------------------------------
 // pipeables
 // -------------------------------------------------------------------------------------

--- a/test/ReaderIO.ts
+++ b/test/ReaderIO.ts
@@ -1,0 +1,112 @@
+import * as assert from 'assert'
+import { pipe } from 'fp-ts/lib/pipeable'
+import * as R from 'fp-ts/lib/Reader'
+import * as IO from 'fp-ts/lib/IO'
+import * as _ from '../src/ReaderIO'
+
+describe('ReaderIO', () => {
+  // -------------------------------------------------------------------------------------
+  // constructors
+  // -------------------------------------------------------------------------------------
+
+  it('fromIO', () => {
+    assert.deepStrictEqual(_.fromIO(IO.of(1))({})(), 1)
+  })
+
+  it('fromIOK', () => {
+    const f = _.fromIOK((s: string) => IO.of(s.length))
+    assert.deepStrictEqual(pipe(_.of('a'), _.chain(f))({})(), 1)
+  })
+
+  it('fromReader', () => {
+    assert.deepStrictEqual(_.fromReader(R.of(1))({})(), 1)
+  })
+
+  it('ask', () => {
+    assert.deepStrictEqual(_.ask()(1)(), 1)
+  })
+
+  it('asks', () => {
+    assert.deepStrictEqual(_.asks((s: string) => s.length)('foo')(), 3)
+  })
+
+  // -------------------------------------------------------------------------------------
+  // combinators
+  // -------------------------------------------------------------------------------------
+
+  it('local', () => {
+    const f = (s: string) => s.length
+    assert.deepStrictEqual(
+      pipe(
+        _.asks((n: number) => n + 1),
+        _.local(f)
+      )('aaa')(),
+      4
+    )
+  })
+
+  it('asksReaderIO', () => {
+    const f = (e: { count: number }) => _.of(e.count + 1)
+    assert.deepStrictEqual(_.asksReaderIO(f)({ count: 0 })(), 1)
+  })
+
+  it('asksReaderIOW', () => {
+    const f = (e: { count: number }) => _.of(e.count + 1)
+    assert.deepStrictEqual(_.asksReaderIOW(f)({ count: 0 })(), 1)
+  })
+
+  // -------------------------------------------------------------------------------------
+  // pipeables
+  // -------------------------------------------------------------------------------------
+
+  it('map', () => {
+    const f = (n: number): number => n * 2
+    assert.deepStrictEqual(pipe(_.of(1), _.map(f))({})(), 2)
+  })
+
+  it('ap', () => {
+    const f = (n: number): number => n * 2
+    assert.deepStrictEqual(pipe(_.of(f), _.ap(_.of(1)))({})(), 2)
+  })
+
+  it('apFirst', () => {
+    assert.deepStrictEqual(pipe(_.of('a'), _.apFirst(_.of('b')))({})(), 'a')
+  })
+
+  it('apSecond', () => {
+    assert.deepStrictEqual(pipe(_.of('a'), _.apSecond(_.of('b')))({})(), 'b')
+  })
+
+  it('of', () => {
+    assert.deepStrictEqual(_.fromReader(R.of(1))({})(), 1)
+  })
+
+  it('chain', () => {
+    const f = (a: string) => _.of(a.length)
+    assert.deepStrictEqual(pipe(_.of('foo'), _.chain(f))({})(), 3)
+    assert.deepStrictEqual(_.Monad.chain(_.of('foo'), f)({})(), 3)
+  })
+
+  it('chainFirst', () => {
+    const f = (a: string) => _.of(a.length)
+    assert.deepStrictEqual(pipe(_.of('foo'), _.chainFirst(f))({})(), 'foo')
+  })
+
+  it('chainIOK', () => {
+    const f = (s: string) => IO.of(s.length)
+    assert.deepStrictEqual(pipe(_.of('a'), _.chainIOK(f))(undefined)(), 1)
+  })
+
+  it('flatten', () => {
+    assert.deepStrictEqual(pipe(_.of(_.of('a')), _.flatten)({})(), 'a')
+  })
+
+  // -------------------------------------------------------------------------------------
+  // utils
+  // -------------------------------------------------------------------------------------
+
+  it('run', () => {
+    const f = (a: string) => a.length
+    assert.deepStrictEqual(_.run(_.asks(f), 'foo'), 3)
+  })
+})


### PR DESCRIPTION
This adds the `asksReaderIO`/`asksReaderIOW` combinators to `ReaderIO` (similar to `ReaderTask`'s `asksReaderTask`/`asksReaderTaskW`).