### PR TITLE
Add type-widening combinators to ReaderIO

### DIFF
--- a/docs/modules/ReaderIO.ts.md
+++ b/docs/modules/ReaderIO.ts.md
@@ -18,16 +18,20 @@ Added in v0.1.0
   - [ap](#ap)
   - [apFirst](#apfirst)
   - [apSecond](#apsecond)
+  - [apW](#apw)
 - [Functor](#functor)
   - [map](#map)
 - [Monad](#monad)
   - [chain](#chain)
   - [chainFirst](#chainfirst)
   - [chainIOK](#chainiok)
+  - [chainW](#chainw)
   - [flatten](#flatten)
+  - [flattenW](#flattenw)
 - [combinators](#combinators)
   - [asksReaderIO](#asksreaderio)
   - [asksReaderIOW](#asksreaderiow)
+  - [chainFirstW](#chainfirstw)
   - [local](#local)
 - [constructors](#constructors)
   - [ask](#ask)
@@ -94,6 +98,20 @@ export declare const apSecond: <E, B>(fb: ReaderIO<E, B>) => <A>(fa: ReaderIO<E,
 
 Added in v0.1.18
 
+## apW
+
+Less strict version of [`ap`](#ap).
+
+**Signature**
+
+```ts
+export declare const apW: <R2, A>(
+  fa: ReaderIO<R2, A>
+) => <R1, B>(fab: ReaderIO<R1, (a: A) => B>) => ReaderIO<R1 & R2, B>
+```
+
+Added in v0.1.28
+
 # Functor
 
 ## map
@@ -138,6 +156,20 @@ export declare const chainIOK: <A, B>(f: (a: A) => I.IO<B>) => <R>(ma: ReaderIO<
 
 Added in v0.1.10
 
+## chainW
+
+Less strict version of [`chain`](#chain).
+
+**Signature**
+
+```ts
+export declare const chainW: <R2, A, B>(
+  f: (a: A) => ReaderIO<R2, B>
+) => <R1>(ma: ReaderIO<R1, A>) => ReaderIO<R1 & R2, B>
+```
+
+Added in v0.1.28
+
 ## flatten
 
 **Signature**
@@ -147,6 +179,18 @@ export declare const flatten: <E, A>(mma: ReaderIO<E, ReaderIO<E, A>>) => Reader
 ```
 
 Added in v0.1.18
+
+## flattenW
+
+Less strict version of [`flatten`](#flatten).
+
+**Signature**
+
+```ts
+export declare const flattenW: <R1, R2, A>(mma: ReaderIO<R1, ReaderIO<R2, A>>) => ReaderIO<R1 & R2, A>
+```
+
+Added in v0.1.28
 
 # combinators
 
@@ -173,6 +217,22 @@ export declare const asksReaderIOW: <R1, R2, A>(f: (r1: R1) => ReaderIO<R2, A>) 
 ```
 
 Added in v0.1.27
+
+## chainFirstW
+
+Less strict version of [`chainFirst`](#chainfirst).
+
+Derivable from `Chain`.
+
+**Signature**
+
+```ts
+export declare const chainFirstW: <R2, A, B>(
+  f: (a: A) => ReaderIO<R2, B>
+) => <R1>(ma: ReaderIO<R1, A>) => ReaderIO<R1 & R2, A>
+```
+
+Added in v0.1.28
 
 ## local
 

--- a/dtslint/ts3.5/ReaderIO.ts
+++ b/dtslint/ts3.5/ReaderIO.ts
@@ -1,4 +1,7 @@
+import { pipe } from 'fp-ts/lib/function'
 import * as _ from '../../src/ReaderIO'
+
+declare const f1: (v: string) => boolean
 
 interface R1 {
   foo: string,
@@ -24,3 +27,71 @@ _.asksReaderIO((r: R1) => _.of<R1, boolean>(true))
 
 // $ExpectError
 _.asksReaderIO((r: R1) => _.of<R2, boolean>(true))
+
+//
+// ap
+//
+
+// $ExpectType ReaderIO<R1, boolean>
+pipe(_.of<R1, typeof f1>(f1), _.ap(_.of<R1, string>('')))
+
+// $ExpectError
+pipe(_.of<R1, typeof f1>(f1), _.ap(_.of<R2, string>('')))
+
+//
+// apW
+//
+
+// $ExpectType ReaderIO<R1 & R2, boolean>
+pipe(_.of<R1, typeof f1>(f1), _.apW(_.of<R2, string>('')))
+
+//
+// chain
+//
+
+// $ExpectType ReaderIO<R1, string>
+pipe(_.of<R1, boolean>(true), _.chain((a: boolean) => _.of<R1, string>('')))
+
+// $ExpectError
+pipe(_.of<R1, boolean>(true), _.chain((a: boolean) => _.of<R2, string>('')))
+
+//
+// chainW
+//
+
+// $ExpectType ReaderIO<R1 & R2, string>
+pipe(_.of<R1, boolean>(true), _.chainW((a: boolean) => _.of<R2, string>('')))
+
+//
+// chainFirst
+//
+
+// $ExpectType ReaderIO<R1, boolean>
+pipe(_.of<R1, boolean>(true), _.chainFirst((a: boolean) => _.of<R1, string>('')))
+
+// $ExpectError
+pipe(_.of<R1, boolean>(true), _.chainFirst((a: boolean) => _.of<R2, string>('')))
+
+//
+// chainFirstW
+//
+
+// $ExpectType ReaderIO<R1 & R2, boolean>
+pipe(_.of<R1, boolean>(true), _.chainFirstW((a: boolean) => _.of<R2, string>('')))
+
+//
+// flatten
+//
+
+// $ExpectType ReaderIO<R1, boolean>
+_.flatten(_.of<R1, _.ReaderIO<R1, boolean>>(_.of(true)))
+
+// $ExpectError
+_.flatten(_.of<R1, _.ReaderIO<R2, boolean>>(_.of(true)))
+
+//
+// flattenW
+//
+
+// $ExpectType ReaderIO<R1 & R2, boolean>
+_.flattenW(_.of<R1, _.ReaderIO<R2, boolean>>(_.of(true)))

--- a/src/ReaderIO.ts
+++ b/src/ReaderIO.ts
@@ -108,6 +108,16 @@ export const ap: <E, A>(fa: ReaderIO<E, A>) => <B>(fab: ReaderIO<E, (a: A) => B>
   T.ap(fab, fa)
 
 /**
+ * Less strict version of [`ap`](#ap).
+ *
+ * @category Apply
+ * @since 0.1.28
+ */
+export const apW: <R2, A>(
+  fa: ReaderIO<R2, A>
+) => <R1, B>(fab: ReaderIO<R1, (a: A) => B>) => ReaderIO<R1 & R2, B> = ap as any
+
+/**
  * @category Apply
  * @since 0.1.18
  */
@@ -143,12 +153,34 @@ export const chain: <E, A, B>(f: (a: A) => ReaderIO<E, B>) => (ma: ReaderIO<E, A
   T.chain(ma, f)
 
 /**
+ * Less strict version of  [`chain`](#chain).
+ *
+ * @category Monad
+ * @since 0.1.28
+ */
+export const chainW: <R2, A, B>(
+  f: (a: A) => ReaderIO<R2, B>
+) => <R1>(ma: ReaderIO<R1, A>) => ReaderIO<R1 & R2, B> = chain as any
+
+/**
  * @category Monad
  * @since 0.1.18
  */
 export const chainFirst: <E, A, B>(f: (a: A) => ReaderIO<E, B>) => (ma: ReaderIO<E, A>) => ReaderIO<E, A> = (f) => (
   ma
 ) => T.chain(ma, (a) => T.map(f(a), () => a))
+
+/**
+ * Less strict version of [`chainFirst`](#chainfirst).
+ *
+ * Derivable from `Chain`.
+ *
+ * @category combinators
+ * @since 0.1.28
+ */
+export const chainFirstW: <R2, A, B>(
+  f: (a: A) => ReaderIO<R2, B>
+) => <R1>(ma: ReaderIO<R1, A>) => ReaderIO<R1 & R2, A> = chainFirst as any
 
 /**
  * @category Monad
@@ -158,10 +190,18 @@ export const chainIOK = <A, B>(f: (a: A) => IO<B>): (<R>(ma: ReaderIO<R, A>) => 
   chain<any, A, B>(fromIOK(f))
 
 /**
+ * Less strict version of [`flatten`](#flatten).
+ *
+ * @category Monad
+ * @since 0.1.28
+ */
+export const flattenW: <R1, R2, A>(mma: ReaderIO<R1, ReaderIO<R2, A>>) => ReaderIO<R1 & R2, A> = chainW(identity)
+
+/**
  * @category Monad
  * @since 0.1.18
  */
-export const flatten: <E, A>(mma: ReaderIO<E, ReaderIO<E, A>>) => ReaderIO<E, A> = (mma) => T.chain(mma, identity)
+export const flatten: <E, A>(mma: ReaderIO<E, ReaderIO<E, A>>) => ReaderIO<E, A> = flattenW
 
 // -------------------------------------------------------------------------------------
 // instances

--- a/test/ReaderIO.ts
+++ b/test/ReaderIO.ts
@@ -69,6 +69,11 @@ describe('ReaderIO', () => {
     assert.deepStrictEqual(pipe(_.of(f), _.ap(_.of(1)))({})(), 2)
   })
 
+  it('apW', () => {
+    const f = (n: number): number => n * 2
+    assert.deepStrictEqual(pipe(_.of(f), _.apW(_.of(1)))({})(), 2)
+  })
+
   it('apFirst', () => {
     assert.deepStrictEqual(pipe(_.of('a'), _.apFirst(_.of('b')))({})(), 'a')
   })
@@ -87,9 +92,19 @@ describe('ReaderIO', () => {
     assert.deepStrictEqual(_.Monad.chain(_.of('foo'), f)({})(), 3)
   })
 
+  it('chainW', () => {
+    const f = (a: string) => _.of(a.length)
+    assert.deepStrictEqual(pipe(_.of('foo'), _.chainW(f))({})(), 3)
+  })
+
   it('chainFirst', () => {
     const f = (a: string) => _.of(a.length)
     assert.deepStrictEqual(pipe(_.of('foo'), _.chainFirst(f))({})(), 'foo')
+  })
+
+  it('chainFirstW', () => {
+    const f = (a: string) => _.of(a.length)
+    assert.deepStrictEqual(pipe(_.of('foo'), _.chainFirstW(f))({})(), 'foo')
   })
 
   it('chainIOK', () => {
@@ -99,6 +114,10 @@ describe('ReaderIO', () => {
 
   it('flatten', () => {
     assert.deepStrictEqual(pipe(_.of(_.of('a')), _.flatten)({})(), 'a')
+  })
+
+  it('flattenW', () => {
+    assert.deepStrictEqual(pipe(_.of(_.of('a')), _.flattenW)({})(), 'a')
   })
 
   // -------------------------------------------------------------------------------------


### PR DESCRIPTION
Spotted `chainW` wasn't there; added a few others too.